### PR TITLE
Add native Windows relay support

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,6 +4,8 @@ Get mobile notifications + approval for your herdr agents in 60 seconds.
 
 ## 1. Install persistent local services
 
+**macOS/Linux:**
+
 ```bash
 git clone https://github.com/dcolinmorgan/herdr-remote
 cd herdr-remote/relay
@@ -11,6 +13,18 @@ cd herdr-remote/relay
 ```
 
 The installer creates restartable user services for the relay and, optionally, Telegram. Choose `none` for the Cloudflare tunnel when you only need Telegram; the bot connects to the relay over localhost.
+
+**Windows PowerShell:**
+
+```powershell
+git clone https://github.com/dcolinmorgan/herdr-remote
+Set-Location herdr-remote
+herdr plugin link .
+./relay/start.ps1
+```
+
+The Windows launcher binds to `127.0.0.1` with no tunnel by default. Set
+`HERDR_RELAY_TOKEN` before enabling a tunnel or binding beyond loopback.
 
 ## 2. Configure Telegram
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ curl -sL https://github.com/dcolinmorgan/herdr-remote/releases/latest/download/H
 
 ## Remote monitoring (phone/Telegram)
 
+The Python relay, web dashboard, TUI, and Telegram client run on macOS, Linux, and Windows.
+
+### macOS/Linux
+
 For monitoring agents across machines or from your phone:
 
 ```bash
@@ -43,6 +47,25 @@ cd herdr-remote/relay && ./start.sh
 ```
 
 Open [herdr-demo.pages.dev](https://herdr-demo.pages.dev) on your phone, paste the tunnel URL.
+
+### Windows
+
+With Git, [uv](https://docs.astral.sh/uv/), and `herdr` installed:
+
+```powershell
+git clone https://github.com/dcolinmorgan/herdr-remote
+Set-Location herdr-remote
+
+herdr plugin link .
+herdr plugin list
+
+./relay/start.ps1
+```
+
+The launcher starts a local-only relay on `127.0.0.1:8375` by default. Set
+`HERDR_RELAY_TOKEN` before enabling a tunnel or binding beyond loopback. Use
+`HERDR_REMOTES` for a comma-separated list of SSH targets and `HERDR_BIN` only
+when `herdr` is not available on `PATH`.
 
 ## Telegram Bot
 
@@ -128,9 +151,17 @@ export HERDR_RELAY_TOKEN="$(openssl rand -hex 32)"
 uv run relay/herdr_relay.py
 ```
 
+On Windows PowerShell:
+
+```powershell
+$env:HERDR_RELAY_TOKEN = [guid]::NewGuid().ToString("N")
+uv run relay/herdr_relay.py
+```
+
 ## Requirements
 
 - macOS 14+ (menu bar app)
+- Windows 10+ (relay/web/TUI/Telegram; no tray app)
 - Python 3.10+ with [uv](https://docs.astral.sh/uv/) (relay/TUI/bot)
 - `cloudflared` (for remote access)
 - herdr 0.7+

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -3,8 +3,8 @@ name = "Herdr Remote"
 version = "0.5.0"
 min_herdr_version = "0.7.0"
 description = "Monitor and approve herdr agents from your phone, menu bar, or Telegram"
-platforms = ["macos", "linux"]
+platforms = ["macos", "linux", "windows"]
 
 [[events]]
 on = "pane.agent_status_changed"
-command = ["python3", "relay/on_event.py"]
+command = ["uv", "run", "--script", "relay/on_event.py"]

--- a/relay/herdr-plugin.toml
+++ b/relay/herdr-plugin.toml
@@ -3,8 +3,8 @@ name = "Herdr Remote Relay"
 version = "0.1.0"
 min_herdr_version = "0.7.0"
 description = "Push agent events to the local herdr-remote relay via UDP"
-platforms = ["macos", "linux"]
+platforms = ["macos", "linux", "windows"]
 
 [[events]]
 on = "pane.agent_status_changed"
-command = ["python3", "on_event.py"]
+command = ["uv", "run", "--script", "on_event.py"]

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -4,7 +4,7 @@
 # dependencies = ["websockets>=14.0", "zeroconf>=0.80.0", "pywebpush>=2.0.0", "py-vapid>=1.9.0"]
 # ///
 """herdr-remote relay — polls herdr, accepts push events (HTTP POST + WebSocket + UDP), broadcasts to clients."""
-import asyncio, json, logging, os, re, shutil, signal, socket, subprocess, time
+import asyncio, json, logging, os, re, shutil, signal, socket, subprocess, threading, time
 
 from agent_state import complete_agent_update_message
 
@@ -20,6 +20,9 @@ import sys
 def _get_log_dir():
     if sys.platform == "darwin":
         return os.path.expanduser("~/Library/Logs/herdr-remote")
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~/AppData/Local"))
+        return os.path.join(base, "herdr-remote", "logs")
     if os.path.isdir("/var/log") and os.access("/var/log", os.W_OK):
         return "/var/log/herdr-remote"
     return os.path.expanduser("~/.local/state/herdr-remote/log")
@@ -41,8 +44,14 @@ log.addHandler(_file_handler)
 log.addHandler(_console_handler)
 logging.getLogger("websockets").setLevel(logging.WARNING)
 
-HERDR = os.environ.get("HERDR_BIN") or shutil.which("herdr") or "/opt/homebrew/bin/herdr"
+HERDR = (
+    os.environ.get("HERDR_BIN")
+    or shutil.which("herdr")
+    or ("herdr" if sys.platform == "win32" else "/opt/homebrew/bin/herdr")
+)
+REMOTE_HERDR = os.environ.get("HERDR_REMOTE_BIN", "herdr")
 WS_PORT = int(os.environ.get("HERDR_RELAY_PORT", "8375"))
+RELAY_HOST = os.environ.get("HERDR_RELAY_HOST", "127.0.0.1")
 POLL_INTERVAL = 2
 AUTH_TOKEN = os.environ.get("HERDR_RELAY_TOKEN", "")  # Optional: shared secret for relay auth
 
@@ -52,6 +61,9 @@ VAPID_PRIVATE_KEY = os.environ.get("HERDR_VAPID_PRIVATE", "")
 VAPID_SUBJECT = os.environ.get("HERDR_VAPID_SUBJECT", "mailto:herdr@localhost")
 push_subscriptions = []  # list of PushSubscription dicts
 PUSH_SUBS_FILE = os.path.join(LOG_DIR, "push_subs.json")
+
+if RELAY_HOST not in {"127.0.0.1", "localhost", "::1"} and not AUTH_TOKEN:
+    raise SystemExit("HERDR_RELAY_TOKEN is required when HERDR_RELAY_HOST binds beyond loopback")
 
 # Remote hosts: comma-separated SSH targets
 REMOTES = [r.strip() for r in os.environ.get("HERDR_REMOTES", "").split(",") if r.strip()]
@@ -72,6 +84,8 @@ event_queue = asyncio.Queue()
 pane_remote_map = {}
 known_panes = set()
 agent_cache = {}
+_remote_locks = {}
+_remote_locks_guard = threading.Lock()
 
 SAFE_RESPONSES = {"y", "n", "a", "yes", "no", "trust", "yes, single permission", "trust, always allow", "no (tab to edit)", "approve all pending", "configure individually", "exit (cancel subagents)"}
 SAFE_KEYS = {"y", "n", "a", "Enter", "Tab", "Escape", "C-c", "Up", "Down", "Left", "Right", "BSpace"} | {
@@ -160,10 +174,39 @@ _load_push_subs()
 
 def run_herdr_result(*args, remote=None):
     if remote:
-        cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", remote, HERDR, *args]
-    else:
-        cmd = [HERDR, *args]
-    return subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        cmd = [
+            "ssh",
+            "-o",
+            "ConnectTimeout=5",
+            "-o",
+            "BatchMode=yes",
+            remote,
+            REMOTE_HERDR,
+            *args,
+        ]
+        with _remote_locks_guard:
+            remote_lock = _remote_locks.get(remote)
+            if remote_lock is None:
+                remote_lock = threading.Lock()
+                _remote_locks[remote] = remote_lock
+        with remote_lock:
+            return subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=15,
+            )
+    cmd = [HERDR, *args]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+    )
 
 
 def run_herdr(*args, remote=None):
@@ -171,6 +214,13 @@ def run_herdr(*args, remote=None):
         return run_herdr_result(*args, remote=remote).stdout.strip()
     except Exception:
         return ""
+
+
+def _mutate_herdr(*args, remote=None):
+    try:
+        return run_herdr_result(*args, remote=remote).returncode == 0
+    except Exception:
+        return False
 
 
 def get_agents_from_host(remote=None):
@@ -203,6 +253,23 @@ def get_all_agents():
     for remote in REMOTES:
         agents.extend(get_agents_from_host(remote=remote))
     return agents
+
+
+def update_pane_maps(agents):
+    current_pane_ids = {agent["pane_id"] for agent in agents}
+    for agent in agents:
+        pane_id = agent["pane_id"]
+        pane_remote_map[pane_id] = agent.get("remote")
+        known_panes.add(pane_id)
+        agent_cache[pane_id] = agent
+
+    stale = known_panes - current_pane_ids
+    if stale:
+        known_panes.difference_update(stale)
+        for pane_id in stale:
+            pane_remote_map.pop(pane_id, None)
+            last_statuses.pop(pane_id, None)
+            agent_cache.pop(pane_id, None)
 
 
 def read_pane(pane_id, remote=None):
@@ -246,11 +313,7 @@ async def poll_loop():
 
 async def _poll_once():
         agents = get_all_agents()
-        # Always broadcast (even empty list) so clients stay in sync
-        for a in agents:
-            pane_remote_map[a["pane_id"]] = a.get("remote")
-            known_panes.add(a["pane_id"])
-            agent_cache[a["pane_id"]] = a
+        update_pane_maps(agents)
         await broadcast({"type": "agents", "agents": agents})
         for a in agents:
             pid, status = a["pane_id"], a["status"]
@@ -274,17 +337,6 @@ async def _poll_once():
             if status != "blocked" and last_statuses.get(pid) == "blocked":
                 await send_web_push("", "", clear=True)
             last_statuses[pid] = status
-        # Clean up panes that are no longer reported
-        current_pane_ids = {a["pane_id"] for a in agents}
-        stale = known_panes - current_pane_ids
-        if stale:
-            known_panes.difference_update(stale)
-            for pid in stale:
-                pane_remote_map.pop(pid, None)
-                last_statuses.pop(pid, None)
-                agent_cache.pop(pid, None)
-
-
 async def event_push():
     while True:
         event = await event_queue.get()
@@ -464,14 +516,15 @@ async def handle_client(ws):
                 if pane_id not in known_panes:
                     await ws.send(json.dumps({"type": "error", "message": "unknown pane_id"}))
                     continue
-                text = msg.get("text", "")
-                if text.strip().lower() not in SAFE_RESPONSES:
+                text = msg.get("text", "").strip()
+                if text.lower() not in SAFE_RESPONSES:
                     await ws.send(json.dumps({"type": "error", "message": "response not in allowlist"}))
                     continue
                 remote = pane_remote_map.get(pane_id)
                 log.info("Response from %s (%s): pane=%s text=%r", ip, device, pane_id, text)
                 audit("respond", ip, device, pane_id, f"text={text!r}")
-                run_herdr("pane", "send-text", pane_id, text + "\n", remote=remote)
+                if _mutate_herdr("pane", "send-text", pane_id, text, remote=remote):
+                    _mutate_herdr("pane", "send-keys", pane_id, "Enter", remote=remote)
             elif msg_type == "agent_event":
                 event_queue.put_nowait(msg)
             elif msg_type == "read_pane":
@@ -561,7 +614,6 @@ def start_mdns():
     try:
         from zeroconf import Zeroconf, ServiceInfo
         import socket as sock_mod
-        import threading
         ip = sock_mod.gethostbyname(sock_mod.gethostname())
         info = ServiceInfo(
             "_herdr-remote._tcp.local.", "herdr-remote._herdr-remote._tcp.local.",
@@ -577,26 +629,61 @@ def start_mdns():
 
 
 async def main():
-    zc, info = start_mdns()
     loop = asyncio.get_running_loop()
-    try:
-        await loop.create_datagram_endpoint(UDPPlugin, local_addr=("127.0.0.1", 8376))
-    except OSError:
-        log.warning("UDP 8376 in use, plugin push disabled")
-    asyncio.create_task(poll_loop())
-    asyncio.create_task(event_push())
-    server = await serve(handle_client, "0.0.0.0", WS_PORT, process_request=process_request)
-    hosts = ["local"] + REMOTES
-    log.info("herdr-remote relay on :%d (WebSocket + HTTP POST)", WS_PORT)
-    log.info("Polling: %s", ", ".join(hosts))
     stop = loop.create_future()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, stop.set_result, None)
-    await stop
-    server.close()
-    if zc and info:
-        zc.unregister_service(info)
-        zc.close()
+    zc = info = udp_transport = server = None
+    tasks = []
+    loop_signal_handlers = []
+    fallback_signal_handlers = {}
+
+    def resolve_stop():
+        if not stop.done():
+            stop.set_result(None)
+
+    def request_stop(*_):
+        loop.call_soon_threadsafe(resolve_stop)
+
+    try:
+        zc, info = start_mdns()
+        try:
+            udp_transport, _ = await loop.create_datagram_endpoint(
+                UDPPlugin, local_addr=("127.0.0.1", 8376)
+            )
+        except OSError:
+            log.warning("UDP 8376 in use, plugin push disabled")
+        tasks = [asyncio.create_task(poll_loop()), asyncio.create_task(event_push())]
+        server = await serve(handle_client, RELAY_HOST, WS_PORT, process_request=process_request)
+        hosts = ["local"] + REMOTES
+        log.info("herdr-remote relay on %s:%d (WebSocket + HTTP POST)", RELAY_HOST, WS_PORT)
+        log.info("Polling: %s", ", ".join(hosts))
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                loop.add_signal_handler(sig, request_stop)
+                loop_signal_handlers.append(sig)
+            except NotImplementedError:
+                fallback_signal_handlers[sig] = signal.getsignal(sig)
+                signal.signal(sig, request_stop)
+        await stop
+    finally:
+        for sig in loop_signal_handlers:
+            loop.remove_signal_handler(sig)
+        for sig, handler in fallback_signal_handlers.items():
+            signal.signal(sig, handler)
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+        if udp_transport is not None:
+            udp_transport.close()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        if zc is not None:
+            try:
+                if info is not None:
+                    zc.unregister_service(info)
+            finally:
+                zc.close()
 
 
 if __name__ == "__main__":

--- a/relay/on_event.py
+++ b/relay/on_event.py
@@ -4,14 +4,33 @@ import json, os, socket
 
 event = json.loads(os.environ.get("HERDR_PLUGIN_EVENT_JSON", "{}"))
 data = event.get("data", {})
+try:
+    context = json.loads(os.environ.get("HERDR_PLUGIN_CONTEXT_JSON", "{}"))
+except (json.JSONDecodeError, TypeError):
+    context = {}
+if not isinstance(context, dict):
+    context = {}
+
+cwd = next(
+    (
+        value
+        for value in (
+            context.get("focused_pane_cwd"),
+            context.get("workspace_cwd"),
+            data.get("cwd"),
+        )
+        if isinstance(value, str) and value
+    ),
+    "",
+)
 
 payload = json.dumps({
     "type": "agent_event",
     "pane_id": data.get("pane_id", ""),
     "status": (data.get("agent_status") or "").lower(),
     "agent": (data.get("agent") or data.get("display_agent") or "").lower(),
-    "project": os.path.basename(data.get("cwd", "")),
-    "cwd": data.get("cwd", ""),
+    "project": os.path.basename(cwd),
+    "cwd": cwd,
     "host": socket.gethostname().split(".")[0],
 }).encode()
 

--- a/relay/start.ps1
+++ b/relay/start.ps1
@@ -1,0 +1,287 @@
+#Requires -Version 5.1
+
+$ErrorActionPreference = "Stop"
+
+function Import-RelayConfig {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return
+    }
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        $trimmedLine = $line.Trim()
+        if ($trimmedLine.Length -eq 0 -or $trimmedLine.StartsWith("#")) {
+            continue
+        }
+
+        $separator = $line.IndexOf("=")
+        if ($separator -lt 1) {
+            continue
+        }
+
+        $name = $line.Substring(0, $separator).Trim()
+        if ($name -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
+            continue
+        }
+
+        $value = $line.Substring($separator + 1).Trim()
+        if ($value.Length -ge 2) {
+            $first = $value[0]
+            $last = $value[$value.Length - 1]
+            if (($first -eq '"' -and $last -eq '"') -or ($first -eq "'" -and $last -eq "'")) {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+        }
+
+        $environmentPath = "Env:{0}" -f $name
+        if (-not (Test-Path -LiteralPath $environmentPath)) {
+            Set-Item -LiteralPath $environmentPath -Value $value
+        }
+    }
+}
+
+function ConvertTo-ProcessArgument {
+    param([AllowEmptyString()][Parameter(Mandatory = $true)][string]$Argument)
+
+    if ($Argument.Length -gt 0 -and $Argument -notmatch '[\s"]') {
+        return $Argument
+    }
+
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.Append('"')
+    $backslashes = 0
+
+    foreach ($character in $Argument.ToCharArray()) {
+        if ($character -eq '\') {
+            $backslashes++
+            continue
+        }
+
+        if ($character -eq '"') {
+            [void]$builder.Append(('\' * (($backslashes * 2) + 1)))
+            [void]$builder.Append('"')
+            $backslashes = 0
+            continue
+        }
+
+        if ($backslashes -gt 0) {
+            [void]$builder.Append(('\' * $backslashes))
+            $backslashes = 0
+        }
+        [void]$builder.Append($character)
+    }
+
+    if ($backslashes -gt 0) {
+        [void]$builder.Append(('\' * ($backslashes * 2)))
+    }
+    [void]$builder.Append('"')
+    return $builder.ToString()
+}
+
+function Start-ConsoleChild {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $argumentLine = (($Arguments | ForEach-Object { ConvertTo-ProcessArgument -Argument $_ }) -join ' ')
+    return Start-Process -FilePath $FilePath -ArgumentList $argumentLine -NoNewWindow -PassThru
+}
+
+function Stop-ChildProcessTree {
+    param([System.Diagnostics.Process]$Process)
+
+    if ($null -eq $Process) {
+        return
+    }
+
+    try {
+        $Process.Refresh()
+        if (-not $Process.HasExited) {
+            $taskkill = Join-Path $env:SystemRoot "System32\taskkill.exe"
+            & $taskkill /PID $Process.Id /T /F 2>$null | Out-Null
+        }
+    }
+    catch {
+        try {
+            Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+        }
+        catch {
+            # The process may already have exited.
+        }
+    }
+    finally {
+        $Process.Dispose()
+    }
+}
+
+$homeDirectory = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+$configFile = Join-Path $homeDirectory ".config\herdr-remote\config.env"
+$secretsFile = Join-Path $homeDirectory ".config\herdr-remote\secrets.env"
+$relayScript = Join-Path $PSScriptRoot "herdr_relay.py"
+
+Import-RelayConfig -Path $configFile
+Import-RelayConfig -Path $secretsFile
+
+$port = $env:HERDR_RELAY_PORT
+if ([string]::IsNullOrWhiteSpace($port)) {
+    $port = "8375"
+}
+
+$relayHost = $env:HERDR_RELAY_HOST
+if ([string]::IsNullOrWhiteSpace($relayHost)) {
+    $env:HERDR_RELAY_HOST = "127.0.0.1"
+}
+else {
+    $env:HERDR_RELAY_HOST = $relayHost.Trim()
+}
+
+$tunnelMode = $env:HERDR_TUNNEL_MODE
+if ([string]::IsNullOrWhiteSpace($tunnelMode)) {
+    $tunnelMode = "none"
+}
+else {
+    $tunnelMode = $tunnelMode.Trim().ToLowerInvariant()
+}
+
+$tunnelName = $env:HERDR_TUNNEL_NAME
+if ($null -ne $tunnelName) {
+    $tunnelName = $tunnelName.Trim()
+}
+
+if ($tunnelMode -notin @("temp", "named", "none")) {
+    Write-Error "Unsupported HERDR_TUNNEL_MODE '$tunnelMode'. Expected temp, named, or none." -ErrorAction Continue
+    exit 1
+}
+
+$normalizedRelayHost = $env:HERDR_RELAY_HOST.Trim().Trim("[", "]").ToLowerInvariant()
+$loopbackHosts = @("127.0.0.1", "::1", "localhost")
+$requiresRelayAuth = $normalizedRelayHost -notin $loopbackHosts -or $tunnelMode -ne "none"
+if ($requiresRelayAuth -and [string]::IsNullOrWhiteSpace($env:HERDR_RELAY_TOKEN)) {
+    Write-Error "HERDR_RELAY_TOKEN is required for LAN binding or tunnel access." -ErrorAction Continue
+    exit 1
+}
+
+$uv = Get-Command uv -CommandType Application -ErrorAction SilentlyContinue
+if ($null -eq $uv) {
+    Write-Error "uv is required to start the relay. Install it with: winget install --id astral-sh.uv -e" -ErrorAction Continue
+    exit 1
+}
+
+if (-not (Test-Path -LiteralPath $relayScript -PathType Leaf)) {
+    Write-Error "Relay script not found at $relayScript" -ErrorAction Continue
+    exit 1
+}
+
+$relayProcess = $null
+$tunnelProcess = $null
+$exitCode = 0
+
+Write-Host "herdr-remote relay"
+Write-Host ""
+
+try {
+    Write-Host "Starting relay on :$port..."
+    $relayProcess = Start-ConsoleChild -FilePath $uv.Source -Arguments @("run", $relayScript)
+    Start-Sleep -Seconds 2
+    $relayProcess.Refresh()
+
+    if ($relayProcess.HasExited) {
+        throw "Relay failed to start (exit code $($relayProcess.ExitCode)). Check whether port $port is already in use."
+    }
+    Write-Host "Relay running (pid $($relayProcess.Id))"
+
+    $cloudflared = Get-Command cloudflared -CommandType Application -ErrorAction SilentlyContinue
+    $effectiveTunnelMode = $tunnelMode
+    $cloudflaredConfig = Join-Path $homeDirectory ".cloudflared\config-herdr.yml"
+
+    if ($effectiveTunnelMode -eq "named") {
+        if ([string]::IsNullOrWhiteSpace($tunnelName)) {
+            Write-Warning "HERDR_TUNNEL_MODE=named requires HERDR_TUNNEL_NAME. Falling back to a temporary tunnel."
+            $effectiveTunnelMode = "temp"
+        }
+        elseif (-not (Test-Path -LiteralPath $cloudflaredConfig -PathType Leaf)) {
+            Write-Warning "Named tunnel config not found at $cloudflaredConfig. Falling back to a temporary tunnel."
+            $effectiveTunnelMode = "temp"
+        }
+    }
+
+    if ($effectiveTunnelMode -eq "none") {
+        Write-Host "Tunnel disabled (config: HERDR_TUNNEL_MODE=none)"
+    }
+    elseif ($null -eq $cloudflared) {
+        Write-Warning "cloudflared was not found; the relay is running locally only."
+        Write-Host "Install it with: winget install --id Cloudflare.cloudflared -e"
+    }
+    else {
+        try {
+            if ($effectiveTunnelMode -eq "named") {
+                Write-Host "Starting named tunnel ($tunnelName)..."
+                $tunnelProcess = Start-ConsoleChild -FilePath $cloudflared.Source -Arguments @(
+                    "tunnel", "--config", $cloudflaredConfig, "run", $tunnelName
+                )
+            }
+            else {
+                Write-Host "Starting temp tunnel..."
+                $tunnelProcess = Start-ConsoleChild -FilePath $cloudflared.Source -Arguments @(
+                    "tunnel", "--url", "http://localhost:$port"
+                )
+            }
+
+            Start-Sleep -Seconds 4
+            $tunnelProcess.Refresh()
+            if ($tunnelProcess.HasExited) {
+                Write-Warning "Tunnel failed to start (exit code $($tunnelProcess.ExitCode)); the relay is still running locally."
+                $tunnelProcess.Dispose()
+                $tunnelProcess = $null
+            }
+            elseif ($effectiveTunnelMode -eq "temp") {
+                Write-Host "Tunnel started; the public URL appears in the cloudflared output above."
+            }
+            else {
+                Write-Host "Named tunnel running (pid $($tunnelProcess.Id))"
+            }
+        }
+        catch [System.Management.Automation.PipelineStoppedException] {
+            throw
+        }
+        catch {
+            if ($null -ne $tunnelProcess) {
+                Stop-ChildProcessTree -Process $tunnelProcess
+                $tunnelProcess = $null
+            }
+            Write-Warning "Tunnel failed to start ($($_.Exception.Message)); the relay is still running locally."
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Ready. Press Ctrl+C to stop."
+    Write-Host ""
+
+    while (-not $relayProcess.HasExited) {
+        Start-Sleep -Milliseconds 500
+        $relayProcess.Refresh()
+    }
+
+    $exitCode = $relayProcess.ExitCode
+    if ($exitCode -ne 0) {
+        Write-Error "Relay exited with code $exitCode." -ErrorAction Continue
+    }
+}
+catch [System.Management.Automation.PipelineStoppedException] {
+    throw
+}
+catch {
+    Write-Error $_.Exception.Message -ErrorAction Continue
+    $exitCode = 1
+}
+finally {
+    Write-Host ""
+    Write-Host "Shutting down..."
+    Stop-ChildProcessTree -Process $tunnelProcess
+    Stop-ChildProcessTree -Process $relayProcess
+    Write-Host "Done."
+}
+
+exit $exitCode

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3,6 +3,15 @@
 PASS=0; FAIL=0
 DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+if command -v python3 >/dev/null 2>&1 && python3 -c "pass" >/dev/null 2>&1; then
+    PYTHON=python3
+elif command -v python >/dev/null 2>&1 && python -c "pass" >/dev/null 2>&1; then
+    PYTHON=python
+else
+    echo "Python 3 is required"
+    exit 1
+fi
+
 assert_eq() {
   if [ "$1" = "$2" ]; then PASS=$((PASS+1)); echo "  pass: $3"
   else FAIL=$((FAIL+1)); echo "  FAIL: $3 (expected '$2', got '$1')"; fi
@@ -14,8 +23,12 @@ echo ""
 # --- Relay ---
 echo "=== Relay ==="
 echo "1. relay syntax"
-python3 -c "import ast; ast.parse(open('$DIR/relay/herdr_relay.py').read())" 2>/dev/null
+"$PYTHON" -c "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))" "$DIR/relay/herdr_relay.py" 2>/dev/null
 assert_eq "$?" "0" "herdr_relay.py parses"
+
+echo "1b. relay behavior"
+"$PYTHON" -m unittest discover -s "$DIR/tests" -p "test_*.py"
+assert_eq "$?" "0" "relay behavior"
 
 echo "2. PEP 723 metadata"
 grep -q "requires-python" "$DIR/relay/herdr_relay.py"
@@ -29,11 +42,11 @@ assert_eq "$?" "0" "start.sh +x"
 echo ""
 echo "=== Telegram bot ==="
 echo "4. telegram bot syntax"
-python3 -c "import ast; ast.parse(open('$DIR/relay/herdr_telegram.py').read())" 2>/dev/null
+"$PYTHON" -c "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))" "$DIR/relay/herdr_telegram.py" 2>/dev/null
 assert_eq "$?" "0" "herdr_telegram.py parses"
 
 echo "5. telegram demo bot syntax"
-python3 -c "import ast; ast.parse(open('$DIR/relay/herdr_telegram_demo.py').read())" 2>/dev/null
+"$PYTHON" -c "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))" "$DIR/relay/herdr_telegram_demo.py" 2>/dev/null
 assert_eq "$?" "0" "herdr_telegram_demo.py parses"
 
 echo "6. telegram bot has all commands"
@@ -58,7 +71,7 @@ assert_eq "$?" "0" "agent state tests"
 echo ""
 echo "=== TUI ==="
 echo "10. TUI syntax"
-python3 -c "import ast; ast.parse(open('$DIR/relay/herdr_tui.py').read())" 2>/dev/null
+"$PYTHON" -c "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))" "$DIR/relay/herdr_tui.py" 2>/dev/null
 assert_eq "$?" "0" "herdr_tui.py parses"
 
 # --- Web app ---

--- a/tests/test_herdr_plugin.py
+++ b/tests/test_herdr_plugin.py
@@ -1,0 +1,134 @@
+import ast
+import json
+import os
+from pathlib import Path
+import runpy
+import socket
+import unittest
+from unittest import mock
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+HOOK_PATH = ROOT_DIR / "relay" / "on_event.py"
+
+
+class PluginManifestTests(unittest.TestCase):
+    def test_manifests_support_windows_and_resolve_their_hook(self):
+        cases = (
+            (
+                ROOT_DIR / "herdr-plugin.toml",
+                ["uv", "run", "--script", "relay/on_event.py"],
+            ),
+            (
+                ROOT_DIR / "relay" / "herdr-plugin.toml",
+                ["uv", "run", "--script", "on_event.py"],
+            ),
+        )
+
+        for manifest_path, expected_command in cases:
+            with self.subTest(manifest=manifest_path.relative_to(ROOT_DIR)):
+                manifest_lines = manifest_path.read_text(encoding="utf-8").splitlines()
+                values = {
+                    key: ast.literal_eval(next(
+                        line.split("=", 1)[1].strip()
+                        for line in manifest_lines
+                        if line.startswith(f"{key} =")
+                    ))
+                    for key in ("platforms", "on", "command")
+                }
+                self.assertEqual(values["platforms"], ["macos", "linux", "windows"])
+                self.assertEqual(values["on"], "pane.agent_status_changed")
+                self.assertEqual(values["command"], expected_command)
+                self.assertEqual(
+                    (manifest_path.parent / values["command"][3]).resolve(strict=True),
+                    HOOK_PATH.resolve(strict=True),
+                )
+
+
+class PluginHookTests(unittest.TestCase):
+    def _run_hook(self, event, context_json=None):
+        environment = {"HERDR_PLUGIN_EVENT_JSON": json.dumps(event)}
+        if context_json is not None:
+            environment["HERDR_PLUGIN_CONTEXT_JSON"] = context_json
+
+        udp_socket = mock.Mock()
+        with mock.patch.dict(os.environ, environment, clear=True), mock.patch(
+            "socket.gethostname", return_value="test-host.example"
+        ), mock.patch("socket.socket", return_value=udp_socket) as socket_factory:
+            runpy.run_path(str(HOOK_PATH), run_name="__main__")
+
+        socket_factory.assert_called_once_with(socket.AF_INET, socket.SOCK_DGRAM)
+        udp_socket.sendto.assert_called_once()
+        encoded_payload, destination = udp_socket.sendto.call_args.args
+        self.assertEqual(destination, ("127.0.0.1", 8376))
+        udp_socket.close.assert_called_once_with()
+        return json.loads(encoded_payload)
+
+    def test_hook_uses_focused_pane_cwd_for_real_agent_status_event(self):
+        focused_cwd = os.path.join(os.sep, "workspaces", "FocusedProject")
+        workspace_cwd = os.path.join(os.sep, "workspaces", "WorkspaceProject")
+        event = {
+            "data": {
+                "pane_id": "pane-7",
+                "agent_status": "WAITING",
+                "agent": "Claude",
+            }
+        }
+        context = {
+            "focused_pane_cwd": focused_cwd,
+            "workspace_cwd": workspace_cwd,
+        }
+
+        payload = self._run_hook(event, json.dumps(context))
+
+        self.assertEqual(
+            payload,
+            {
+                "type": "agent_event",
+                "pane_id": "pane-7",
+                "status": "waiting",
+                "agent": "claude",
+                "project": "FocusedProject",
+                "cwd": focused_cwd,
+                "host": "test-host",
+            },
+        )
+
+    def test_hook_cwd_fallbacks_degrade_safely(self):
+        workspace_cwd = os.path.join(os.sep, "workspaces", "WorkspaceProject")
+        legacy_cwd = os.path.join(os.sep, "workspaces", "LegacyProject")
+        base_data = {
+            "pane_id": "pane-7",
+            "agent_status": "WAITING",
+            "agent": "Claude",
+        }
+        cases = (
+            (
+                "workspace context",
+                json.dumps({"workspace_cwd": workspace_cwd}),
+                legacy_cwd,
+                workspace_cwd,
+            ),
+            ("missing context", None, legacy_cwd, legacy_cwd),
+            ("malformed context", "{not-json", legacy_cwd, legacy_cwd),
+            ("non-object context", "[]", legacy_cwd, legacy_cwd),
+            ("no cwd source", None, None, ""),
+        )
+
+        for name, context_json, event_cwd, expected_cwd in cases:
+            with self.subTest(name=name):
+                data = dict(base_data)
+                if event_cwd is not None:
+                    data["cwd"] = event_cwd
+
+                payload = self._run_hook({"data": data}, context_json)
+
+                self.assertEqual(payload["cwd"], expected_cwd)
+                self.assertEqual(payload["project"], os.path.basename(expected_cwd))
+                self.assertEqual(payload["status"], "waiting")
+                self.assertEqual(payload["agent"], "claude")
+                self.assertEqual(payload["host"], "test-host")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -1,0 +1,294 @@
+import asyncio
+import importlib.util
+import json
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+import types
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from unittest import mock
+import uuid
+
+
+RELAY_PATH = Path(__file__).resolve().parents[1] / "relay" / "herdr_relay.py"
+
+
+class _ConnectionClosed(Exception):
+    pass
+
+
+def _websockets_stubs():
+    websockets = types.ModuleType("websockets")
+    websockets.__path__ = []
+    websockets_asyncio = types.ModuleType("websockets.asyncio")
+    websockets_asyncio.__path__ = []
+    websockets_server = types.ModuleType("websockets.asyncio.server")
+    websockets_server.serve = object()
+    exceptions = types.ModuleType("websockets.exceptions")
+    exceptions.ConnectionClosedError = _ConnectionClosed
+    exceptions.ConnectionClosedOK = _ConnectionClosed
+    return {
+        "websockets": websockets,
+        "websockets.asyncio": websockets_asyncio,
+        "websockets.asyncio.server": websockets_server,
+        "websockets.exceptions": exceptions,
+    }
+
+
+@contextmanager
+def loaded_relay(*, herdr_bin=None):
+    module_name = f"herdr_relay_test_{uuid.uuid4().hex}"
+    logger = logging.getLogger("herdr-relay")
+    original_handlers = tuple(logger.handlers)
+    original_level = logger.level
+    original_disabled = logger.disabled
+    websockets_logger = logging.getLogger("websockets")
+    original_websockets_level = websockets_logger.level
+
+    relay_dir = str(RELAY_PATH.parent)
+    added_relay_dir = relay_dir not in sys.path
+    if added_relay_dir:
+        sys.path.insert(0, relay_dir)
+
+    with tempfile.TemporaryDirectory() as log_dir:
+        environment = {"HERDR_LOG_DIR": log_dir}
+        if herdr_bin is not None:
+            environment["HERDR_BIN"] = herdr_bin
+
+        with mock.patch.dict(os.environ, environment, clear=False), mock.patch.dict(
+            sys.modules, _websockets_stubs(), clear=False
+        ):
+            if herdr_bin is None:
+                os.environ.pop("HERDR_BIN", None)
+
+            spec = importlib.util.spec_from_file_location(module_name, RELAY_PATH)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            try:
+                spec.loader.exec_module(module)
+                logger.disabled = True
+                yield module
+            finally:
+                sys.modules.pop(module_name, None)
+                if added_relay_dir:
+                    sys.path.remove(relay_dir)
+                for handler in tuple(logger.handlers):
+                    if handler not in original_handlers:
+                        logger.removeHandler(handler)
+                        handler.close()
+                audit_logger = logging.getLogger("herdr-audit")
+                for handler in tuple(audit_logger.handlers):
+                    audit_logger.removeHandler(handler)
+                    handler.close()
+                logger.setLevel(original_level)
+                logger.disabled = original_disabled
+                websockets_logger.setLevel(original_websockets_level)
+
+
+class _FakeWebSocket:
+    def __init__(self, messages):
+        self.remote_address = ("127.0.0.1", 12345)
+        self.request = types.SimpleNamespace(
+            headers={"User-Agent": "Python unittest", "Origin": ""}
+        )
+        self._messages = iter(messages)
+        self.sent = []
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._messages)
+        except StopIteration:
+            raise StopAsyncIteration
+
+    async def send(self, message):
+        self.sent.append(message)
+
+
+class RelayConfigurationTests(unittest.TestCase):
+    def test_herdr_defaults_to_path_lookup(self):
+        with loaded_relay() as relay:
+            expected = relay.shutil.which("herdr")
+            if expected is None:
+                expected = "herdr" if relay.sys.platform == "win32" else "/opt/homebrew/bin/herdr"
+            self.assertEqual(relay.HERDR, expected)
+
+    def test_herdr_bin_override_is_honored(self):
+        configured_path = os.path.join("custom", "bin", "herdr")
+        with loaded_relay(herdr_bin=configured_path) as relay:
+            self.assertEqual(relay.HERDR, configured_path)
+
+    def test_herdr_output_uses_utf8_decoding(self):
+        with loaded_relay() as relay:
+            completed = subprocess.CompletedProcess([], 0, stdout="ready\n", stderr="")
+            with mock.patch.object(relay.subprocess, "run", return_value=completed) as run:
+                for remote in (None, "agent-host"):
+                    with self.subTest(remote=remote):
+                        self.assertEqual(relay.run_herdr("pane", "list", remote=remote), "ready")
+                        kwargs = run.call_args.kwargs
+                        self.assertEqual(kwargs["encoding"], "utf-8")
+                        self.assertEqual(kwargs["errors"], "replace")
+
+    def test_herdr_output_falls_back_to_empty_string_on_invocation_error(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(relay.subprocess, "run", side_effect=OSError("unavailable")):
+                self.assertEqual(relay.run_herdr("pane", "list"), "")
+
+
+class RelayResponseTests(unittest.TestCase):
+    def test_respond_strips_crlf_and_sends_canonical_text_before_enter(self):
+        with loaded_relay() as relay:
+            pane_id = "pane-1"
+            remote = "agent-host"
+            relay.known_panes.add(pane_id)
+            relay.pane_remote_map[pane_id] = remote
+            ws = _FakeWebSocket(
+                [json.dumps({"type": "respond", "pane_id": pane_id, "text": "  yes\r\n"})]
+            )
+            completed = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            with mock.patch.object(relay, "get_all_agents", return_value=[]),                  mock.patch.object(relay.subprocess, "run", return_value=completed) as run:
+                asyncio.run(relay.handle_client(ws))
+
+            prefix = [
+                "ssh",
+                "-o",
+                "ConnectTimeout=5",
+                "-o",
+                "BatchMode=yes",
+                remote,
+                relay.REMOTE_HERDR,
+            ]
+            self.assertEqual(
+                [call.args[0] for call in run.call_args_list],
+                [
+                    [*prefix, "pane", "send-text", pane_id, "yes"],
+                    [*prefix, "pane", "send-keys", pane_id, "Enter"],
+                ],
+            )
+
+    def test_respond_does_not_send_enter_when_send_text_fails(self):
+        with loaded_relay() as relay:
+            pane_id = "pane-1"
+            relay.known_panes.add(pane_id)
+            ws = _FakeWebSocket(
+                [json.dumps({"type": "respond", "pane_id": pane_id, "text": "yes"})]
+            )
+            failed = subprocess.CompletedProcess([], 1, stdout="", stderr="failed")
+            with mock.patch.object(relay, "get_all_agents", return_value=[]),                  mock.patch.object(relay.subprocess, "run", return_value=failed) as run:
+                asyncio.run(relay.handle_client(ws))
+
+            run.assert_called_once()
+            self.assertEqual(
+                run.call_args.args[0], [relay.HERDR, "pane", "send-text", pane_id, "yes"]
+            )
+
+
+class RelaySubprocessConcurrencyTests(unittest.TestCase):
+    def test_calls_to_the_same_remote_are_serialized(self):
+        with loaded_relay() as relay:
+            first_entered = threading.Event()
+            second_started = threading.Event()
+            second_entered = threading.Event()
+            release_first = threading.Event()
+            invocation_count = 0
+            count_lock = threading.Lock()
+
+            def fake_subprocess_run(command, **kwargs):
+                nonlocal invocation_count
+                with count_lock:
+                    invocation_count += 1
+                    invocation = invocation_count
+                if invocation == 1:
+                    first_entered.set()
+                    if not release_first.wait(5):
+                        raise AssertionError("test did not release the first subprocess")
+                else:
+                    second_entered.set()
+                return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+            def run_second_call():
+                second_started.set()
+                return relay.run_herdr("pane", "read", "second", remote="same-host")
+
+            with mock.patch.object(relay.subprocess, "run", side_effect=fake_subprocess_run):
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    first = executor.submit(
+                        relay.run_herdr, "pane", "read", "first", remote="same-host"
+                    )
+                    self.assertTrue(first_entered.wait(2), "first subprocess did not start")
+                    second = executor.submit(run_second_call)
+                    self.assertTrue(second_started.wait(2), "second call did not start")
+                    try:
+                        self.assertFalse(
+                            second_entered.wait(0.5),
+                            "second subprocess entered before the first completed",
+                        )
+                    finally:
+                        release_first.set()
+                    self.assertEqual(first.result(timeout=2), "ok")
+                    self.assertEqual(second.result(timeout=2), "ok")
+
+            self.assertTrue(second_entered.is_set())
+            self.assertEqual(invocation_count, 2)
+
+    def test_other_remotes_and_local_calls_do_not_share_a_lock(self):
+        with loaded_relay() as relay:
+            entered = {
+                "blocked-host": threading.Event(),
+                "other-host": threading.Event(),
+                "local": threading.Event(),
+            }
+            release_blocked = threading.Event()
+
+            def command_target(command):
+                if command[0] != "ssh":
+                    return "local"
+                batch_mode_index = command.index("BatchMode=yes")
+                return command[batch_mode_index + 1]
+
+            def fake_subprocess_run(command, **kwargs):
+                target = command_target(command)
+                entered[target].set()
+                if target == "blocked-host" and not release_blocked.wait(5):
+                    raise AssertionError("test did not release blocked-host")
+                return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+            with mock.patch.object(relay.subprocess, "run", side_effect=fake_subprocess_run):
+                with ThreadPoolExecutor(max_workers=3) as executor:
+                    blocked = executor.submit(
+                        relay.run_herdr, "pane", "read", "one", remote="blocked-host"
+                    )
+                    self.assertTrue(
+                        entered["blocked-host"].wait(2),
+                        "blocked remote subprocess did not start",
+                    )
+                    other = executor.submit(
+                        relay.run_herdr, "pane", "read", "two", remote="other-host"
+                    )
+                    local = executor.submit(relay.run_herdr, "pane", "read", "three")
+                    try:
+                        self.assertTrue(
+                            entered["other-host"].wait(2),
+                            "different remote was blocked by the first remote",
+                        )
+                        self.assertTrue(
+                            entered["local"].wait(2),
+                            "local execution was blocked by a remote",
+                        )
+                    finally:
+                        release_blocked.set()
+                    self.assertEqual(blocked.result(timeout=2), "ok")
+                    self.assertEqual(other.result(timeout=2), "ok")
+                    self.assertEqual(local.result(timeout=2), "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -459,7 +459,7 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
 
     def test_relay_allows_numeric_approval_keys_and_acknowledges_them(self):
         relay_path = ROOT / "relay" / "herdr_relay.py"
-        source = relay_path.read_text()
+        source = relay_path.read_text(encoding="utf-8")
         tree = ast.parse(source)
         safe_keys = next(
             node.value


### PR DESCRIPTION
## Summary

- add a PowerShell relay launcher for Windows
- support local-only, temporary Cloudflare, and named Cloudflare modes
- default to loopback-only, local-only operation
- require `HERDR_RELAY_TOKEN` for public tunnels and non-loopback listeners
- discover `herdr` from `PATH` while preserving `HERDR_BIN`
- use a Windows-appropriate log directory
- run plugin hooks through `uv run --script` across Windows, macOS, and Linux
- preserve pushed status events during transient polling failures
- serialize subprocess calls per SSH target without blocking unrelated targets
- document Windows setup, authentication, plugin linking, tunnels, and bundled clients
- add Windows/plugin/relay behavior tests

## Motivation

Herdi.app is macOS-only, but the Python relay and its web, TUI, and Telegram clients are otherwise cross-platform. Windows users currently need undocumented setup and encounter platform assumptions around executable discovery, logging, plugin execution, startup, and signal handling.

This enables the existing relay and clients on Windows without adding a native tray application.

## Security

- relay binds to `127.0.0.1` by default
- launcher defaults to `HERDR_TUNNEL_MODE=none`
- tokens are required for temporary/named tunnels and non-loopback binds
- direct relay execution enforces the same non-loopback rule
- bundled clients can authenticate with a token-bearing `HERDR_RELAY` URL

## Verification

- `tests/run.sh`: 18 passed, 0 failed
- relay/plugin behavior tests: 11 passed
- PowerShell launcher starts and stops the relay process tree
- branch is one clean commit over `main`

## Scope

This does not add a native Windows tray application.