### PR TITLE
Support OMP ask interactions from remote clients

### DIFF
--- a/herdi-ios/Sources/Models/Agent.swift
+++ b/herdi-ios/Sources/Models/Agent.swift
@@ -14,6 +14,11 @@ final class Agent: Identifiable {
     var host: String
     var prompt: String?
     var options: [String]?
+    var promptId: String?
+    var multiOptions: [String] = []
+    var selectedOptions: [String] = []
+    var interaction: String?
+    var isMultiSelect = false
 
     init(id: String, name: String, status: AgentStatus, project: String, cwd: String, host: String = "local") {
         self.id = id
@@ -34,6 +39,12 @@ struct AgentMessage: Decodable {
     let project: String?
     let prompt: String?
     let options: [String]?
+    let prompt_id: String?
+    let multi_options: [String]?
+    let selected_options: [String]?
+    let interaction: String?
+    let multi: Bool?
+    let update: Bool?
 
     struct AgentData: Decodable {
         let pane_id: String
@@ -45,7 +56,8 @@ struct AgentMessage: Decodable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case type, agents, pane_id, agent, project, prompt, options
+        case type, agents, pane_id, agent, project, prompt, options, prompt_id
+        case multi_options, selected_options, interaction, multi, update
     }
 
     init(from decoder: Decoder) throws {
@@ -56,6 +68,12 @@ struct AgentMessage: Decodable {
         project = try? values.decode(String.self, forKey: .project)
         prompt = try? values.decode(String.self, forKey: .prompt)
         options = try? values.decode([String].self, forKey: .options)
+        prompt_id = try? values.decode(String.self, forKey: .prompt_id)
+        multi_options = try? values.decode([String].self, forKey: .multi_options)
+        selected_options = try? values.decode([String].self, forKey: .selected_options)
+        interaction = try? values.decode(String.self, forKey: .interaction)
+        multi = try? values.decode(Bool.self, forKey: .multi)
+        update = try? values.decode(Bool.self, forKey: .update)
         if type == "agent_update" {
             agentData = try? values.decode(AgentData.self, forKey: .agent)
             agent = nil
@@ -69,5 +87,19 @@ struct AgentMessage: Decodable {
 struct ResponseMessage: Codable {
     let type = "respond"
     let pane_id: String
+    let prompt_id: String?
     let text: String
+}
+
+struct QuestionToggleMessage: Codable {
+    let type = "question_toggle"
+    let pane_id: String
+    let prompt_id: String
+    let option: String
+}
+
+struct QuestionSubmitMessage: Codable {
+    let type = "question_submit"
+    let pane_id: String
+    let prompt_id: String
 }

--- a/herdi-ios/Sources/Services/RelayConnection.swift
+++ b/herdi-ios/Sources/Services/RelayConnection.swift
@@ -107,6 +107,20 @@ final class RelayConnection {
         task?.send(.string(String(data: data, encoding: .utf8)!)) { _ in }
     }
 
+    func toggleQuestionOption(paneId: String, promptId: String, option: String) {
+        guard let data = try? JSONEncoder().encode(
+            QuestionToggleMessage(pane_id: paneId, prompt_id: promptId, option: option)
+        ) else { return }
+        task?.send(.string(String(data: data, encoding: .utf8)!)) { _ in }
+    }
+
+    func submitQuestion(paneId: String, promptId: String) {
+        guard let data = try? JSONEncoder().encode(
+            QuestionSubmitMessage(pane_id: paneId, prompt_id: promptId)
+        ) else { return }
+        task?.send(.string(String(data: data, encoding: .utf8)!)) { _ in }
+    }
+
     func fetchHistory(for paneId: String) {
         let msg = ["type": "read_pane", "pane_id": paneId]
         guard let data = try? JSONSerialization.data(withJSONObject: msg) else { return }
@@ -174,10 +188,17 @@ final class RelayConnection {
                 if let pid = msg.pane_id,
                    let agent = agents.first(where: { $0.id == pid }) {
                     agent.prompt = msg.prompt
+                    agent.promptId = msg.prompt_id
                     agent.options = msg.options
+                    agent.multiOptions = msg.multi_options ?? []
+                    agent.selectedOptions = msg.selected_options ?? []
+                    agent.interaction = msg.interaction
+                    agent.isMultiSelect = msg.multi ?? false
                     agent.status = .blocked
-                    HapticManager.shared.blocked()
-                    NotificationManager.shared.notifyBlocked(agent: agent.name, project: agent.project)
+                    if msg.update != true {
+                        HapticManager.shared.blocked()
+                        NotificationManager.shared.notifyBlocked(agent: agent.name, project: agent.project)
+                    }
                 }
 
             case "pane_content":

--- a/herdi-ios/Sources/Views/AgentDetailView.swift
+++ b/herdi-ios/Sources/Views/AgentDetailView.swift
@@ -35,7 +35,24 @@ struct AgentDetailView: View {
             if agent.status == .blocked {
                 Divider()
                 VStack(spacing: 10) {
-                    if let options = agent.options {
+                    if agent.isMultiSelect, let promptId = agent.promptId {
+                        ForEach(agent.multiOptions, id: \.self) { option in
+                            Button {
+                                toggle(option, promptId: promptId)
+                            } label: {
+                                Label(
+                                    option,
+                                    systemImage: agent.selectedOptions.contains(option)
+                                        ? "checkmark.square.fill" : "square"
+                                )
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 10)
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                        Button("Submit") { submit(promptId: promptId) }
+                            .buttonStyle(.borderedProminent)
+                    } else if let options = agent.options {
                         ForEach(options, id: \.self) { option in
                             Button {
                                 respond(option)
@@ -72,10 +89,30 @@ struct AgentDetailView: View {
 
     private func respond(_ text: String) {
         HapticManager.shared.sent()
-        relay.send(response: ResponseMessage(pane_id: agent.id, text: text))
+        relay.send(response: ResponseMessage(pane_id: agent.id, prompt_id: agent.promptId, text: text))
         agent.status = .working
         agent.prompt = nil
+        agent.promptId = nil
         agent.options = nil
+    }
+
+    private func toggle(_ option: String, promptId: String) {
+        relay.toggleQuestionOption(paneId: agent.id, promptId: promptId, option: option)
+        if let index = agent.selectedOptions.firstIndex(of: option) {
+            agent.selectedOptions.remove(at: index)
+        } else {
+            agent.selectedOptions.append(option)
+        }
+    }
+
+    private func submit(promptId: String) {
+        HapticManager.shared.sent()
+        relay.submitQuestion(paneId: agent.id, promptId: promptId)
+        agent.status = .working
+        agent.prompt = nil
+        agent.promptId = nil
+        agent.multiOptions = []
+        agent.selectedOptions = []
     }
 
     private func tint(for option: String) -> Color {

--- a/herdi-ios/Sources/Views/AgentListView.swift
+++ b/herdi-ios/Sources/Views/AgentListView.swift
@@ -147,9 +147,10 @@ struct SwipeableAgentCard: View {
 
     private func respond(_ text: String) {
         HapticManager.shared.sent()
-        relay.send(response: ResponseMessage(pane_id: agent.id, text: text))
+        relay.send(response: ResponseMessage(pane_id: agent.id, prompt_id: agent.promptId, text: text))
         agent.status = .working
         agent.prompt = nil
+        agent.promptId = nil
         agent.options = nil
     }
 }

--- a/herdi-ios/Sources/Views/ApprovalView.swift
+++ b/herdi-ios/Sources/Views/ApprovalView.swift
@@ -17,7 +17,27 @@ struct ApprovalView: View {
                 }
                 .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
 
-                if let options = agent.options {
+                if agent.isMultiSelect, let promptId = agent.promptId {
+                    VStack(spacing: 10) {
+                        ForEach(agent.multiOptions, id: \.self) { option in
+                            Button {
+                                toggle(option, promptId: promptId)
+                            } label: {
+                                Label(
+                                    option,
+                                    systemImage: agent.selectedOptions.contains(option)
+                                        ? "checkmark.square.fill" : "square"
+                                )
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.vertical, 12)
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                        Button("Submit") { submit(promptId: promptId) }
+                            .buttonStyle(.borderedProminent)
+                            .frame(maxWidth: .infinity)
+                    }
+                } else if let options = agent.options {
                     VStack(spacing: 10) {
                         ForEach(options, id: \.self) { option in
                             Button {
@@ -55,10 +75,31 @@ struct ApprovalView: View {
 
     private func respond(_ text: String) {
         HapticManager.shared.sent()
-        relay.send(response: ResponseMessage(pane_id: agent.id, text: text))
+        relay.send(response: ResponseMessage(pane_id: agent.id, prompt_id: agent.promptId, text: text))
         agent.status = .working
         agent.prompt = nil
+        agent.promptId = nil
         agent.options = nil
+        dismiss()
+    }
+
+    private func toggle(_ option: String, promptId: String) {
+        relay.toggleQuestionOption(paneId: agent.id, promptId: promptId, option: option)
+        if let index = agent.selectedOptions.firstIndex(of: option) {
+            agent.selectedOptions.remove(at: index)
+        } else {
+            agent.selectedOptions.append(option)
+        }
+    }
+
+    private func submit(promptId: String) {
+        HapticManager.shared.sent()
+        relay.submitQuestion(paneId: agent.id, promptId: promptId)
+        agent.status = .working
+        agent.prompt = nil
+        agent.promptId = nil
+        agent.multiOptions = []
+        agent.selectedOptions = []
         dismiss()
     }
 

--- a/herdi-mac/Sources/Agent.swift
+++ b/herdi-mac/Sources/Agent.swift
@@ -14,6 +14,11 @@ final class Agent: Identifiable {
     var host: String
     var prompt: String?
     var options: [String]?
+    var promptId: String?
+    var multiOptions: [String] = []
+    var selectedOptions: [String] = []
+    var interaction: String?
+    var isMultiSelect = false
 
     init(id: String, name: String, status: AgentStatus, project: String, cwd: String, host: String = "local") {
         self.id = id
@@ -34,6 +39,12 @@ struct AgentMessage: Decodable {
     let project: String?
     let prompt: String?
     let options: [String]?
+    let prompt_id: String?
+    let multi_options: [String]?
+    let selected_options: [String]?
+    let interaction: String?
+    let multi: Bool?
+    let update: Bool?
 
     struct AgentData: Decodable {
         let pane_id: String
@@ -45,7 +56,8 @@ struct AgentMessage: Decodable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case type, agents, pane_id, agent, project, prompt, options
+        case type, agents, pane_id, agent, project, prompt, options, prompt_id
+        case multi_options, selected_options, interaction, multi, update
     }
 
     init(from decoder: Decoder) throws {
@@ -56,6 +68,12 @@ struct AgentMessage: Decodable {
         project = try? values.decode(String.self, forKey: .project)
         prompt = try? values.decode(String.self, forKey: .prompt)
         options = try? values.decode([String].self, forKey: .options)
+        prompt_id = try? values.decode(String.self, forKey: .prompt_id)
+        multi_options = try? values.decode([String].self, forKey: .multi_options)
+        selected_options = try? values.decode([String].self, forKey: .selected_options)
+        interaction = try? values.decode(String.self, forKey: .interaction)
+        multi = try? values.decode(Bool.self, forKey: .multi)
+        update = try? values.decode(Bool.self, forKey: .update)
         if type == "agent_update" {
             agentData = try? values.decode(AgentData.self, forKey: .agent)
             agent = nil
@@ -69,5 +87,19 @@ struct AgentMessage: Decodable {
 struct ResponseMessage: Codable {
     let type = "respond"
     let pane_id: String
+    let prompt_id: String?
     let text: String
+}
+
+struct QuestionToggleMessage: Codable {
+    let type = "question_toggle"
+    let pane_id: String
+    let prompt_id: String
+    let option: String
+}
+
+struct QuestionSubmitMessage: Codable {
+    let type = "question_submit"
+    let pane_id: String
+    let prompt_id: String
 }

--- a/herdi-mac/Sources/NotchContentView.swift
+++ b/herdi-mac/Sources/NotchContentView.swift
@@ -466,9 +466,14 @@ private struct AgentSessionRow: View {
             // Actions
             if hovered || style == .blocked {
                 HStack(spacing: 4) {
-                    if style == .blocked {
+                    if style == .blocked,
+                       agent.options?.contains("yes, single permission") == true {
                         Button {
-                            relay.send(response: ResponseMessage(pane_id: agent.id, text: "yes, single permission"))
+                            relay.send(response: ResponseMessage(
+                                pane_id: agent.id,
+                                prompt_id: agent.promptId,
+                                text: "yes, single permission"
+                            ))
                         } label: {
                             Image(systemName: "checkmark.circle.fill")
                                 .font(.system(size: 14))
@@ -588,11 +593,36 @@ private struct ApprovalCard: View {
             )
             .padding(.horizontal, 12)
 
-            // Response buttons — clean grid of common actions
-            ResponseButtonGrid(options: agent.options) { response in
-                respond(response)
+            if agent.isMultiSelect, let promptId = agent.promptId {
+                VStack(spacing: 6) {
+                    ForEach(agent.multiOptions, id: \.self) { option in
+                        Button {
+                            toggle(option, promptId: promptId)
+                        } label: {
+                            HStack {
+                                Image(systemName: agent.selectedOptions.contains(option) ? "checkmark.square.fill" : "square")
+                                Text(option)
+                                Spacer()
+                            }
+                            .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    Button {
+                        submit(promptId: promptId)
+                    } label: {
+                        Label("Submit", systemImage: "checkmark.circle.fill")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding(.horizontal, 12)
+            } else {
+                ResponseButtonGrid(options: agent.options) { response in
+                    respond(response)
+                }
+                .padding(.horizontal, 12)
             }
-            .padding(.horizontal, 12)
 
             // Custom text input
             HStack(spacing: 6) {
@@ -627,10 +657,30 @@ private struct ApprovalCard: View {
     }
 
     private func respond(_ text: String) {
-        relay.send(response: ResponseMessage(pane_id: agent.id, text: text))
+        relay.send(response: ResponseMessage(pane_id: agent.id, prompt_id: agent.promptId, text: text))
         agent.status = .working
         agent.prompt = nil
+        agent.promptId = nil
         agent.options = nil
+        onDismiss()
+    }
+
+    private func toggle(_ option: String, promptId: String) {
+        relay.toggleQuestionOption(paneId: agent.id, promptId: promptId, option: option)
+        if let index = agent.selectedOptions.firstIndex(of: option) {
+            agent.selectedOptions.remove(at: index)
+        } else {
+            agent.selectedOptions.append(option)
+        }
+    }
+
+    private func submit(promptId: String) {
+        relay.submitQuestion(paneId: agent.id, promptId: promptId)
+        agent.status = .working
+        agent.prompt = nil
+        agent.promptId = nil
+        agent.multiOptions = []
+        agent.selectedOptions = []
         onDismiss()
     }
 }
@@ -644,7 +694,7 @@ private struct ResponseButtonGrid: View {
     let onRespond: (String) -> Void
 
     private var buttons: [ResponseAction] {
-        guard let options else { return defaultActions }
+        guard let options else { return [] }
         return options.map { mapOption($0) }
     }
 
@@ -654,15 +704,6 @@ private struct ResponseButtonGrid: View {
                 ResponseButton(action: btn) { onRespond(btn.rawValue) }
             }
         }
-    }
-
-    // Default actions when no options detected
-    private var defaultActions: [ResponseAction] {
-        [
-            ResponseAction(label: "Allow", icon: "checkmark", tint: .green, shortcut: "⌘Y", rawValue: "yes, single permission"),
-            ResponseAction(label: "Trust", icon: "shield.checkered", tint: .blue, shortcut: "⌘T", rawValue: "trust, always allow"),
-            ResponseAction(label: "Deny", icon: "xmark", tint: .red, shortcut: "⌘N", rawValue: "no (tab to edit)"),
-        ]
     }
 
     private func mapOption(_ option: String) -> ResponseAction {

--- a/herdi-mac/Sources/RelayConnection.swift
+++ b/herdi-mac/Sources/RelayConnection.swift
@@ -227,10 +227,27 @@ final class RelayConnection {
                     _ = runHerdr("pane", "send-text", paneId, response.text + "\n")
                 }
             }
+
         } else {
             guard let data = try? JSONEncoder().encode(response) else { return }
             task?.send(.string(String(data: data, encoding: .utf8)!)) { _ in }
         }
+    }
+
+    func toggleQuestionOption(paneId: String, promptId: String, option: String) {
+        guard mode == .relay,
+              let data = try? JSONEncoder().encode(
+                QuestionToggleMessage(pane_id: paneId, prompt_id: promptId, option: option)
+              ) else { return }
+        task?.send(.string(String(data: data, encoding: .utf8)!)) { _ in }
+    }
+
+    func submitQuestion(paneId: String, promptId: String) {
+        guard mode == .relay,
+              let data = try? JSONEncoder().encode(
+                QuestionSubmitMessage(pane_id: paneId, prompt_id: promptId)
+              ) else { return }
+        task?.send(.string(String(data: data, encoding: .utf8)!)) { _ in }
     }
 
     func focusPane(_ paneId: String) {
@@ -296,9 +313,16 @@ final class RelayConnection {
             case "blocked":
                 if let pid = msg.pane_id, let agent = agents.first(where: { $0.id == pid }) {
                     agent.prompt = msg.prompt
+                    agent.promptId = msg.prompt_id
                     agent.options = msg.options
+                    agent.multiOptions = msg.multi_options ?? []
+                    agent.selectedOptions = msg.selected_options ?? []
+                    agent.interaction = msg.interaction
+                    agent.isMultiSelect = msg.multi ?? false
                     agent.status = .blocked
-                    sendNotification(agent: agent.name, project: agent.project)
+                    if msg.update != true {
+                        sendNotification(agent: agent.name, project: agent.project)
+                    }
                 }
             default: break
             }

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -4,7 +4,7 @@
 # dependencies = ["websockets>=14.0", "zeroconf>=0.80.0", "pywebpush>=2.0.0", "py-vapid>=1.9.0"]
 # ///
 """herdr-remote relay — polls herdr, accepts push events (HTTP POST + WebSocket + UDP), broadcasts to clients."""
-import asyncio, json, logging, os, re, shutil, signal, socket, subprocess, time
+import asyncio, hashlib, json, logging, os, re, shutil, signal, socket, subprocess, time
 
 from agent_state import complete_agent_update_message
 
@@ -65,9 +65,16 @@ CHROME_RE = re.compile(
     r"|type to queue"
     r"|^\s*[◔◑◕●]\s+(Shell|Bash)"
 )
+QUESTION_OPTION_RE = re.compile(
+    r"^(?P<cursor>[\uf054>›❯▸→])?\s*"
+    r"(?P<marker>[\uf046\uf10c\uf192\uf096\uf14a○◉☐☑]|\([ o]\)|\[[ xX]\])\s+"
+    r"(?P<label>.+?)\s*$"
+)
+QUESTION_OTHER = "Other (type your own)"
 
 clients = set()
 last_statuses = {}
+last_blocked_prompts = {}
 event_queue = asyncio.Queue()
 pane_remote_map = {}
 known_panes = set()
@@ -172,6 +179,16 @@ def run_herdr(*args, remote=None):
     except Exception:
         return ""
 
+def _mutate_herdr(*args, remote=None):
+    try:
+        if remote:
+            cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", remote, HERDR, *args]
+        else:
+            cmd = [HERDR, *args]
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=15).returncode == 0
+    except Exception:
+        return False
+
 
 def get_agents_from_host(remote=None):
     raw = run_herdr("pane", "list", remote=remote)
@@ -205,19 +222,273 @@ def get_all_agents():
     return agents
 
 
+def update_pane_maps(agents):
+    current_pane_ids = {agent["pane_id"] for agent in agents}
+    for agent in agents:
+        pane_id = agent["pane_id"]
+        pane_remote_map[pane_id] = agent.get("remote")
+        known_panes.add(pane_id)
+
+    stale = known_panes - current_pane_ids
+    if stale:
+        known_panes.difference_update(stale)
+        for pane_id in stale:
+            pane_remote_map.pop(pane_id, None)
+            last_statuses.pop(pane_id, None)
+            last_blocked_prompts.pop(pane_id, None)
+            agent_cache.pop(pane_id, None)
+
+
+
 def read_pane(pane_id, remote=None):
-    raw = run_herdr("pane", "read", pane_id, "--lines", "50", "--source", "recent", remote=remote)
+    raw = run_herdr("pane", "read", pane_id, "--lines", "200", "--source", "recent", remote=remote)
     lines = [l for l in raw.splitlines() if l.strip() and not CHROME_RE.search(l)]
-    return "\n".join(lines[-20:])
+    display_lines = lines[-50:]
+    question = detect_question("\n".join(lines))
+    if question and question["text"] and question["text"] not in display_lines:
+        option_start = next(
+            (
+                index for index in range(len(display_lines) - 1, -1, -1)
+                if QUESTION_OPTION_RE.match(display_lines[index].strip().strip("│|").strip())
+            ),
+            None,
+        )
+        if option_start is not None:
+            while option_start > 0 and QUESTION_OPTION_RE.match(
+                display_lines[option_start - 1].strip().strip("│|").strip()
+            ):
+                option_start -= 1
+        else:
+            option_start = 0
+        display_lines.insert(option_start, question["text"])
+    return "\n".join(display_lines)
 
 
-def detect_options(text):
+def detect_question(text):
+    blocks = []
+    current = []
+    current_start = None
+    lines = text.splitlines()
+    for line_index, raw_line in enumerate(lines):
+        line = raw_line.strip().strip("│|").strip()
+        match = QUESTION_OPTION_RE.match(line)
+        if not match:
+            if current:
+                blocks.append((current_start, current))
+                current = []
+                current_start = None
+            continue
+        if current_start is None:
+            current_start = line_index
+        current.append({
+            "label": match.group("label").strip(),
+            "selected": bool(match.group("cursor")),
+            "multi": match.group("marker") in {"\uf046", "\uf096", "\uf14a", "☐", "☑", "[ ]", "[x]", "[X]"},
+            "checked": match.group("marker") in {"\uf046", "\uf14a", "☑", "[x]", "[X]"},
+        })
+    if current:
+        blocks.append((current_start, current))
+
+    for block_start, block in reversed(blocks):
+        has_other = any(option["label"] == QUESTION_OTHER for option in block)
+        has_done = any("Done selecting" in option["label"] for option in block)
+        if has_other or has_done:
+            question_lines = []
+            for raw_line in reversed(lines[:block_start]):
+                line = raw_line.strip().strip("│|").strip()
+                if not line:
+                    if question_lines:
+                        break
+                    continue
+                if (
+                    "submit" in line.casefold()
+                    or re.fullmatch(r"[\W_]*ask[\W_]*", line, re.IGNORECASE)
+                    or not any(character.isalnum() for character in line)
+                ):
+                    if question_lines:
+                        break
+                    continue
+                question_lines.append(line)
+            return {
+                "options": block,
+                "selected_index": next(
+                    (index for index, option in enumerate(block) if option["selected"]),
+                    0,
+                ),
+                "multi": any(option["multi"] for option in block) or has_done,
+                "text": " ".join(reversed(question_lines)),
+            }
+    return None
+
+
+def detect_approval_options(text):
     lower = text.lower()
     if "yes, single permission" in lower:
         return TOOL_OPTIONS
     if "approve all pending" in lower:
         return SUBAGENT_OPTIONS
-    return None
+    return []
+
+
+def detect_options(text):
+    approval_options = detect_approval_options(text)
+    if approval_options:
+        return approval_options
+    question = detect_question(text)
+    if not question:
+        return []
+    return [
+        option["label"]
+        for option in question["options"]
+        if option["label"] != QUESTION_OTHER and "Done selecting" not in option["label"]
+    ]
+
+
+def custom_editor_active(text):
+    return "Enter your response:" in text or (
+        "Custom answer:" in text and "submit" in text.lower()
+    )
+
+def question_prompt_id(pane_id, content):
+    question = detect_question(content)
+    if not question:
+        return hashlib.sha256(f"{pane_id}\n{' '.join(content.split())}".encode("utf-8")).hexdigest()[:20]
+    labels = [
+        option["label"]
+        for option in question["options"]
+        if option["label"] != QUESTION_OTHER and "Done selecting" not in option["label"]
+    ]
+    signature = json.dumps(
+        {
+            "pane_id": pane_id,
+            "question": question["text"],
+            "multi": question["multi"],
+            "labels": labels,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(signature.encode("utf-8")).hexdigest()[:20]
+
+
+def blocked_message(pane_id, agent, project, host, content):
+    question = detect_question(content) if agent == "omp" else None
+    options = detect_options(content) if agent == "omp" else detect_approval_options(content)
+    return {
+        "type": "blocked",
+        "pane_id": pane_id,
+        "agent": agent,
+        "project": project,
+        "host": host,
+        "prompt": content[-500:],
+        "prompt_id": question_prompt_id(pane_id, content),
+        "options": [] if question and question["multi"] else options,
+        "multi_options": options if question and question["multi"] else [],
+        "selected_options": [
+            option["label"] for option in question["options"]
+            if option["multi"] and option["label"] != QUESTION_OTHER
+            and "Done selecting" not in option["label"] and option.get("checked", False)
+        ] if question else [],
+        "interaction": "omp_question" if question else "prompt",
+        "multi": bool(question and question["multi"]),
+        "update": False,
+    }
+
+
+def prompt_matches(pane_id, prompt_id, remote=None):
+    if not prompt_id:
+        return False
+    content = read_pane(pane_id, remote=remote)
+    return question_prompt_id(pane_id, content) == prompt_id
+
+
+def pane_is_omp(pane_id, remote=None):
+    return any(
+        agent["pane_id"] == pane_id and agent["agent"] == "omp" and agent.get("remote") == remote
+        for agent in get_all_agents()
+    )
+
+
+def move_question_cursor(pane_id, question, target_index, remote=None):
+    selected_index = question["selected_index"]
+    direction = "Down" if target_index >= selected_index else "Up"
+    keys = [direction] * abs(target_index - selected_index)
+    return not keys or _mutate_herdr("pane", "send-keys", pane_id, *keys, remote=remote)
+
+
+def toggle_question_option(pane_id, option_label, remote=None):
+    if not pane_is_omp(pane_id, remote=remote):
+        return False
+    question = detect_question(read_pane(pane_id, remote=remote))
+    if not question or not question["multi"]:
+        return False
+    target_index = next((
+        index
+        for index, option in enumerate(question["options"])
+        if option["label"].casefold() == option_label.casefold()
+    ), None)
+    if target_index is None or not move_question_cursor(pane_id, question, target_index, remote=remote):
+        return False
+    return _mutate_herdr("pane", "send-keys", pane_id, "Enter", remote=remote)
+
+
+def submit_multi_question(pane_id, remote=None):
+    if not pane_is_omp(pane_id, remote=remote):
+        return False
+    content = read_pane(pane_id, remote=remote)
+    question = detect_question(content)
+    if not question or not question["multi"]:
+        return False
+    done_index = next((
+        index
+        for index, option in enumerate(question["options"])
+        if "Done selecting" in option["label"]
+    ), None)
+    if done_index is not None:
+        if not move_question_cursor(pane_id, question, done_index, remote=remote):
+            return False
+        return _mutate_herdr("pane", "send-keys", pane_id, "Enter", remote=remote)
+    if "Submit" in content and any(
+        marker in content for marker in ("\uf14a", "\uf046", "☑", "[x]", "[X]")
+    ):
+        return _mutate_herdr("pane", "send-keys", pane_id, "Tab", "Enter", remote=remote)
+    return False
+
+
+def respond_to_question(pane_id, text, question, remote=None):
+    options = question["options"]
+    target_index = next(
+        (index for index, option in enumerate(options) if option["label"].casefold() == text.casefold()),
+        None,
+    )
+    custom_response = target_index is None
+    if custom_response:
+        target_index = next(
+            (index for index, option in enumerate(options) if option["label"] == QUESTION_OTHER),
+            None,
+        )
+    if target_index is None:
+        return False
+
+    selected_index = question["selected_index"]
+    direction = "Down" if target_index >= selected_index else "Up"
+    keys = [direction] * abs(target_index - selected_index) + ["Enter"]
+    if not _mutate_herdr("pane", "send-keys", pane_id, *keys, remote=remote):
+        return False
+    if not custom_response:
+        return True
+    deadline = time.monotonic() + 1.5
+    while time.monotonic() < deadline:
+        editor_content = read_pane(pane_id, remote=remote)
+        if "Enter your response:" in editor_content or (
+            "Custom answer:" in editor_content and "submit" in editor_content.lower()
+        ):
+            break
+        time.sleep(0.05)
+    else:
+        return False
+    return _mutate_herdr("pane", "send-text", pane_id, text, remote=remote) and _mutate_herdr(
+        "pane", "send-keys", pane_id, "Enter", remote=remote
+    )
 
 
 async def broadcast(msg):
@@ -234,6 +505,22 @@ async def broadcast(msg):
         log.debug("Removed %d dead client(s)", len(dead))
     clients.difference_update(dead)
 
+async def send_current_snapshot(ws):
+    agents = get_all_agents()
+    update_pane_maps(agents)
+    await ws.send(json.dumps({"type": "agents", "agents": agents}))
+    for agent in agents:
+        if agent["status"] != "blocked":
+            continue
+        content = read_pane(agent["pane_id"], remote=agent.get("remote"))
+        await ws.send(json.dumps(blocked_message(
+            agent["pane_id"],
+            agent["agent"],
+            agent["project"],
+            agent.get("host", "local"),
+            content,
+        )))
+
 
 async def poll_loop():
     while True:
@@ -246,43 +533,42 @@ async def poll_loop():
 
 async def _poll_once():
         agents = get_all_agents()
+        update_pane_maps(agents)
         # Always broadcast (even empty list) so clients stay in sync
         for a in agents:
-            pane_remote_map[a["pane_id"]] = a.get("remote")
-            known_panes.add(a["pane_id"])
             agent_cache[a["pane_id"]] = a
         await broadcast({"type": "agents", "agents": agents})
         for a in agents:
             pid, status = a["pane_id"], a["status"]
-            if status == "blocked" and last_statuses.get(pid) != "blocked":
+            if status == "blocked":
                 content = read_pane(pid, remote=a.get("remote"))
-                options = detect_options(content)
-                await broadcast({
-                    "type": "blocked", "pane_id": pid,
-                    "agent": a["agent"], "project": a["project"],
-                    "host": a.get("host", "local"),
-                    "prompt": content[:500],
-                    "options": options or TOOL_OPTIONS
-                })
-                # Web Push notification
-                await send_web_push(
-                    title=f"🐑 {a['project']} blocked",
-                    body=content[:120],
-                    url=f"/?pane={pid}",
+                message = blocked_message(
+                    pid,
+                    a["agent"],
+                    a["project"],
+                    a.get("host", "local"),
+                    content,
                 )
-            # Send clear push when agent unblocks
-            if status != "blocked" and last_statuses.get(pid) == "blocked":
-                await send_web_push("", "", clear=True)
+                fingerprint = (
+                    message["prompt_id"],
+                    tuple(message["selected_options"]),
+                    message["prompt"],
+                )
+                previous = last_blocked_prompts.get(pid)
+                if previous != fingerprint:
+                    message["update"] = previous is not None and previous[0] == message["prompt_id"]
+                    last_blocked_prompts[pid] = fingerprint
+                    await broadcast(message)
+                    await send_web_push(
+                        title=f"🐑 {a['project']} blocked",
+                        body=content[:120],
+                        url=f"/?pane={pid}",
+                    )
+            else:
+                last_blocked_prompts.pop(pid, None)
+                if last_statuses.get(pid) == "blocked":
+                    await send_web_push("", "", clear=True)
             last_statuses[pid] = status
-        # Clean up panes that are no longer reported
-        current_pane_ids = {a["pane_id"] for a in agents}
-        stale = known_panes - current_pane_ids
-        if stale:
-            known_panes.difference_update(stale)
-            for pid in stale:
-                pane_remote_map.pop(pid, None)
-                last_statuses.pop(pid, None)
-                agent_cache.pop(pid, None)
 
 
 async def event_push():
@@ -308,15 +594,19 @@ async def event_push():
                 content = read_pane(pane_id, remote=remote)
             else:
                 content = event.get("prompt", "Agent is blocked")
-            options = detect_options(content)
-            await broadcast({
-                "type": "blocked", "pane_id": pane_id,
-                "agent": agent_data.get("agent", ""),
-                "project": agent_data.get("project", ""),
-                "host": host,
-                "prompt": content[:500],
-                "options": options or TOOL_OPTIONS
-            })
+            message = blocked_message(
+                pane_id,
+                agent_data.get("agent", ""),
+                agent_data.get("project", ""),
+                host,
+                content,
+            )
+            last_blocked_prompts[pane_id] = (
+                message["prompt_id"],
+                tuple(message["selected_options"]),
+                message["prompt"],
+            )
+            await broadcast(message)
 
         if update:
             known_panes.add(pane_id)
@@ -409,7 +699,6 @@ async def process_request(connection, request):
                 body = f.read()
             headers = Headers([("Content-Type", "image/svg+xml")])
             return Response(200, "OK", headers, body)
-
     # HTTP POST — parse event from URL query params as fallback
     import urllib.parse
     if "?" in (request.path or ""):
@@ -453,25 +742,82 @@ async def handle_client(ws):
     clients.add(ws)
     connected_at = time.monotonic()
     try:
+        await send_current_snapshot(ws)
         async for raw in ws:
             try:
                 msg = json.loads(raw)
             except json.JSONDecodeError:
                 continue
             msg_type = msg.get("type")
-            if msg_type == "respond":
+            if msg_type == "question_toggle":
+                pane_id = msg["pane_id"]
+                option = msg.get("option", "")
+                if pane_id not in known_panes or not option:
+                    await ws.send(json.dumps({"type": "error", "message": "invalid question option"}))
+                    continue
+                remote = pane_remote_map.get(pane_id)
+                if not prompt_matches(pane_id, msg.get("prompt_id", ""), remote=remote):
+                    await ws.send(json.dumps({"type": "error", "message": "question changed; refresh and try again"}))
+                    continue
+                if not toggle_question_option(pane_id, option, remote=remote):
+                    await ws.send(json.dumps({"type": "error", "message": "question option toggle failed"}))
+            elif msg_type == "question_submit":
                 pane_id = msg["pane_id"]
                 if pane_id not in known_panes:
                     await ws.send(json.dumps({"type": "error", "message": "unknown pane_id"}))
                     continue
-                text = msg.get("text", "")
-                if text.strip().lower() not in SAFE_RESPONSES:
-                    await ws.send(json.dumps({"type": "error", "message": "response not in allowlist"}))
+                remote = pane_remote_map.get(pane_id)
+                if not prompt_matches(pane_id, msg.get("prompt_id", ""), remote=remote):
+                    await ws.send(json.dumps({"type": "error", "message": "question changed; refresh and try again"}))
+                    continue
+                if not submit_multi_question(pane_id, remote=remote):
+                    await ws.send(json.dumps({"type": "error", "message": "question submission failed"}))
+            elif msg_type == "respond":
+                pane_id = msg["pane_id"]
+                request_id = msg.get("request_id")
+
+                def command_error(message):
+                    response = {"type": "error", "message": message}
+                    if request_id:
+                        response["request_id"] = request_id
+                    return response
+
+                if pane_id not in known_panes:
+                    await ws.send(json.dumps(command_error("unknown pane_id")))
+                    continue
+                text = msg.get("text", "").strip()
+                if not text or len(text) > 1000:
+                    await ws.send(json.dumps(command_error("response empty or too long")))
                     continue
                 remote = pane_remote_map.get(pane_id)
+                content = read_pane(pane_id, remote=remote)
+                if question_prompt_id(pane_id, content) != msg.get("prompt_id", ""):
+                    await ws.send(json.dumps(command_error("prompt changed; refresh and try again")))
+                    continue
+                is_omp = pane_is_omp(pane_id, remote=remote)
+                question = detect_question(content) if is_omp else None
                 log.info("Response from %s (%s): pane=%s text=%r", ip, device, pane_id, text)
+                if question:
+                    delivered = respond_to_question(pane_id, text, question, remote=remote)
+                elif (is_omp and custom_editor_active(content)) or text.lower() in SAFE_RESPONSES:
+                    delivered = _mutate_herdr(
+                        "pane", "send-text", pane_id, text, remote=remote
+                    ) and _mutate_herdr(
+                        "pane", "send-keys", pane_id, "Enter", remote=remote
+                    )
+                else:
+                    await ws.send(json.dumps(command_error(
+                        "free-text response requires a detected question"
+                    )))
+                    continue
+                if not delivered:
+                    await ws.send(json.dumps(command_error("response delivery failed")))
+                    continue
                 audit("respond", ip, device, pane_id, f"text={text!r}")
-                run_herdr("pane", "send-text", pane_id, text + "\n", remote=remote)
+                response = {"type": "command_result", "command": "respond", "ok": True}
+                if request_id:
+                    response["request_id"] = request_id
+                await ws.send(json.dumps(response))
             elif msg_type == "agent_event":
                 event_queue.put_nowait(msg)
             elif msg_type == "read_pane":
@@ -493,6 +839,11 @@ async def handle_client(ws):
                     await ws.send(json.dumps({"type": "error", "message": "keys contain disallowed values"}))
                     continue
                 remote = pane_remote_map.get(pane_id)
+                content = read_pane(pane_id, remote=remote)
+                if detect_approval_options(content) and any(key.isdigit() for key in keys):
+                    if question_prompt_id(pane_id, content) != msg.get("prompt_id", ""):
+                        await ws.send(json.dumps({"type": "error", "message": "prompt changed; refresh and try again"}))
+                        continue
                 log.info("Keys from %s (%s): pane=%s keys=%s", ip, device, pane_id, keys)
                 audit("send_keys", ip, device, pane_id, f"keys={keys}")
                 try:
@@ -505,7 +856,10 @@ async def handle_client(ws):
                     log.warning("send_keys command failed for pane %s with exit %s", pane_id, result.returncode)
                     await ws.send(json.dumps({"type": "error", "message": "send_keys command failed"}))
                     continue
-                await ws.send(json.dumps({"type": "command_result", "command": "send_keys", "ok": True}))
+                response = {"type": "command_result", "command": "send_keys", "ok": True}
+                if msg.get("request_id"):
+                    response["request_id"] = msg["request_id"]
+                await ws.send(json.dumps(response))
             elif msg_type == "send_text":
                 pane_id = msg["pane_id"]
                 if pane_id not in known_panes:

--- a/relay/herdr_telegram.py
+++ b/relay/herdr_telegram.py
@@ -43,6 +43,7 @@ if not TOKEN:
 # State
 pending: OrderedDict[tuple[int, int], str] = OrderedDict()  # (chat_id, message_id) -> pane_id
 approval_tokens: dict[str, str] = {}  # pane_id -> current blocked-notification generation
+blocked_prompt_ids: dict[str, str] = {}  # pane_id -> current relay prompt identity
 agents: list[dict] = []       # current agent list from relay
 prev_statuses: dict[str, str] = {}  # pane_id -> last known status
 relay_connected = False
@@ -50,6 +51,7 @@ daily_stats: dict[str, dict] = {}  # pane_id -> {agent, project, blocked_count, 
 
 AGENT_PAGE_SIZE = 20
 PENDING_LIMIT = 500
+COMMAND_ACK_TIMEOUT = 20
 STATUS_ORDER = {"blocked": 0, "working": 1, "done": 2, "idle": 3, "unknown": 3}
 STATUS_LABELS = {"blocked": "BLOCKED", "working": "WORKING", "done": "DONE", "idle": "IDLE", "unknown": "IDLE"}
 ACTION_CODES = {
@@ -65,31 +67,61 @@ CODE_ACTIONS = {code: action for action, code in ACTION_CODES.items()}
 
 # --- Relay communication ---
 
-async def send_to_relay(pane_id: str, text: str):
+async def await_command_result(ws, request_id: str, command: str):
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + COMMAND_ACK_TIMEOUT
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise RuntimeError(f"relay did not acknowledge {command}")
+        try:
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError(f"relay did not acknowledge {command}") from exc
+        response = json.loads(raw)
+        response_request_id = response.get("request_id")
+        if response.get("type") == "command_result" and response_request_id != request_id:
+            continue
+        if response_request_id not in (None, request_id):
+            continue
+        if response.get("type") == "error":
+            raise RuntimeError(response.get("message", f"relay rejected {command}"))
+        if response.get("type") == "command_result" and response.get("command") == command:
+            if not response.get("ok"):
+                raise RuntimeError(response.get("message", f"relay rejected {command}"))
+            return
+
+
+async def send_to_relay(pane_id: str, text: str, prompt_id: str | None = None):
     """Send a response to the relay via WebSocket."""
     import websockets
-    try:
-        async with websockets.connect(RELAY_WS) as ws:
-            await ws.send(json.dumps({"type": "respond", "pane_id": pane_id, "text": text}))
-    except Exception as e:
-        log.warning(f"Failed to send to relay: {scrub(e)}")
+    async with websockets.connect(RELAY_WS) as ws:
+        request_id = secrets.token_hex(8)
+        await ws.send(json.dumps({
+            "type": "respond",
+            "pane_id": pane_id,
+            "prompt_id": prompt_id if prompt_id is not None else blocked_prompt_ids.get(pane_id, ""),
+            "text": text,
+            "request_id": request_id,
+        }))
+        await await_command_result(ws, request_id, "respond")
 
 
-async def send_keys_to_relay(pane_id: str, keys: list[str]):
+async def send_keys_to_relay(pane_id: str, keys: list[str], prompt_id: str | None = None):
     """Send raw key presses to the relay via WebSocket (e.g. ["1"] to pick a prompt option)."""
     import websockets
     async with websockets.connect(RELAY_WS) as ws:
-        await ws.send(json.dumps({"type": "send_keys", "pane_id": pane_id, "keys": keys}))
-        for _ in range(5):
-            raw = await asyncio.wait_for(ws.recv(), timeout=5)
-            response = json.loads(raw)
-            if response.get("type") == "error":
-                raise RuntimeError(response.get("message", "relay rejected keys"))
-            if response.get("type") == "command_result" and response.get("command") == "send_keys":
-                if not response.get("ok"):
-                    raise RuntimeError(response.get("message", "relay rejected keys"))
-                return
-        raise RuntimeError("relay did not acknowledge keys")
+        request_id = secrets.token_hex(8)
+        message = {
+            "type": "send_keys",
+            "pane_id": pane_id,
+            "keys": keys,
+            "request_id": request_id,
+        }
+        if prompt_id is not None:
+            message["prompt_id"] = prompt_id
+        await ws.send(json.dumps(message))
+        await await_command_result(ws, request_id, "send_keys")
 
 
 async def read_pane(pane_id: str, lines: int = 15) -> str:
@@ -152,6 +184,7 @@ def clear_relay_connection_state():
     relay_connected = False
     agents = []
     approval_tokens.clear()
+    blocked_prompt_ids.clear()
 
 
 async def send_reply_prompt(message, chat, agent: dict, content: str | None = None):
@@ -437,10 +470,8 @@ async def cmd_interrupt(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(f"No agent matching '{query}'.")
         return
 
-    import websockets
     try:
-        async with websockets.connect(RELAY_WS) as ws:
-            await ws.send(json.dumps({"type": "send_keys", "pane_id": match["pane_id"], "keys": ["Ctrl+c"]}))
+        await send_keys_to_relay(match["pane_id"], ["C-c"])
         await update.message.reply_text(f"Sent Ctrl+C to {match['project']}")
     except Exception as e:
         await update.message.reply_text(f"Failed: {scrub(e)}")
@@ -523,8 +554,15 @@ async def cmd_trust(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(f"No blocked agent matching '{query}'.")
         return
 
-    await send_to_relay(match["pane_id"], "trust, always allow")
-    await update.message.reply_text(f"Trusted {match['project']} (always allow)")
+    try:
+        await send_to_relay(
+            match["pane_id"],
+            "trust, always allow",
+            prompt_id=blocked_prompt_ids.get(match["pane_id"]),
+        )
+        await update.message.reply_text(f"Trusted {match['project']} (always allow)")
+    except Exception as e:
+        await update.message.reply_text(f"Failed: {scrub(e)}")
 
 
 async def cmd_digest(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
@@ -595,10 +633,8 @@ async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return
 
     if action == "interrupt":
-        import websockets
         try:
-            async with websockets.connect(RELAY_WS) as ws:
-                await ws.send(json.dumps({"type": "send_keys", "pane_id": data["pane_id"], "keys": ["Ctrl+c"]}))
+            await send_keys_to_relay(data["pane_id"], ["C-c"])
             await query.message.reply_text("Sent Ctrl+C")
         except Exception as e:
             await query.message.reply_text(f"Failed: {scrub(e)}")
@@ -616,8 +652,15 @@ async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return
 
     if action == "trust":
-        await send_to_relay(data["pane_id"], "trust, always allow")
-        await query.message.reply_text(f"Trusted {selected_agent['project']} (always allow)")
+        try:
+            await send_to_relay(
+                data["pane_id"],
+                "trust, always allow",
+                prompt_id=blocked_prompt_ids.get(data["pane_id"]),
+            )
+            await query.message.reply_text(f"Trusted {selected_agent['project']} (always allow)")
+        except Exception as e:
+            await query.message.reply_text(f"Failed: {scrub(e)}")
         return
 
     if action != "approval":
@@ -629,6 +672,46 @@ async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         await query.message.reply_text(
             "That approval belongs to an older prompt. Use the controls on the latest blocked notification."
         )
+        return
+
+    prompt_id = blocked_prompt_ids.get(pane_id)
+    if not prompt_id:
+        await query.message.reply_text(
+            "That approval belongs to an older prompt. Use the controls on the latest blocked notification."
+        )
+        return
+
+    option_index = data.get("i")
+    if option_index is not None:
+        try:
+            option_index = int(option_index)
+        except (TypeError, ValueError):
+            await query.message.reply_text("That approval action is no longer supported. Use the latest notification.")
+            return
+        label = None
+        if query.message and query.message.reply_markup:
+            for row in query.message.reply_markup.inline_keyboard:
+                for btn in row:
+                    try:
+                        button_data = parse_callback_data(btn.callback_data)
+                    except (ValueError, TypeError, json.JSONDecodeError):
+                        continue
+                    if button_data.get("i") == str(option_index):
+                        label = btn.text
+                        break
+                if label is not None:
+                    break
+        if not label:
+            await query.message.reply_text("That approval action is no longer supported. Use the latest notification.")
+            return
+        try:
+            await send_to_relay(pane_id, label, prompt_id=prompt_id)
+        except Exception as e:
+            await query.message.reply_text(f"Failed: {scrub(e)}")
+            return
+        approval_tokens.pop(pane_id, None)
+        await query.edit_message_reply_markup(reply_markup=None)
+        await query.message.reply_text(f"Sent: {label}")
         return
 
     # Confirm a blocked agent's prompt by pressing the option number.
@@ -651,7 +734,7 @@ async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
                 except (ValueError, TypeError):
                     pass
     try:
-        await send_keys_to_relay(pane_id, [key])
+        await send_keys_to_relay(pane_id, [key], prompt_id=prompt_id)
     except Exception as e:
         await query.message.reply_text(f"Failed: {scrub(e)}")
         return
@@ -680,7 +763,11 @@ async def handle_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return
 
     try:
-        await send_text_to_relay(pane_id, update.message.text)
+        prompt_id = blocked_prompt_ids.get(pane_id)
+        if prompt_id:
+            await send_to_relay(pane_id, update.message.text, prompt_id=prompt_id)
+        else:
+            await send_text_to_relay(pane_id, update.message.text)
         await update.message.reply_text("Sent")
     except Exception as e:
         await update.message.reply_text(f"Failed: {scrub(e)}")
@@ -705,20 +792,34 @@ def make_keyboard(
     pane_id: str,
     options: list[str] | None,
     generation: str | None = None,
+    interaction: str | None = None,
 ) -> InlineKeyboardMarkup:
-    if options and "trust" in " ".join(options).lower():
+    if not options:
+        return interaction_keyboard(pane_id)
+    if interaction == "omp_question":
+        buttons = [(opt, opt) for opt in options]
+    elif "trust" in " ".join(options).lower():
         buttons = TOOL_BUTTONS
-    elif options and "approve all" in " ".join(options).lower():
+    elif "approve all" in " ".join(options).lower():
         buttons = SUBAGENT_BUTTONS
     else:
-        buttons = [(opt.split(",")[0], opt) for opt in (options or ["yes, single permission", "no (tab to edit)"])]
+        buttons = [(opt.split(",")[0], opt) for opt in options]
 
-    # Encode the option's 1-based position as "k"; the callback presses that number
-    # key on the agent's prompt. Sending the option *text* does not work (see handle_callback).
-    # callback_data must stay under Telegram's 64-byte limit, so keep it to the
-    # pane token and the option number; the confirmation label is recovered from the
-    # keyboard on press (see handle_callback).
     generation = generation or secrets.token_hex(4)
+    if interaction == "omp_question":
+        keyboard = [
+            [InlineKeyboardButton(label, callback_data=pane_callback_data(
+                "approval", pane_id, g=generation, i=str(i),
+            ))]
+            for i, (label, _resp) in enumerate(buttons)
+        ]
+        keyboard.append([InlineKeyboardButton(
+            "Open output & reply",
+            callback_data=pane_callback_data("select_reply", pane_id),
+        )])
+        return InlineKeyboardMarkup(keyboard)
+
+    # Standard approval prompts require a real numeric key press.
     keyboard = [
         [InlineKeyboardButton(label, callback_data=pane_callback_data(
             "approval", pane_id, g=generation, k=str(i + 1)))]
@@ -740,23 +841,47 @@ def interaction_keyboard(pane_id: str) -> InlineKeyboardMarkup:
     ]])
 
 
-async def notify_blocked(app: Application, pane_id: str, agent: str, project: str, prompt: str, options: list[str] | None):
+async def notify_blocked(
+    app: Application,
+    pane_id: str,
+    agent: str,
+    project: str,
+    prompt: str,
+    options: list[str] | None,
+    prompt_id: str | None = None,
+    interaction: str | None = None,
+    multi: bool = False,
+):
     if not CHAT_ID:
         return
+    instruction = (
+        "Use the web terminal or manual terminal controls to select multiple options."
+        if multi
+        else "Use an approval button, open the output, or reply to this notification."
+    )
     text = (
         f"*{agent}* blocked in `{project}`\n\n```\n{prompt[:400]}\n```\n\n"
-        "Use an approval button, open the output, or reply to this notification."
+        f"{instruction}"
     )
     generation = secrets.token_hex(4)
-    keyboard = make_keyboard(pane_id, options, generation=generation)
+    keyboard = make_keyboard(
+        pane_id,
+        [] if multi else options,
+        generation=generation,
+        interaction=interaction,
+    )
     msg = await app.bot.send_message(
         chat_id=int(CHAT_ID), text=text, parse_mode="Markdown", reply_markup=keyboard
     )
     approval_tokens[pane_id] = generation
+    if prompt_id:
+        blocked_prompt_ids[pane_id] = prompt_id
     register_pending(int(CHAT_ID), msg.message_id, pane_id)
 
 
 async def notify_blocked_safely(app: Application, msg: dict):
+    if msg.get("update"):
+        return
     try:
         await notify_blocked(
             app,
@@ -765,6 +890,9 @@ async def notify_blocked_safely(app: Application, msg: dict):
             project=msg.get("project", ""),
             prompt=msg.get("prompt", ""),
             options=msg.get("options"),
+            prompt_id=msg.get("prompt_id"),
+            interaction=msg.get("interaction"),
+            multi=bool(msg.get("multi")),
         )
     except Exception as e:
         log.warning("Failed to send blocked notification: %s", scrub(e))
@@ -801,6 +929,7 @@ async def track_agent_updates(app: Application, updated_agents: list[dict]):
             stats["last_change"] = now
         if agent_data.get("status") and new_status != "blocked":
             approval_tokens.pop(pane_id, None)
+            blocked_prompt_ids.pop(pane_id, None)
 
         if old_status and old_status != new_status and new_status in ("idle", "done") and old_status in ("working", "blocked"):
             try:
@@ -843,6 +972,7 @@ async def relay_listener(app: Application):
                         for pane_id in list(approval_tokens):
                             if pane_id not in blocked_panes:
                                 approval_tokens.pop(pane_id, None)
+                                blocked_prompt_ids.pop(pane_id, None)
                         await track_agent_updates(app, new_agents)
                         agents = apply_agent_message(agents, msg)
 

--- a/relay/herdr_tui.py
+++ b/relay/herdr_tui.py
@@ -49,10 +49,24 @@ class ApprovalPanel(Vertical):
     """Shows when an agent is blocked — prompt + buttons."""
 
     class Responded(Message):
-        def __init__(self, pane_id: str, text: str):
+        def __init__(self, pane_id: str, prompt_id: str | None, text: str):
             super().__init__()
             self.pane_id = pane_id
+            self.prompt_id = prompt_id
             self.text = text
+
+    class QuestionToggled(Message):
+        def __init__(self, pane_id: str, prompt_id: str, option: str):
+            super().__init__()
+            self.pane_id = pane_id
+            self.prompt_id = prompt_id
+            self.option = option
+
+    class QuestionSubmitted(Message):
+        def __init__(self, pane_id: str, prompt_id: str):
+            super().__init__()
+            self.pane_id = pane_id
+            self.prompt_id = prompt_id
 
     def __init__(self, agent: dict, **kw):
         super().__init__(**kw)
@@ -64,21 +78,40 @@ class ApprovalPanel(Vertical):
     def compose(self) -> ComposeResult:
         prompt = self.agent.get("prompt", "Waiting for input...")
         yield Static(prompt[:400], classes="prompt-text")
-        options = self.agent.get("options") or []
+        multi = self.agent.get("interaction") == "omp_question" and self.agent.get("multi")
+        options = self.agent.get("multi_options") if multi else self.agent.get("options")
+        options = options or []
+        selected = set(self.agent.get("selected_options") or [])
         for i, opt in enumerate(options):
             color = "green" if "yes" in opt or "approve" in opt else "red" if "no" in opt or "cancel" in opt else "blue"
-            yield Button(opt, id=f"opt-{i}", variant="success" if color == "green" else "error" if color == "red" else "primary")
+            label = f"{'☑' if opt in selected else '☐'} {opt}" if multi else opt
+            button_id = f"multi-{i}" if multi else f"opt-{i}"
+            yield Button(label, id=button_id, variant="success" if color == "green" else "error" if color == "red" else "primary")
+        if multi:
+            yield Button("Submit", id="multi-submit", variant="success")
         yield Input(placeholder="Custom response…", id="custom-input")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "multi-submit":
+            if prompt_id := self.agent.get("prompt_id"):
+                self.post_message(self.QuestionSubmitted(self.agent["pane_id"], prompt_id))
+            return
+        if event.button.id.startswith("multi-"):
+            idx = int(event.button.id.split("-")[1])
+            options = self.agent.get("multi_options") or []
+            if idx < len(options) and (prompt_id := self.agent.get("prompt_id")):
+                self.post_message(
+                    self.QuestionToggled(self.agent["pane_id"], prompt_id, options[idx])
+                )
+            return
         idx = int(event.button.id.split("-")[1])
         options = self.agent.get("options") or []
         if idx < len(options):
-            self.post_message(self.Responded(self.agent["pane_id"], options[idx]))
+            self.post_message(self.Responded(self.agent["pane_id"], self.agent.get("prompt_id"), options[idx]))
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if event.value.strip():
-            self.post_message(self.Responded(self.agent["pane_id"], event.value.strip()))
+            self.post_message(self.Responded(self.agent["pane_id"], self.agent.get("prompt_id"), event.value.strip()))
 
 
 class HerdrRemoteTUI(App):
@@ -179,11 +212,35 @@ class HerdrRemoteTUI(App):
             self.recompose()
 
     def on_approval_panel_responded(self, event: ApprovalPanel.Responded) -> None:
-        self._send_response(event.pane_id, event.text)
+        self._send_response(event.pane_id, event.prompt_id, event.text)
 
-    def _send_response(self, pane_id: str, text: str):
+    def on_approval_panel_question_toggled(self, event: ApprovalPanel.QuestionToggled) -> None:
         if self._ws:
-            msg = json.dumps({"type": "respond", "pane_id": pane_id, "text": text})
+            msg = json.dumps({
+                "type": "question_toggle",
+                "pane_id": event.pane_id,
+                "prompt_id": event.prompt_id,
+                "option": event.option,
+            })
+            asyncio.ensure_future(self._ws.send(msg))
+
+    def on_approval_panel_question_submitted(self, event: ApprovalPanel.QuestionSubmitted) -> None:
+        if self._ws:
+            msg = json.dumps({
+                "type": "question_submit",
+                "pane_id": event.pane_id,
+                "prompt_id": event.prompt_id,
+            })
+            asyncio.ensure_future(self._ws.send(msg))
+            self._blocked_data = [
+                blocked for blocked in self._blocked_data
+                if blocked.get("pane_id") != event.pane_id
+            ]
+            self.recompose()
+
+    def _send_response(self, pane_id: str, prompt_id: str | None, text: str):
+        if self._ws:
+            msg = json.dumps({"type": "respond", "pane_id": pane_id, "prompt_id": prompt_id, "text": text})
             asyncio.ensure_future(self._ws.send(msg))
             # Remove from blocked
             self._blocked_data = [b for b in self._blocked_data if b.get("pane_id") != pane_id]
@@ -195,8 +252,9 @@ class HerdrRemoteTUI(App):
     def action_approve_first(self) -> None:
         if self._blocked_data:
             a = self._blocked_data[0]
-            options = a.get("options") or ["yes, single permission"]
-            self._send_response(a["pane_id"], options[0])
+            options = a.get("options") or []
+            if options:
+                self._send_response(a["pane_id"], a.get("prompt_id"), options[0])
 
 
 if __name__ == "__main__":

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3,6 +3,15 @@
 PASS=0; FAIL=0
 DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+if command -v python3 >/dev/null 2>&1 && python3 -c "pass" >/dev/null 2>&1; then
+    PYTHON=python3
+elif command -v python >/dev/null 2>&1 && python -c "pass" >/dev/null 2>&1; then
+    PYTHON=python
+else
+    echo "Python 3 is required"
+    exit 1
+fi
+
 assert_eq() {
   if [ "$1" = "$2" ]; then PASS=$((PASS+1)); echo "  pass: $3"
   else FAIL=$((FAIL+1)); echo "  FAIL: $3 (expected '$2', got '$1')"; fi
@@ -14,8 +23,13 @@ echo ""
 # --- Relay ---
 echo "=== Relay ==="
 echo "1. relay syntax"
-python3 -c "import ast; ast.parse(open('$DIR/relay/herdr_relay.py').read())" 2>/dev/null
+"$PYTHON" -c "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))" "$DIR/relay/herdr_relay.py" 2>/dev/null
 assert_eq "$?" "0" "herdr_relay.py parses"
+
+echo "1b. relay behavior"
+uv run --with 'python-telegram-bot>=21.0' --with 'websockets>=14.0' \
+  python -m unittest discover -s "$DIR/tests" -p "test_*.py"
+assert_eq "$?" "0" "relay behavior"
 
 echo "2. PEP 723 metadata"
 grep -q "requires-python" "$DIR/relay/herdr_relay.py"
@@ -29,11 +43,11 @@ assert_eq "$?" "0" "start.sh +x"
 echo ""
 echo "=== Telegram bot ==="
 echo "4. telegram bot syntax"
-python3 -c "import ast; ast.parse(open('$DIR/relay/herdr_telegram.py').read())" 2>/dev/null
+"$PYTHON" -c "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))" "$DIR/relay/herdr_telegram.py" 2>/dev/null
 assert_eq "$?" "0" "herdr_telegram.py parses"
 
 echo "5. telegram demo bot syntax"
-python3 -c "import ast; ast.parse(open('$DIR/relay/herdr_telegram_demo.py').read())" 2>/dev/null
+"$PYTHON" -c "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))" "$DIR/relay/herdr_telegram_demo.py" 2>/dev/null
 assert_eq "$?" "0" "herdr_telegram_demo.py parses"
 
 echo "6. telegram bot has all commands"
@@ -46,56 +60,48 @@ echo "7. telegram bot env vars documented"
 grep -q "HERDR_TG_TOKEN" "$DIR/relay/herdr_telegram.py" && grep -q "HERDR_TG_CHAT_ID" "$DIR/relay/herdr_telegram.py"
 assert_eq "$?" "0" "env vars referenced"
 
-echo "8. telegram dashboard behavior"
-uv run "$DIR/tests/test_telegram.py"
-assert_eq "$?" "0" "telegram dashboard tests"
-
-echo "9. relay agent state behavior"
-python3 "$DIR/tests/test_agent_state.py"
-assert_eq "$?" "0" "agent state tests"
-
 # --- TUI ---
 echo ""
 echo "=== TUI ==="
-echo "10. TUI syntax"
-python3 -c "import ast; ast.parse(open('$DIR/relay/herdr_tui.py').read())" 2>/dev/null
+echo "8. TUI syntax"
+"$PYTHON" -c "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))" "$DIR/relay/herdr_tui.py" 2>/dev/null
 assert_eq "$?" "0" "herdr_tui.py parses"
 
 # --- Web app ---
 echo ""
 echo "=== Web app ==="
-echo "11. web app key elements"
+echo "9. web app key elements"
 WEB="$DIR/web/index.html"
 grep -q "WebSocket" "$WEB" && grep -q "theme" "$WEB" && grep -q "sendKey" "$WEB"
 assert_eq "$?" "0" "has WebSocket, themes, keyboard"
 
-echo "12. web app no hardcoded secrets"
+echo "10. web app no hardcoded secrets"
 ! grep -q "c4a2385e" "$WEB" && ! grep -q "graffold" "$WEB"
 assert_eq "$?" "0" "no secrets in web app"
 
 # --- macOS app ---
 echo ""
 echo "=== macOS app ==="
-echo "13. Swift sources parse"
+echo "11. Swift sources parse"
 if command -v swiftc >/dev/null 2>&1; then
-  swiftc -parse "$DIR/herdi-mac/Sources/Agent.swift" "$DIR/herdi-mac/Sources/RelayConnection.swift" 2>/dev/null
-  assert_eq "$?" "0" "core Swift parses"
+  swiftc -parse "$DIR/herdi-mac/Sources/"*.swift "$DIR/herdi-ios/Sources/"*.swift "$DIR/herdi-ios/Sources/Models/"*.swift "$DIR/herdi-ios/Sources/Services/"*.swift "$DIR/herdi-ios/Sources/Views/"*.swift 2>/dev/null
+  assert_eq "$?" "0" "Swift clients parse"
 else
   PASS=$((PASS+1)); echo "  skip: swiftc not available"
 fi
 
-echo "14. build.sh and dmg.sh present"
+echo "12. build.sh and dmg.sh present"
 [ -x "$DIR/herdi-mac/build.sh" ] && [ -f "$DIR/herdi-mac/dmg.sh" ]
 assert_eq "$?" "0" "build scripts present"
 
-echo "15. updater points to correct repo"
+echo "13. updater points to correct repo"
 grep -q "dcolinmorgan/herdr-remote" "$DIR/herdi-mac/Sources/Updater.swift"
 assert_eq "$?" "0" "updater repo correct"
 
 # --- Demo worker ---
 echo ""
 echo "=== Demo worker ==="
-echo "16. demo worker syntax"
+echo "14. demo worker syntax"
 if [ -f "$DIR/demo-worker/src/index.js" ]; then
   node --check "$DIR/demo-worker/src/index.js" 2>/dev/null
   assert_eq "$?" "0" "demo worker parses"
@@ -106,19 +112,19 @@ fi
 # --- Integration ---
 echo ""
 echo "=== Integration ==="
-echo "17. README links to herdr-demo.pages.dev"
+echo "15. README links to herdr-demo.pages.dev"
 grep -q "herdr-demo.pages.dev" "$DIR/README.md"
 assert_eq "$?" "0" "demo URL correct"
 
-echo "18. README links to herdr-push"
+echo "16. README links to herdr-push"
 grep -q "dcolinmorgan/herdr-push" "$DIR/README.md"
 assert_eq "$?" "0" "plugin link present"
 
-echo "19. installer service behavior"
+echo "17. installer service behavior"
 "$DIR/tests/install-service.sh"
 assert_eq "$?" "0" "installer handles Telegram service lifecycle"
 
-echo "20. LICENSE is AGPL"
+echo "18. LICENSE is AGPL"
 grep -q "GNU AFFERO GENERAL PUBLIC LICENSE" "$DIR/LICENSE"
 assert_eq "$?" "0" "AGPL license"
 

--- a/tests/test_client_payloads.py
+++ b/tests/test_client_payloads.py
@@ -1,0 +1,79 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ClientPayloadTests(unittest.TestCase):
+    def test_web_preserves_and_sends_omp_question_state(self):
+        source = (ROOT / "web" / "index.html").read_text(encoding="utf-8")
+
+        for field in (
+            "prompt_id",
+            "multi_options",
+            "selected_options",
+            "interaction",
+            "multi",
+        ):
+            self.assertIn(field, source)
+        self.assertIn("type:'question_toggle'", source)
+        self.assertIn("type:'question_submit'", source)
+        self.assertIn("prompt_id:a.prompt_id", source)
+
+    def test_swift_models_decode_omp_question_state(self):
+        for relative_path in (
+            "herdi-ios/Sources/Models/Agent.swift",
+            "herdi-mac/Sources/Agent.swift",
+        ):
+            source = (ROOT / relative_path).read_text(encoding="utf-8")
+            for field in (
+                "prompt_id",
+                "multi_options",
+                "selected_options",
+                "interaction",
+                "multi",
+            ):
+                self.assertIn(field, source)
+            self.assertIn('let type = "question_toggle"', source)
+            self.assertIn('let type = "question_submit"', source)
+
+    def test_native_clients_render_and_send_multi_selection_state(self):
+        ios = (ROOT / "herdi-ios" / "Sources" / "Views" / "ApprovalView.swift").read_text(
+            encoding="utf-8"
+        )
+        mac = (ROOT / "herdi-mac" / "Sources" / "NotchContentView.swift").read_text(
+            encoding="utf-8"
+        )
+
+        for source in (ios, mac):
+            self.assertIn("selectedOptions.contains(option)", source)
+            self.assertIn("toggleQuestionOption", source)
+            self.assertIn("submitQuestion", source)
+
+    def test_native_question_actions_are_connection_methods(self):
+        for relative_path in (
+            "herdi-ios/Sources/Services/RelayConnection.swift",
+            "herdi-mac/Sources/RelayConnection.swift",
+        ):
+            source = (ROOT / relative_path).read_text(encoding="utf-8")
+            for method in ("toggleQuestionOption", "submitQuestion"):
+                declaration = next(
+                    line for line in source.splitlines() if f"func {method}(" in line
+                )
+                self.assertTrue(
+                    declaration.startswith("    func "),
+                    f"{method} must be declared at RelayConnection class scope",
+                )
+
+    def test_tui_sends_multi_selection_messages_with_prompt_identity(self):
+        source = (ROOT / "relay" / "herdr_tui.py").read_text(encoding="utf-8")
+
+        self.assertIn('"type": "question_toggle"', source)
+        self.assertIn('"type": "question_submit"', source)
+        self.assertIn('"prompt_id": event.prompt_id', source)
+        self.assertIn("selected_options", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -1,0 +1,427 @@
+import asyncio
+import importlib.util
+import json
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+import types
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from unittest import mock
+import uuid
+
+
+RELAY_PATH = Path(__file__).resolve().parents[1] / "relay" / "herdr_relay.py"
+
+
+class _ConnectionClosed(Exception):
+    pass
+
+
+def _websockets_stubs():
+    websockets = types.ModuleType("websockets")
+    websockets.__path__ = []
+    websockets_asyncio = types.ModuleType("websockets.asyncio")
+    websockets_asyncio.__path__ = []
+    websockets_server = types.ModuleType("websockets.asyncio.server")
+    websockets_server.serve = object()
+    exceptions = types.ModuleType("websockets.exceptions")
+    exceptions.ConnectionClosedError = _ConnectionClosed
+    exceptions.ConnectionClosedOK = _ConnectionClosed
+    return {
+        "websockets": websockets,
+        "websockets.asyncio": websockets_asyncio,
+        "websockets.asyncio.server": websockets_server,
+        "websockets.exceptions": exceptions,
+    }
+
+
+@contextmanager
+def loaded_relay(*, herdr_bin=None):
+    module_name = f"herdr_relay_test_{uuid.uuid4().hex}"
+    logger = logging.getLogger("herdr-relay")
+    original_handlers = tuple(logger.handlers)
+    original_level = logger.level
+    original_disabled = logger.disabled
+    websockets_logger = logging.getLogger("websockets")
+    original_websockets_level = websockets_logger.level
+
+    with tempfile.TemporaryDirectory() as log_dir:
+        environment = {"HERDR_LOG_DIR": log_dir}
+        if herdr_bin is not None:
+            environment["HERDR_BIN"] = herdr_bin
+
+        with mock.patch.dict(os.environ, environment, clear=False), mock.patch.dict(
+            sys.modules, _websockets_stubs(), clear=False
+        ), mock.patch.object(sys, "path", [str(RELAY_PATH.parent), *sys.path]):
+            if herdr_bin is None:
+                os.environ.pop("HERDR_BIN", None)
+
+            spec = importlib.util.spec_from_file_location(module_name, RELAY_PATH)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            try:
+                spec.loader.exec_module(module)
+                logger.disabled = True
+                yield module
+            finally:
+                sys.modules.pop(module_name, None)
+                for handler in tuple(logger.handlers):
+                    if handler not in original_handlers:
+                        logger.removeHandler(handler)
+                        handler.close()
+                audit_logger = logging.getLogger("herdr-audit")
+                for handler in tuple(audit_logger.handlers):
+                    audit_logger.removeHandler(handler)
+                    handler.close()
+                logger.setLevel(original_level)
+                logger.disabled = original_disabled
+                websockets_logger.setLevel(original_websockets_level)
+
+
+class _FakeWebSocket:
+    def __init__(self, messages):
+        self.remote_address = ("127.0.0.1", 12345)
+        self.request = types.SimpleNamespace(
+            headers={"User-Agent": "Python unittest", "Origin": ""}
+        )
+        self._messages = iter(messages)
+        self.sent = []
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._messages)
+        except StopIteration:
+            raise StopAsyncIteration
+
+    async def send(self, message):
+        self.sent.append(message)
+
+
+class RelayQuestionTests(unittest.TestCase):
+    ASK_SCREEN = """
+╭─ Ask ─╮
+│ Which color? │
+│   Red │
+│    Blue │
+│    Green │
+│    Other (type your own) │
+│ Enter select · ↑/↓ move · Esc cancel │
+╰───────╯
+"""
+    MULTI_SCREEN = """
+╭─ Ask ─╮
+│ Which capabilities? │
+│   Color output │
+│    Nerd Font │
+│    Mobile layout │
+│    Other (type your own) │
+╰───────╯
+"""
+
+    MULTI_SELECTED_SCREEN = """
+╭─ Ask ─╮
+│ capabilities    Submit │
+│ Which capabilities? │
+│    Color output │
+│   Nerd Font │
+│    Mobile layout │
+│    Other (type your own) │
+╰───────╯
+"""
+
+
+    def test_detects_live_omp_question_options_and_cursor(self):
+        with loaded_relay() as relay:
+            question = relay.detect_question(self.ASK_SCREEN)
+
+            self.assertIsNotNone(question)
+            self.assertEqual(
+                [option["label"] for option in question["options"]],
+                ["Red", "Blue", "Green", relay.QUESTION_OTHER],
+            )
+            self.assertEqual(question["selected_index"], 0)
+            self.assertEqual(relay.detect_options(self.ASK_SCREEN), ["Red", "Blue", "Green"])
+
+    def test_prompt_identity_includes_question_text(self):
+        first_prompt = self.ASK_SCREEN.replace("Which color?", "Which environment?")
+        second_prompt = self.ASK_SCREEN.replace("Which color?", "Delete all data?")
+
+        with loaded_relay() as relay:
+            self.assertNotEqual(
+                relay.question_prompt_id("pane-1", first_prompt),
+                relay.question_prompt_id("pane-1", second_prompt),
+            )
+
+    def test_long_questions_with_identical_options_have_distinct_identity(self):
+        first_prompt = "Which deployment target should receive this very long request?\n" + "\n".join(
+            f"detail line {index}" for index in range(35)
+        ) + "\n  staging\n   production\n   Other (type your own)"
+        second_prompt = first_prompt.replace(
+            "Which deployment target should receive this very long request?",
+            "Which database should receive this very long request?",
+        )
+
+        with loaded_relay() as relay:
+            self.assertNotEqual(
+                relay.question_prompt_id("pane-1", first_prompt),
+                relay.question_prompt_id("pane-1", second_prompt),
+            )
+
+    def test_long_option_lists_keep_question_text_in_identity(self):
+        options = "\n".join(
+            [f"   option {index}" for index in range(120)]
+            + ["   Other (type your own)"]
+        )
+        first_prompt = f"Which environment?\n{options}"
+        second_prompt = f"Which database?\n{options}"
+
+        with loaded_relay() as relay:
+            self.assertNotEqual(
+                relay.question_prompt_id("pane-1", first_prompt),
+                relay.question_prompt_id("pane-1", second_prompt),
+            )
+
+    def test_read_pane_preserves_long_question_for_prompt_identity(self):
+        def pane_output(question):
+            return "\n".join([
+                question,
+                *(f"detail line {index}" for index in range(35)),
+                "  staging",
+                "   production",
+                "   Other (type your own)",
+            ])
+
+        with loaded_relay() as relay:
+            with mock.patch.object(
+                relay,
+                "run_herdr",
+                side_effect=[
+                    pane_output("Which deployment target should receive this request?"),
+                    pane_output("Which database should receive this request?"),
+                ],
+            ):
+                first = relay.read_pane("pane-1")
+                second = relay.read_pane("pane-1")
+
+            self.assertNotEqual(
+                relay.question_prompt_id("pane-1", first),
+                relay.question_prompt_id("pane-1", second),
+            )
+
+    def test_prompt_identity_ignores_multi_selection_state(self):
+        with loaded_relay() as relay:
+            self.assertEqual(
+                relay.question_prompt_id("pane-1", self.MULTI_SCREEN),
+                relay.question_prompt_id("pane-1", self.MULTI_SELECTED_SCREEN),
+            )
+
+    def test_unknown_blocked_prompt_has_no_approval_fallback(self):
+        with loaded_relay() as relay:
+            message = relay.blocked_message("pane-1", "omp", "project", "local", "What name?")
+
+            self.assertEqual(message["options"], [])
+            self.assertEqual(message["interaction"], "prompt")
+
+    def test_question_choice_moves_from_live_cursor_before_enter(self):
+        with loaded_relay() as relay:
+            question = relay.detect_question(self.ASK_SCREEN)
+            with mock.patch.object(relay, "_mutate_herdr", return_value=True) as mutate:
+                delivered = relay.respond_to_question(
+                    "pane-1", "Blue", question, remote="agent-host"
+                )
+
+            self.assertTrue(delivered)
+            mutate.assert_called_once_with(
+                "pane", "send-keys", "pane-1", "Down", "Enter", remote="agent-host"
+            )
+
+    def test_custom_question_answer_waits_for_editor_then_submits(self):
+        with loaded_relay() as relay:
+            question = relay.detect_question(self.ASK_SCREEN)
+            with mock.patch.object(
+                relay,
+                "read_pane",
+                return_value="Custom answer: Which color?\n>\nenter or ctrl+q submit",
+            ), mock.patch.object(relay, "_mutate_herdr", return_value=True) as mutate:
+                delivered = relay.respond_to_question(
+                    "pane-1", "Purple", question, remote=None
+                )
+
+            self.assertTrue(delivered)
+            self.assertEqual(
+                mutate.call_args_list,
+                [
+                    mock.call("pane", "send-keys", "pane-1", "Down", "Down", "Down", "Enter", remote=None),
+                    mock.call("pane", "send-text", "pane-1", "Purple", remote=None),
+                    mock.call("pane", "send-keys", "pane-1", "Enter", remote=None),
+                ],
+            )
+
+
+
+    def test_multi_question_toggle_and_done_submission_use_live_cursor(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(relay, "pane_is_omp", return_value=True), \
+                 mock.patch.object(
+                     relay,
+                     "read_pane",
+                     side_effect=[self.MULTI_SCREEN, self.MULTI_SELECTED_SCREEN],
+                 ), mock.patch.object(relay, "_mutate_herdr", return_value=True) as mutate:
+                toggled = relay.toggle_question_option("pane-1", "Nerd Font")
+                submitted = relay.submit_multi_question("pane-1")
+
+            self.assertTrue(toggled)
+            self.assertTrue(submitted)
+            self.assertEqual(
+                mutate.call_args_list,
+                [
+                    mock.call("pane", "send-keys", "pane-1", "Down", remote=None),
+                    mock.call("pane", "send-keys", "pane-1", "Enter", remote=None),
+                    mock.call("pane", "send-keys", "pane-1", "Tab", "Enter", remote=None),
+                ],
+            )
+
+    def test_non_omp_checkbox_prompt_never_uses_question_navigation(self):
+        with loaded_relay() as relay:
+            message = relay.blocked_message("pane-1", "claude", "project", "local", self.MULTI_SCREEN)
+
+            self.assertEqual(message["interaction"], "prompt")
+            self.assertEqual(message["options"], [])
+
+    def test_arbitrary_response_is_rejected_for_non_question_prompt(self):
+        with loaded_relay() as relay:
+            pane_id = "pane-1"
+            content = "Approve this tool?"
+            relay.known_panes.add(pane_id)
+            ws = _FakeWebSocket([
+                json.dumps({
+                    "type": "respond",
+                    "pane_id": pane_id,
+                    "prompt_id": relay.question_prompt_id(pane_id, content),
+                    "text": "run arbitrary command",
+                })
+            ])
+            with mock.patch.object(relay, "send_current_snapshot", new=mock.AsyncMock()), \
+                 mock.patch.object(relay, "read_pane", return_value=content), \
+                 mock.patch.object(relay, "_mutate_herdr") as mutate:
+                asyncio.run(relay.handle_client(ws))
+
+            mutate.assert_not_called()
+            self.assertIn("detected question", json.loads(ws.sent[-1])["message"])
+
+    def test_non_omp_custom_editor_text_is_rejected(self):
+        with loaded_relay() as relay:
+            pane_id = "pane-1"
+            content = "Custom answer: prompt\nenter or ctrl+q submit"
+            relay.known_panes.add(pane_id)
+            ws = _FakeWebSocket([
+                json.dumps({
+                    "type": "respond",
+                    "pane_id": pane_id,
+                    "prompt_id": relay.question_prompt_id(pane_id, content),
+                    "text": "arbitrary",
+                })
+            ])
+            with mock.patch.object(relay, "send_current_snapshot", new=mock.AsyncMock()), \
+                 mock.patch.object(
+                     relay,
+                     "read_pane",
+                     return_value=content,
+                 ), mock.patch.object(relay, "pane_is_omp", return_value=False), \
+                 mock.patch.object(relay, "_mutate_herdr") as mutate:
+                asyncio.run(relay.handle_client(ws))
+
+            mutate.assert_not_called()
+            self.assertIn("detected question", json.loads(ws.sent[-1])["message"])
+
+
+    def test_stale_question_response_is_rejected_before_input(self):
+        with loaded_relay() as relay:
+            pane_id = "pane-1"
+            relay.known_panes.add(pane_id)
+            current_prompt_id = relay.question_prompt_id(pane_id, self.ASK_SCREEN)
+            ws = _FakeWebSocket([
+                json.dumps({
+                    "type": "respond",
+                    "pane_id": pane_id,
+                    "prompt_id": "stale-prompt",
+                    "text": "Blue",
+                })
+            ])
+            with mock.patch.object(relay, "send_current_snapshot", new=mock.AsyncMock()), \
+                 mock.patch.object(relay, "read_pane", return_value=self.ASK_SCREEN), \
+                 mock.patch.object(relay, "pane_is_omp", return_value=True), \
+                 mock.patch.object(relay, "_mutate_herdr") as mutate:
+                asyncio.run(relay.handle_client(ws))
+
+            self.assertNotEqual(current_prompt_id, "stale-prompt")
+            mutate.assert_not_called()
+            self.assertIn("prompt changed", json.loads(ws.sent[-1])["message"])
+
+    def test_stale_standard_approval_is_rejected_before_input(self):
+        with loaded_relay() as relay:
+            pane_id = "pane-1"
+            old_content = "Run read-only status command?\nyes, single permission"
+            current_content = "Delete production data?\nyes, single permission"
+            relay.known_panes.add(pane_id)
+            ws = _FakeWebSocket([
+                json.dumps({
+                    "type": "respond",
+                    "pane_id": pane_id,
+                    "prompt_id": relay.question_prompt_id(pane_id, old_content),
+                    "text": "yes, single permission",
+                })
+            ])
+
+            with mock.patch.object(relay, "send_current_snapshot", new=mock.AsyncMock()), \
+                 mock.patch.object(relay, "read_pane", return_value=current_content), \
+                 mock.patch.object(relay, "_mutate_herdr") as mutate:
+                asyncio.run(relay.handle_client(ws))
+
+            mutate.assert_not_called()
+            self.assertIn("prompt changed", json.loads(ws.sent[-1])["message"])
+
+    def test_respond_sends_correlated_acknowledgement(self):
+        with loaded_relay() as relay:
+            pane_id = "pane-1"
+            content = "yes, single permission"
+            relay.known_panes.add(pane_id)
+            ws = _FakeWebSocket([
+                json.dumps({
+                    "type": "respond",
+                    "pane_id": pane_id,
+                    "prompt_id": relay.question_prompt_id(pane_id, content),
+                    "text": "yes",
+                    "request_id": "request-123",
+                })
+            ])
+
+            with mock.patch.object(relay, "send_current_snapshot", new=mock.AsyncMock()), \
+                 mock.patch.object(relay, "read_pane", return_value=content), \
+                 mock.patch.object(relay, "pane_is_omp", return_value=False), \
+                 mock.patch.object(relay, "_mutate_herdr", return_value=True):
+                asyncio.run(relay.handle_client(ws))
+
+            self.assertEqual(
+                json.loads(ws.sent[-1]),
+                {
+                    "type": "command_result",
+                    "command": "respond",
+                    "ok": True,
+                    "request_id": "request-123",
+                },
+            )
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_herdr_telegram.py
+++ b/tests/test_herdr_telegram.py
@@ -1,0 +1,96 @@
+import asyncio
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest import mock
+import uuid
+
+
+TELEGRAM_PATH = Path(__file__).resolve().parents[1] / "relay" / "herdr_telegram.py"
+
+
+def _telegram_stubs():
+    telegram = types.ModuleType("telegram")
+
+    class InlineKeyboardButton:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    class InlineKeyboardMarkup:
+        def __init__(self, inline_keyboard):
+            self.inline_keyboard = inline_keyboard
+
+    class ForceReply:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    telegram.Update = object
+    telegram.ForceReply = ForceReply
+    telegram.InlineKeyboardButton = InlineKeyboardButton
+    telegram.InlineKeyboardMarkup = InlineKeyboardMarkup
+
+    ext = types.ModuleType("telegram.ext")
+    ext.Application = object
+    ext.CallbackQueryHandler = object
+    ext.CommandHandler = object
+    ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object)
+    ext.MessageHandler = object
+    ext.filters = types.SimpleNamespace()
+    return {"telegram": telegram, "telegram.ext": ext}
+
+
+def loaded_telegram():
+    module_name = f"herdr_telegram_test_{uuid.uuid4().hex}"
+    with mock.patch.dict(os.environ, {"HERDR_TG_TOKEN": "test"}, clear=False), mock.patch.dict(
+        sys.modules, _telegram_stubs(), clear=False
+    ), mock.patch.object(sys, "path", [str(TELEGRAM_PATH.parent), *sys.path]):
+        spec = importlib.util.spec_from_file_location(module_name, TELEGRAM_PATH)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+
+
+class _Bot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, **kwargs):
+        self.sent.append(kwargs)
+        return types.SimpleNamespace(message_id=42)
+
+
+class TelegramQuestionTests(unittest.TestCase):
+    def test_multi_select_notification_only_offers_safe_output_link(self):
+        telegram = loaded_telegram()
+        telegram.CHAT_ID = "1"
+        bot = _Bot()
+        app = types.SimpleNamespace(bot=bot)
+
+        asyncio.run(
+            telegram.notify_blocked(
+                app,
+                pane_id="pane-1",
+                agent="omp",
+                project="demo",
+                prompt="Which capabilities?",
+                options=["Color", "Font"],
+                multi=True,
+            )
+        )
+
+        markup = bot.sent[0]["reply_markup"]
+        self.assertEqual(
+            [button.text for row in markup.inline_keyboard for button in row],
+            ["Open output & reply"],
+        )
+        self.assertIn("web terminal or manual terminal controls", bot.sent[0]["text"])
+        self.assertEqual(telegram.pending[(1, 42)], "pane-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -116,6 +116,7 @@ def make_active_approval_keyboard(pane_id, options):
     markup = tg.make_keyboard(pane_id, options)
     generation = json.loads(markup.inline_keyboard[0][0].callback_data)["g"]
     tg.approval_tokens[pane_id] = generation
+    tg.blocked_prompt_ids[pane_id] = "prompt-123"
     return markup
 
 
@@ -127,6 +128,7 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
         tg.relay_connected = False
         tg.pending.clear()
         tg.approval_tokens.clear()
+        tg.blocked_prompt_ids.clear()
         tg.prev_statuses.clear()
         tg.daily_stats.clear()
 
@@ -410,7 +412,7 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
         with patch.object(tg, "send_keys_to_relay", AsyncMock()) as send_keys:
             await tg.handle_callback(make_update(callback=callback), SimpleNamespace())
 
-        send_keys.assert_awaited_once_with("w0:p1", ["1"])
+        send_keys.assert_awaited_once_with("w0:p1", ["1"], prompt_id="prompt-123")
         self.assertEqual(callback.edit_calls, 1)
         self.assertIn("Sent: yes", callback.message.replies[0][0])
         self.assertNotIn("w0:p1", tg.approval_tokens)
@@ -446,11 +448,18 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
     async def test_send_keys_requires_positive_relay_acknowledgement(self):
         accepted = FakeRelayConnection([
             {"type": "agents", "agents": []},
-            {"type": "command_result", "command": "send_keys", "ok": True},
+            {"type": "command_result", "command": "send_keys", "ok": True, "request_id": "request-123"},
         ])
-        with patch("websockets.connect", return_value=accepted):
+        with patch("websockets.connect", return_value=accepted), patch.object(
+            tg.secrets, "token_hex", return_value="request-123"
+        ):
             await tg.send_keys_to_relay("w0:p1", ["1"])
-        self.assertEqual(accepted.sent, [{"type": "send_keys", "pane_id": "w0:p1", "keys": ["1"]}])
+        self.assertEqual(accepted.sent, [{
+            "type": "send_keys",
+            "pane_id": "w0:p1",
+            "keys": ["1"],
+            "request_id": "request-123",
+        }])
 
         rejected = FakeRelayConnection([{"type": "error", "message": "keys contain disallowed values"}])
         with patch("websockets.connect", return_value=rejected):
@@ -459,7 +468,7 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
 
     def test_relay_allows_numeric_approval_keys_and_acknowledges_them(self):
         relay_path = ROOT / "relay" / "herdr_relay.py"
-        source = relay_path.read_text()
+        source = relay_path.read_text(encoding="utf-8")
         tree = ast.parse(source)
         safe_keys = next(
             node.value
@@ -469,19 +478,46 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
         )
         values = eval(compile(ast.Expression(safe_keys), str(relay_path), "eval"), {"range": range})
         self.assertTrue({"1", "2", "3"}.issubset(values))
-        self.assertIn('"command": "send_keys", "ok": True', source)
+        self.assertIn('"command": "send_keys"', source)
+        self.assertIn('"ok": True', source)
         self.assertIn("if result.returncode != 0:", source)
+
+    async def test_omp_choice_uses_question_response_with_label_and_prompt_id(self):
+        tg.relay_connected = True
+        tg.agents = make_agents(1, status="blocked")
+        tg.agents[0]["agent"] = "omp"
+        tg.blocked_prompt_ids["w0:p1"] = "prompt-123"
+        markup = tg.make_keyboard(
+            "w0:p1",
+            ["Red", "Blue"],
+            generation="generation",
+            interaction="omp_question",
+        )
+        tg.approval_tokens["w0:p1"] = "generation"
+        callback = FakeCallback(markup.inline_keyboard[1][0].callback_data)
+        callback.message.reply_markup = markup
+
+        with (
+            patch.object(tg, "send_to_relay", AsyncMock()) as send_to_relay,
+            patch.object(tg, "send_keys_to_relay", AsyncMock()) as send_keys,
+        ):
+            await tg.handle_callback(make_update(callback=callback), SimpleNamespace())
+
+        send_to_relay.assert_awaited_once_with("w0:p1", "Blue", prompt_id="prompt-123")
+        send_keys.assert_not_awaited()
 
     def test_relay_disconnect_clears_approval_generations(self):
         tg.relay_connected = True
         tg.agents = make_agents(1, status="blocked")
         tg.approval_tokens["w0:p1"] = "generation"
+        tg.blocked_prompt_ids["w0:p1"] = "prompt"
 
         tg.clear_relay_connection_state()
 
         self.assertFalse(tg.relay_connected)
         self.assertEqual(tg.agents, [])
         self.assertEqual(tg.approval_tokens, {})
+        self.assertEqual(tg.blocked_prompt_ids, {})
 
     async def test_failed_blocked_notification_preserves_previous_generation(self):
         tg.approval_tokens["w0:p1"] = "previous"
@@ -614,6 +650,26 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
 
         send_text.assert_awaited_once_with("w0:p1", "follow up")
         self.assertEqual(message.replies[0][0], "Sent")
+
+    async def test_blocked_notification_reply_uses_prompt_response(self):
+        tg.relay_connected = True
+        tg.agents = make_agents(1, status="blocked")
+        tg.blocked_prompt_ids["w0:p1"] = "prompt-123"
+        tg.register_pending(42, 77, "w0:p1")
+        message = FakeMessage()
+        message.reply_to_message = SimpleNamespace(message_id=77)
+        message.text = "custom answer"
+
+        with (
+            patch.object(tg, "send_to_relay", AsyncMock()) as send_response,
+            patch.object(tg, "send_text_to_relay", AsyncMock()) as send_text,
+        ):
+            await tg.handle_text(make_update(message=message), SimpleNamespace())
+
+        send_response.assert_awaited_once_with(
+            "w0:p1", "custom answer", prompt_id="prompt-123"
+        )
+        send_text.assert_not_awaited()
 
     async def test_mapped_reply_rejects_disconnected_and_stale_panes(self):
         tg.register_pending(42, 77, "w0:p1")

--- a/web/index.html
+++ b/web/index.html
@@ -385,7 +385,22 @@ function handleMessage(msg) {
       }
       prevStatuses[a.pane_id] = a.status;
     }
-    agents = msg.agents; render();
+    const previousAgents = new Map(agents.map(agent => [agent.pane_id, agent]));
+    agents = msg.agents.map(agent => {
+      const previous = previousAgents.get(agent.pane_id);
+      if (agent.status !== 'blocked' || !previous) return agent;
+      return {
+        ...agent,
+        prompt: previous.prompt,
+        options: previous.options,
+        multi_options: previous.multi_options,
+        interaction: previous.interaction,
+        multi: previous.multi,
+        prompt_id: previous.prompt_id,
+        selected_options: previous.selected_options,
+      };
+    });
+    render();
   }
   else if (msg.type === 'agent_update') {
     const update = msg.agent;
@@ -403,12 +418,24 @@ function handleMessage(msg) {
   }
   else if (msg.type === 'blocked') {
     const a = agents.find(x => x.pane_id === msg.pane_id);
-    if (a) { a.status='blocked'; a.prompt=msg.prompt; a.options=msg.options; }
+    if (a) {
+      a.status='blocked';
+      a.prompt=msg.prompt;
+      a.prompt_id=msg.prompt_id;
+      a.options=msg.options;
+      a.selected_options=msg.selected_options||[];
+      a.multi_options=msg.multi_options||[];
+      a.interaction=msg.interaction;
+      a.multi=msg.multi;
+    }
     else agents.push({...msg, status:'blocked'});
     if(window.cue) cue('chime');
-    timeline.unshift({project: msg.project, agent: msg.agent, status: 'blocked', time: new Date()});
-    if (timeline.length > 100) timeline.pop();
+    if (!msg.update) {
+      timeline.unshift({project: msg.project, agent: msg.agent, status: 'blocked', time: new Date()});
+      if (timeline.length > 100) timeline.pop();
+    }
     render();
+    if (msg.pane_id===activePane) openTerminal(activePane);
   } else if (msg.type === 'pane_content' && msg.pane_id === activePane) {
     const el = document.getElementById('termContent');
     const prevHeight = el.scrollHeight;
@@ -533,21 +560,54 @@ function openTerminal(paneId) {
   const a = agents.find(x => x.pane_id===paneId);
   document.getElementById('termTitle').textContent = a?`${a.label||a.project} · ${a.agent}`:paneId;
   document.getElementById('agentListView').style.display = 'none';
+  if (refreshInterval) clearInterval(refreshInterval);
   document.getElementById('terminalView').classList.add('active');
   const qa = document.getElementById('quickActions');
   const ak = document.getElementById('actionKeys');
+  qa.replaceChildren();
+  ak.replaceChildren();
   if (a&&a.status==='blocked') {
-    const opts = a.options||['yes, single permission','trust, always allow','no (tab to edit)'];
-    qa.innerHTML = opts.map(o => {
-      const cls = o.includes('yes')||o.includes('approve')?'btn-yes':o.includes('trust')?'btn-trust':'btn-no';
-      const icon = o.includes('yes') ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>' : o.includes('trust') ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>' : '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
-      const label = o.includes('yes') ? 'Yes' : o.includes('trust') ? 'Yes All' : 'No';
-      return `<button class="${cls}" onclick="respond('${o.replace(/'/g,"\\'")}')">${icon} ${label}</button>`;
-    }).join('');
-    ak.innerHTML = '';
-  } else {
-    qa.innerHTML='';
-    ak.innerHTML='';
+    const opts = a.interaction==='omp_question'&&a.multi
+      ? (Array.isArray(a.multi_options)?a.multi_options:[])
+      : (Array.isArray(a.options)?a.options:[]);
+    for (const option of opts) {
+      const button = document.createElement('button');
+      const lower = option.toLowerCase();
+      button.className = lower.includes('yes')||lower.includes('approve')?'btn-yes':lower.includes('trust')?'btn-trust':'btn-no';
+      button.textContent = option.split(',')[0];
+      if (a.interaction==='omp_question'&&a.multi) {
+        button.dataset.selected=String((a.selected_options||[]).includes(option));
+        button.classList.toggle('selected',button.dataset.selected==='true');
+        button.addEventListener('click',()=>{
+          const selected=button.dataset.selected!=='true';
+          button.dataset.selected=String(selected);
+          button.classList.toggle('selected',selected);
+          ws.send(JSON.stringify({type:'question_toggle',pane_id:activePane,prompt_id:a.prompt_id,option}));
+        });
+      } else {
+        button.addEventListener('click',()=>respond(option));
+      }
+      qa.appendChild(button);
+    }
+    if (a.interaction==='omp_question'&&a.multi) {
+      const submit=document.createElement('button');
+      submit.className='btn-yes';
+      submit.textContent='Submit';
+      submit.addEventListener('click',()=>ws.send(JSON.stringify({type:'question_submit',pane_id:activePane,prompt_id:a.prompt_id})));
+      qa.appendChild(submit);
+    } else if (a.interaction!=='omp_question'&&opts.includes('yes, single permission')) {
+      for (const [label,cls,response] of [
+        ['y','key-green','yes, single permission'],
+        ['a','key-blue','trust, always allow'],
+        ['n','key-red','no (tab to edit)'],
+      ]) {
+        const button = document.createElement('button');
+        button.className = cls;
+        button.textContent = label;
+        button.addEventListener('click',()=>respond(response));
+        ak.appendChild(button);
+      }
+    }
   }
   refreshPane();
   refreshInterval = setInterval(refreshPane, 3000);
@@ -560,13 +620,18 @@ function closeTerminal() {
 }
 
 let paneLines = 200;
-function refreshPane() { if(ws&&activePane) ws.send(JSON.stringify({type:'read_pane',pane_id:activePane,lines:paneLines})); }
+function refreshPane() { if(ws&&ws.readyState===WebSocket.OPEN&&activePane) ws.send(JSON.stringify({type:'read_pane',pane_id:activePane,lines:paneLines})); }
 function loadMore() { paneLines = Math.min(paneLines + 500, 5000); refreshPane(); }
 function sendText() {
   const i=document.getElementById('termInput');
   if(!i.value||!ws||!activePane)return;
-  ws.send(JSON.stringify({type:'send_text',pane_id:activePane,text:i.value}));
-  ws.send(JSON.stringify({type:'send_keys',pane_id:activePane,keys:['Enter']}));
+  const agent=agents.find(a=>a.pane_id===activePane);
+  if(agent&&agent.status==='blocked') {
+    ws.send(JSON.stringify({type:'respond',pane_id:activePane,prompt_id:agent.prompt_id,text:i.value}));
+  } else {
+    ws.send(JSON.stringify({type:'send_text',pane_id:activePane,text:i.value}));
+    ws.send(JSON.stringify({type:'send_keys',pane_id:activePane,keys:['Enter']}));
+  }
   i.value=''; setTimeout(refreshPane,500);
 }
 function sendKey(k){if(!ws||!activePane)return;ws.send(JSON.stringify({type:'send_keys',pane_id:activePane,keys:[k]}));setTimeout(refreshPane,300);}


### PR DESCRIPTION
## Summary

- recognize OMP's rendered `ask` selector separately from ordinary approvals
- scope selector navigation strictly to OMP panes
- attach stable prompt IDs and reject stale actions
- support single choice and custom `Other` answers
- support staged web multi-select toggles plus Submit
- preserve checked state across updates and reconnects
- propagate prompt IDs through web, Telegram, TUI, macOS, and iOS
- withhold misleading one-shot multi-select controls from incompatible clients
- retain allowlisted ordinary approvals and reject arbitrary unknown input
- refresh active web controls when prompts change
- deduplicate prompt updates/notifications and correlate Telegram pane reads
- add focused regression tests

## Motivation

Herdr Remote treated every blocked agent as a Yes/Trust/No approval. OMP's `ask` tool is a terminal selector, so choices were fabricated and text responses did not select the intended option.

This adds explicit OMP support without claiming a generic question protocol for every agent.

## Protocol additions

Blocked messages add `interaction`, `prompt_id`, `multi`, `multi_options`, `selected_options`, and `update`. Client messages add prompt IDs plus `question_toggle` and `question_submit`.

Actions are accepted only when the prompt ID still matches the live OMP selector.

## Verification

- focused relay/Telegram tests: 19 passed
- `tests/run.sh`: 18 passed, 0 failed
- live single-choice, custom `Other`, and multi-select flows exercised
- stale-prompt regression sends no terminal input
- non-OMP checkbox/custom-editor regressions confirm isolation
- branch is one clean commit over `main`

## Scope

This integration is intentionally OMP-specific. Other agents retain existing approval and manual-terminal paths.