### PR TITLE
Fix IME confirmation enter submitting terminal input

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -338,7 +338,7 @@ function sendKeys(k){if(!ws||!activePane)return;ws.send(JSON.stringify({type:'se
 function toggleArrows(){document.getElementById('arrowPopup').classList.toggle('show');}
 function hideArrows(){document.getElementById('arrowPopup').classList.remove('show');}
 function respond(t){if(!ws||!activePane)return;ws.send(JSON.stringify({type:'respond',pane_id:activePane,text:t}));document.getElementById('quickActions').innerHTML='';setTimeout(refreshPane,500);}
-document.getElementById('termInput').addEventListener('keydown',e=>{if(e.key==='Enter'){e.preventDefault();sendText();}});
+document.getElementById('termInput').addEventListener('keydown',e=>{if(e.key==='Enter'&&!e.isComposing&&e.keyCode!==229){e.preventDefault();sendText();}});
 
 if (savedUrl) setTimeout(connect, 100); else showSetup();
 </script>

--- a/web/index.html
+++ b/web/index.html
@@ -338,7 +338,7 @@ function sendKeys(k){if(!ws||!activePane)return;ws.send(JSON.stringify({type:'se
 function toggleArrows(){document.getElementById('arrowPopup').classList.toggle('show');}
 function hideArrows(){document.getElementById('arrowPopup').classList.remove('show');}
 function respond(t){if(!ws||!activePane)return;ws.send(JSON.stringify({type:'respond',pane_id:activePane,text:t}));document.getElementById('quickActions').innerHTML='';setTimeout(refreshPane,500);}
-document.getElementById('termInput').addEventListener('keydown',e=>{if(e.key==='Enter'&&!e.isComposing&&e.keyCode!==229){e.preventDefault();sendText();}});
+document.getElementById('termInput').addEventListener('keydown',e=>{if(e.key==='Enter'&&!e.isComposing&&e.keyCode!==229){e.preventDefault();sendText();}}); // IME confirmation also emits Enter; do not submit while composing.
 
 if (savedUrl) setTimeout(connect, 100); else showSetup();
 </script>


### PR DESCRIPTION
## Summary
- Avoid submitting terminal input while an IME composition is being confirmed with Enter
- Keep the existing Enter-to-send behavior for normal keyboard input
- Add an inline note so non-IME users understand why the guard exists

## Test Plan
- `python3` HTML parser check for `web/index.html`
- `git diff --check origin/main...HEAD`
