### PR TITLE
fix(web): adopt relay token from URL query (iOS PWA storage is isolated)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -278,6 +278,8 @@ const DEMO_RELAY = 'wss://herdr-remote-demo.yyrzrh5wfg.workers.dev';
 const isDemo = location.hostname.includes('herdr-demo.pages.dev');
 const isSelfRelay = !isDemo && !location.hostname.includes('pages.dev') && !location.hostname.includes('localhost');
 const savedUrl = localStorage.getItem('herdr_relay_url') || (isSelfRelay ? autoRelayUrl : (isDemo ? DEMO_RELAY : ''));
+const urlToken = new URLSearchParams(location.search).get('token');
+if (urlToken) localStorage.setItem('herdr_relay_token', urlToken);
 const savedToken = localStorage.getItem('herdr_relay_token') || '';
 document.getElementById('relayUrl').value = savedUrl;
 document.getElementById('relayToken').value = savedToken;


### PR DESCRIPTION
## Problem
The web app reads the relay token only from `localStorage`. On iOS, a home-screen PWA runs in its own storage container, separate from the Safari tab where the user pasted the token — so the installed app always starts with an empty token and shows "offline" until the user re-enters it inside the PWA.

## Fix
On load, if the page URL carries `?token=…` (which it does when the relay itself served the page behind token auth), persist it into `localStorage` before the saved-token read. A bookmarked/installed URL becomes fully self-configuring.