### PR TITLE
fix(relay): broadcast crash on client churn kills poll_loop permanently

### DIFF
--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -215,7 +215,7 @@ def detect_options(text):
 async def broadcast(msg):
     data = json.dumps(msg)
     dead = set()
-    for ws in clients:
+    for ws in list(clients):
         try:
             await ws.send(data)
         except (ConnectionClosedError, ConnectionClosedOK):
@@ -229,6 +229,14 @@ async def broadcast(msg):
 
 async def poll_loop():
     while True:
+        try:
+            await _poll_once()
+        except Exception:
+            log.exception("poll cycle failed; retrying")
+        await asyncio.sleep(POLL_INTERVAL)
+
+
+async def _poll_once():
         agents = get_all_agents()
         # Always broadcast (even empty list) so clients stay in sync
         for a in agents:
@@ -265,7 +273,6 @@ async def poll_loop():
             for pid in stale:
                 pane_remote_map.pop(pid, None)
                 last_statuses.pop(pid, None)
-        await asyncio.sleep(POLL_INTERVAL)
 
 
 async def event_push():


### PR DESCRIPTION
## Problem
`broadcast()` iterates the live `clients` set while `await ws.send()` yields to the event loop. If a client connects or disconnects during the broadcast (very common with the iOS PWA, which reconnects every few seconds as the OS suspends/resumes it), the set mutates mid-iteration:

```
Task exception was never retrieved
future: <Task finished name=Task-4 coro=<poll_loop() ...> exception=RuntimeError(Set changed size during iteration)>
```

Because `poll_loop()` is a fire-and-forget task, the exception kills polling permanently while the WS server keeps accepting connections — clients show "connected, 0 agents" until a manual restart.

## Fix
1. `broadcast()` iterates a snapshot (`list(clients)`).
2. The poll body moves into `_poll_once()`; `poll_loop()` wraps it in try/except so no per-cycle exception can ever kill polling again.

Reproduced and verified on a Linux host driving the relay with rapid connect/disconnect churn while a second client listened — before: first frame never arrives after the crash; after: agents frame delivered throughout.