### PR TITLE
fix: show complete Telegram agent menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ The web app is a single self-contained HTML file (`web/index.html`) with inline 
 
 Messages are JSON with a `type` field:
 
-**Server → Client:** `agents` (state list), `blocked` (approval prompt), `pane_content` (terminal read)
+**Server → Client:** `agents` (complete state snapshot), `agent_update` (single-pane state merge), `blocked` (approval prompt), `pane_content` (terminal read)
 
 **Client → Server:** `respond` (send text to agent), `read_pane` (request terminal content), `send_keys` (send key sequences), `send_text` (raw text without newline)
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -32,6 +32,8 @@ herdr server reload-config
 **Web app** (phone):
 Open [herdr-remote.pages.dev](https://herdr-remote.pages.dev), tap ⚙, paste your tunnel URL.
 
+**Telegram:** send `/start` for a clickable dashboard of every running agent. Select an agent to read its recent output and send your next message; larger herds include Previous and Next buttons.
+
 **Menu bar app** (macOS):
 Download from [Releases](https://github.com/dcolinmorgan/herdr-remote/releases).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download [Herdi.app](https://github.com/dcolinmorgan/herdr-remote/releases/lates
 Monitors all your local herdr agents automatically -- no relay, no config, no account.
 
 ```bash
-curl -sL https://github.com/dcolinmorgan/herdr-remote/releases/latest/download/Herdi-0.6.3.dmg -o /tmp/Herdi.dmg && open /tmp/Herdi.dmg
+curl -sL https://github.com/dcolinmorgan/herdr-remote/releases/latest/download/Herdi-0.7.0.dmg -o /tmp/Herdi.dmg && open /tmp/Herdi.dmg
 ```
 
 ## What you get
@@ -114,6 +114,10 @@ uv run relay/herdr_relay.py
 - Zero-dep plugin: [`herdr-push`](https://github.com/dcolinmorgan/herdr-push)
 
 ## Changelog
+
+### v0.7.0
+
+- **Notch panel** — Dynamic Island-style agent status in the MacBook notch; see working/waiting/blocked at a glance without switching windows
 
 ### v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ uv run relay/herdr_telegram.py
 
 | Command | Action |
 |---------|--------|
+| `/start` | Show the clickable agent dashboard |
 | `/agents` | List all with status |
 | `/read` | Read agent output |
 | `/reply` | Read + respond in one flow |
@@ -63,6 +64,8 @@ uv run relay/herdr_telegram.py
 | `/trust` | Trust all tools for blocked agent |
 | `/interrupt` | Send Ctrl+C |
 | `/digest` | Today's activity summary |
+
+The `/start`, `/read`, `/reply`, `/send`, `/interrupt`, and `/trust` pickers keep every eligible agent reachable. Normal herds appear in one list; larger herds include Previous and Next buttons. Selecting an agent from `/start` reads its recent output and sends your next message to that agent.
 
 ## Architecture
 

--- a/herdi-ios/Sources/Models/Agent.swift
+++ b/herdi-ios/Sources/Models/Agent.swift
@@ -25,22 +25,44 @@ final class Agent: Identifiable {
     }
 }
 
-struct AgentMessage: Codable {
+struct AgentMessage: Decodable {
     let type: String
     let agents: [AgentData]?
     let pane_id: String?
     let agent: String?
+    let agentData: AgentData?
     let project: String?
     let prompt: String?
     let options: [String]?
 
-    struct AgentData: Codable {
+    struct AgentData: Decodable {
         let pane_id: String
         let agent: String
         let status: String
         let cwd: String
         let project: String
         let host: String?
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, agents, pane_id, agent, project, prompt, options
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        type = try values.decode(String.self, forKey: .type)
+        agents = try? values.decode([AgentData].self, forKey: .agents)
+        pane_id = try? values.decode(String.self, forKey: .pane_id)
+        project = try? values.decode(String.self, forKey: .project)
+        prompt = try? values.decode(String.self, forKey: .prompt)
+        options = try? values.decode([String].self, forKey: .options)
+        if type == "agent_update" {
+            agentData = try? values.decode(AgentData.self, forKey: .agent)
+            agent = nil
+        } else {
+            agent = try? values.decode(String.self, forKey: .agent)
+            agentData = nil
+        }
     }
 }
 

--- a/herdi-ios/Sources/Services/RelayConnection.swift
+++ b/herdi-ios/Sources/Services/RelayConnection.swift
@@ -158,29 +158,17 @@ final class RelayConnection {
             case "agents":
                 guard let list = msg.agents else { return }
                 for a in list {
-                    if let existing = agents.first(where: { $0.id == a.pane_id }) {
-                        existing.status = AgentStatus(rawValue: a.status) ?? .unknown
-                        existing.project = a.project
-                        existing.host = a.host ?? "local"
-                    } else {
-                        agents.append(Agent(
-                            id: a.pane_id, name: a.agent,
-                            status: AgentStatus(rawValue: a.status) ?? .unknown,
-                            project: a.project, cwd: a.cwd, host: a.host ?? "local"
-                        ))
-                    }
+                    upsertAgent(a)
                 }
                 let activeIds = Set(list.map(\.pane_id))
                 agents.removeAll { !activeIds.contains($0.id) }
-                // Update live activity + widget
-                let b = agents.filter { $0.status == .blocked }.count
-                let w = agents.filter { $0.status == .working }.count
-                let i = agents.filter { $0.status == .idle || $0.status == .unknown }.count
-                LiveActivityManager.shared.update(blocked: b, working: w, idle: i)
-                let defaults = UserDefaults(suiteName: "group.com.dcolinmorgan.herdi")
-                defaults?.set(b, forKey: "blocked_count")
-                defaults?.set(w, forKey: "working_count")
-                defaults?.set(i, forKey: "idle_count")
+                updateAgentCounts()
+
+            case "agent_update":
+                if let update = msg.agentData {
+                    upsertAgent(update)
+                    updateAgentCounts()
+                }
 
             case "blocked":
                 if let pid = msg.pane_id,
@@ -201,5 +189,32 @@ final class RelayConnection {
                 break
             }
         }
+    }
+
+    private func upsertAgent(_ data: AgentMessage.AgentData) {
+        if let existing = agents.first(where: { $0.id == data.pane_id }) {
+            existing.name = data.agent
+            existing.status = AgentStatus(rawValue: data.status) ?? .unknown
+            existing.project = data.project
+            existing.cwd = data.cwd
+            existing.host = data.host ?? "local"
+            return
+        }
+        agents.append(Agent(
+            id: data.pane_id, name: data.agent,
+            status: AgentStatus(rawValue: data.status) ?? .unknown,
+            project: data.project, cwd: data.cwd, host: data.host ?? "local"
+        ))
+    }
+
+    private func updateAgentCounts() {
+        let blocked = agents.filter { $0.status == .blocked }.count
+        let working = agents.filter { $0.status == .working }.count
+        let idle = agents.filter { $0.status == .idle || $0.status == .unknown }.count
+        LiveActivityManager.shared.update(blocked: blocked, working: working, idle: idle)
+        let defaults = UserDefaults(suiteName: "group.com.dcolinmorgan.herdi")
+        defaults?.set(blocked, forKey: "blocked_count")
+        defaults?.set(working, forKey: "working_count")
+        defaults?.set(idle, forKey: "idle_count")
     }
 }

--- a/herdi-mac/Sources/Agent.swift
+++ b/herdi-mac/Sources/Agent.swift
@@ -25,22 +25,44 @@ final class Agent: Identifiable {
     }
 }
 
-struct AgentMessage: Codable {
+struct AgentMessage: Decodable {
     let type: String
     let agents: [AgentData]?
     let pane_id: String?
     let agent: String?
+    let agentData: AgentData?
     let project: String?
     let prompt: String?
     let options: [String]?
 
-    struct AgentData: Codable {
+    struct AgentData: Decodable {
         let pane_id: String
         let agent: String
         let status: String
         let cwd: String
         let project: String
         let host: String?
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, agents, pane_id, agent, project, prompt, options
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        type = try values.decode(String.self, forKey: .type)
+        agents = try? values.decode([AgentData].self, forKey: .agents)
+        pane_id = try? values.decode(String.self, forKey: .pane_id)
+        project = try? values.decode(String.self, forKey: .project)
+        prompt = try? values.decode(String.self, forKey: .prompt)
+        options = try? values.decode([String].self, forKey: .options)
+        if type == "agent_update" {
+            agentData = try? values.decode(AgentData.self, forKey: .agent)
+            agent = nil
+        } else {
+            agent = try? values.decode(String.self, forKey: .agent)
+            agentData = nil
+        }
     }
 }
 

--- a/herdi-mac/Sources/NotchPanel.swift
+++ b/herdi-mac/Sources/NotchPanel.swift
@@ -22,17 +22,25 @@ private class NotchHostingView<Content: View>: NSHostingView<Content> {
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
+    private func applySuperNeedsUpdateConstraints(_ value: Bool) {
+        super.needsUpdateConstraints = value
+    }
+
+    private func applySuperNeedsLayout(_ value: Bool) {
+        super.needsLayout = value
+    }
+
     override var needsUpdateConstraints: Bool {
         get { super.needsUpdateConstraints }
         set {
             if applyingDeferred {
-                super.needsUpdateConstraints = newValue
+                applySuperNeedsUpdateConstraints(newValue)
                 return
             }
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.applyingDeferred = true
-                super.needsUpdateConstraints = newValue
+                self.applySuperNeedsUpdateConstraints(newValue)
                 self.applyingDeferred = false
             }
         }
@@ -42,13 +50,13 @@ private class NotchHostingView<Content: View>: NSHostingView<Content> {
         get { super.needsLayout }
         set {
             if applyingDeferred {
-                super.needsLayout = newValue
+                applySuperNeedsLayout(newValue)
                 return
             }
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.applyingDeferred = true
-                super.needsLayout = newValue
+                self.applySuperNeedsLayout(newValue)
                 self.applyingDeferred = false
             }
         }

--- a/herdi-mac/Sources/RelayConnection.swift
+++ b/herdi-mac/Sources/RelayConnection.swift
@@ -288,20 +288,11 @@ final class RelayConnection {
                 var seen = Set<String>()
                 for a in list {
                     seen.insert(a.pane_id)
-                    if let existing = agents.first(where: { $0.id == a.pane_id }) {
-                        let s = AgentStatus(rawValue: a.status) ?? .unknown
-                        if existing.status != s { existing.status = s }
-                        if existing.project != a.project { existing.project = a.project }
-                        existing.host = a.host ?? "local"
-                    } else {
-                        agents.append(Agent(
-                            id: a.pane_id, name: a.agent,
-                            status: AgentStatus(rawValue: a.status) ?? .unknown,
-                            project: a.project, cwd: a.cwd, host: a.host ?? "local"
-                        ))
-                    }
+                    upsertAgent(a)
                 }
                 agents.removeAll { !seen.contains($0.id) }
+            case "agent_update":
+                if let update = msg.agentData { upsertAgent(update) }
             case "blocked":
                 if let pid = msg.pane_id, let agent = agents.first(where: { $0.id == pid }) {
                     agent.prompt = msg.prompt
@@ -312,6 +303,22 @@ final class RelayConnection {
             default: break
             }
         }
+    }
+
+    private func upsertAgent(_ data: AgentMessage.AgentData) {
+        if let existing = agents.first(where: { $0.id == data.pane_id }) {
+            existing.name = data.agent
+            existing.status = AgentStatus(rawValue: data.status) ?? .unknown
+            existing.project = data.project
+            existing.cwd = data.cwd
+            existing.host = data.host ?? "local"
+            return
+        }
+        agents.append(Agent(
+            id: data.pane_id, name: data.agent,
+            status: AgentStatus(rawValue: data.status) ?? .unknown,
+            project: data.project, cwd: data.cwd, host: data.host ?? "local"
+        ))
     }
 
     private func sendNotification(agent: String, project: String) {

--- a/herdi-mac/build.sh
+++ b/herdi-mac/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_NAME="Herdi"
 BUNDLE_ID="com.dcolinmorgan.herdi"
-VERSION="0.6.3"
+VERSION="0.7.0"
 BUILD_DIR="$SCRIPT_DIR/.build/release"
 APP_DIR="$SCRIPT_DIR/dist/$APP_NAME.app"
 

--- a/herdi-mac/dmg.sh
+++ b/herdi-mac/dmg.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_NAME="Herdi"
 DMG_NAME="Herdi"
-VERSION="0.6.3"
+VERSION="0.7.0"
 APP_DIR="$SCRIPT_DIR/dist/$APP_NAME.app"
 DMG_DIR="$SCRIPT_DIR/dist/dmg"
 DMG_PATH="$SCRIPT_DIR/dist/$DMG_NAME-$VERSION.dmg"

--- a/relay/agent_state.py
+++ b/relay/agent_state.py
@@ -1,0 +1,53 @@
+"""Shared relay agent snapshot and incremental-update helpers."""
+from typing import Optional
+
+AGENT_EVENT_FIELDS = ("pane_id", "agent", "status", "cwd", "project", "host")
+REQUIRED_AGENT_FIELDS = ("pane_id", "agent", "status", "cwd", "project")
+
+
+def agent_update_message(event: dict, local_hostname: Optional[str] = None) -> dict:
+    """Build a single-pane update without masquerading as a full snapshot."""
+    agent = {field: event[field] for field in AGENT_EVENT_FIELDS if field in event}
+    if agent.get("host") in (None, ""):
+        agent.pop("host", None)
+    host = str(agent.get("host") or "").lower().split(".", 1)[0]
+    local_host = str(local_hostname or "").lower().split(".", 1)[0]
+    if host and local_host and host == local_host:
+        agent["host"] = "local"
+    return {"type": "agent_update", "agent": agent}
+
+
+def complete_agent_update_message(event: dict, current: Optional[dict] = None, local_hostname: Optional[str] = None):
+    """Enrich a sparse event and return None until it describes a usable agent."""
+    merged = dict(current or {})
+    for field, value in event.items():
+        if field in (*REQUIRED_AGENT_FIELDS, "host") and value in (None, "") and merged.get(field):
+            continue
+        merged[field] = value
+    message = agent_update_message(merged, local_hostname=local_hostname)
+    if not all(message["agent"].get(field) not in (None, "") for field in REQUIRED_AGENT_FIELDS):
+        return None
+    return message
+
+
+def apply_agent_message(current: list[dict], message: dict) -> list[dict]:
+    """Replace on snapshots and merge one pane on incremental updates."""
+    if message.get("type") == "agents":
+        return [dict(agent) for agent in message.get("agents", [])]
+
+    if message.get("type") != "agent_update":
+        return current
+
+    update = message.get("agent") or {}
+    pane_id = update.get("pane_id")
+    if not pane_id:
+        return current
+
+    result = [dict(agent) for agent in current]
+    for agent in result:
+        if agent.get("pane_id") == pane_id:
+            agent.update(update)
+            return result
+
+    result.append(dict(update))
+    return result

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -6,6 +6,8 @@
 """herdr-remote relay — polls herdr, accepts push events (HTTP POST + WebSocket + UDP), broadcasts to clients."""
 import asyncio, json, logging, os, re, shutil, signal, socket, subprocess, time
 
+from agent_state import complete_agent_update_message
+
 try:
     from websockets.asyncio.server import serve
 except ImportError:
@@ -69,6 +71,7 @@ last_statuses = {}
 event_queue = asyncio.Queue()
 pane_remote_map = {}
 known_panes = set()
+agent_cache = {}
 
 SAFE_RESPONSES = {"y", "n", "a", "yes", "no", "trust", "yes, single permission", "trust, always allow", "no (tab to edit)", "approve all pending", "configure individually", "exit (cancel subagents)"}
 SAFE_KEYS = {"y", "n", "a", "Enter", "Tab", "Escape", "C-c", "Up", "Down", "Left", "Right", "BSpace"}
@@ -242,6 +245,7 @@ async def _poll_once():
         for a in agents:
             pane_remote_map[a["pane_id"]] = a.get("remote")
             known_panes.add(a["pane_id"])
+            agent_cache[a["pane_id"]] = a
         await broadcast({"type": "agents", "agents": agents})
         for a in agents:
             pid, status = a["pane_id"], a["status"]
@@ -273,14 +277,25 @@ async def _poll_once():
             for pid in stale:
                 pane_remote_map.pop(pid, None)
                 last_statuses.pop(pid, None)
+                agent_cache.pop(pid, None)
 
 
 async def event_push():
     while True:
         event = await event_queue.get()
         pane_id = event.get("pane_id", "")
-        status = event.get("status", "")
-        host = event.get("host", "local")
+        update = None
+        if pane_id and event.get("type") == "agent_event":
+            update = complete_agent_update_message(
+                event,
+                current=agent_cache.get(pane_id),
+                local_hostname=socket.gethostname(),
+            )
+            if update is None:
+                continue
+        agent_data = update["agent"] if update else event
+        status = agent_data.get("status", "")
+        host = agent_data.get("host", "local")
 
         if status == "blocked" and pane_id:
             remote = pane_remote_map.get(pane_id)
@@ -291,24 +306,18 @@ async def event_push():
             options = detect_options(content)
             await broadcast({
                 "type": "blocked", "pane_id": pane_id,
-                "agent": event.get("agent", ""),
-                "project": event.get("project", ""),
+                "agent": agent_data.get("agent", ""),
+                "project": agent_data.get("project", ""),
                 "host": host,
                 "prompt": content[:500],
                 "options": options or TOOL_OPTIONS
             })
 
-        if pane_id and event.get("type") == "agent_event":
-            await broadcast({
-                "type": "agents", "agents": [{
-                    "pane_id": pane_id,
-                    "agent": event.get("agent", ""),
-                    "status": status,
-                    "cwd": event.get("cwd", ""),
-                    "project": event.get("project", ""),
-                    "host": host,
-                }]
-            })
+        if update:
+            known_panes.add(pane_id)
+            pane_remote_map.setdefault(pane_id, None)
+            agent_cache[pane_id] = {**agent_cache.get(pane_id, {}), **update["agent"]}
+            await broadcast(update)
 
 
 async def process_request(connection, request):

--- a/relay/herdr_telegram.py
+++ b/relay/herdr_telegram.py
@@ -4,10 +4,13 @@
 # dependencies = ["python-telegram-bot>=21.0", "websockets>=14.0"]
 # ///
 """herdr-remote Telegram bot — monitor and approve agents from Telegram."""
-import asyncio, json, os, logging
+import asyncio, hashlib, json, os, logging
+from collections import Counter
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import Application, CallbackQueryHandler, CommandHandler, MessageHandler, ContextTypes, filters
+
+from agent_state import apply_agent_message
 
 logging.basicConfig(level=logging.INFO)
 # httpx logs every request URL at INFO; that URL contains the bot token. Silence it.
@@ -44,6 +47,10 @@ prev_statuses: dict[str, str] = {}  # pane_id -> last known status
 relay_connected = False
 send_target: str = ""         # pane_id for next free-text message (set by /send picker)
 daily_stats: dict[str, dict] = {}  # pane_id -> {agent, project, blocked_count, working_mins, last_change}
+
+AGENT_PAGE_SIZE = 20
+STATUS_ORDER = {"blocked": 0, "working": 1, "done": 2, "idle": 3, "unknown": 3}
+STATUS_LABELS = {"blocked": "BLOCKED", "working": "WORKING", "done": "DONE", "idle": "IDLE", "unknown": "IDLE"}
 
 
 # --- Relay communication ---
@@ -96,23 +103,138 @@ def authorized(update: Update) -> bool:
     return str(update.effective_chat.id) == CHAT_ID
 
 
+def agents_for_action(action: str) -> list[dict]:
+    if action == "interrupt":
+        return [agent for agent in agents if agent.get("status") in ("working", "blocked")]
+    if action == "trust":
+        return [agent for agent in agents if agent.get("status") == "blocked"]
+    return list(agents)
+
+
+def sorted_agents(agent_list: list[dict]) -> list[dict]:
+    return sorted(agent_list, key=lambda agent: (
+        STATUS_ORDER.get(agent.get("status", "unknown"), 3),
+        agent.get("project", "").lower(),
+        agent.get("agent", "").lower(),
+        agent.get("host", "local").lower(),
+        agent.get("pane_id", ""),
+    ))
+
+
+def compact_identifier(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    digest = hashlib.sha1(value.encode()).hexdigest()[:12]
+    return value[:limit - 15] + "..." + digest
+
+
+def agent_button_labels(agent_list: list[dict]) -> list[str]:
+    bases = []
+    contexts = []
+    for agent in agent_list:
+        status = STATUS_LABELS.get(agent.get("status", "unknown"), "UNKNOWN")
+        project = agent.get("project") or agent.get("cwd") or "unknown"
+        name = agent.get("agent") or "agent"
+        host = agent.get("host", "local")
+        bases.append(f"[{status}] {project} ({name})")
+        contexts.append(f" @{compact_identifier(host, 24)}" if host != "local" else "")
+
+    provisional = [base[:max(1, 64 - len(context))] + context for base, context in zip(bases, contexts)]
+    counts = Counter(provisional)
+    labels = []
+    for agent, base, context, candidate in zip(agent_list, bases, contexts, provisional):
+        if counts[candidate] == 1:
+            labels.append(candidate)
+            continue
+        pane_id = compact_identifier(agent.get("pane_id", "?"), 18)
+        suffix = context + f" [{pane_id}]"
+        labels.append(base[:max(1, 64 - len(suffix))] + suffix)
+    unique_labels = []
+    used = set()
+    for label in labels:
+        candidate = label
+        ordinal = 2
+        while candidate in used:
+            marker = f" #{ordinal}"
+            candidate = label[:64 - len(marker)] + marker
+            ordinal += 1
+        used.add(candidate)
+        unique_labels.append(candidate)
+    return unique_labels
+
+
+def build_agent_keyboard(action: str, page: int = 0, agent_list: list[dict] | None = None) -> InlineKeyboardMarkup:
+    ordered = sorted_agents(agents_for_action(action) if agent_list is None else agent_list)
+    page_count = max(1, (len(ordered) + AGENT_PAGE_SIZE - 1) // AGENT_PAGE_SIZE)
+    page = min(max(page, 0), page_count - 1)
+    start = page * AGENT_PAGE_SIZE
+    visible = ordered[start:start + AGENT_PAGE_SIZE]
+    labels = agent_button_labels(ordered)[start:start + AGENT_PAGE_SIZE]
+    keyboard = [[InlineKeyboardButton(
+        label,
+        callback_data=json.dumps(
+            {"action": action, "pane_id": agent["pane_id"]}, separators=(",", ":")
+        ),
+    )] for agent, label in zip(visible, labels)]
+
+    if page_count > 1:
+        navigation = []
+        if page > 0:
+            navigation.append(InlineKeyboardButton(
+                "Previous",
+                callback_data=json.dumps(
+                    {"action": "page", "menu": action, "page": page - 1}, separators=(",", ":")
+                ),
+            ))
+        if page + 1 < page_count:
+            navigation.append(InlineKeyboardButton(
+                "Next",
+                callback_data=json.dumps(
+                    {"action": "page", "menu": action, "page": page + 1}, separators=(",", ":")
+                ),
+            ))
+        keyboard.append(navigation)
+    return InlineKeyboardMarkup(keyboard)
+
+
+def refresh_keyboard(action: str) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup([[
+        InlineKeyboardButton(
+            "Refresh agents",
+            callback_data=json.dumps({"action": "page", "menu": action, "page": 0}, separators=(",", ":")),
+        )
+    ]])
+
+
+def dashboard_text() -> str:
+    if not relay_connected:
+        text = "herdr-remote bot\n\nRelay disconnected. Use /status for connection details."
+    elif not agents:
+        text = "herdr-remote bot\n\nConnected to relay. No agents are running."
+    else:
+        blocked = sum(agent.get("status") == "blocked" for agent in agents)
+        working = sum(agent.get("status") == "working" for agent in agents)
+        done = sum(agent.get("status") == "done" for agent in agents)
+        idle = len(agents) - blocked - working - done
+        text = f"herdr-remote bot\n\nAgents: {len(agents)} ({blocked} blocked, {working} working, {done} done, {idle} idle)\nSelect an agent to read and reply."
+    if not CHAT_ID:
+        text += "\n\nChat ID: {chat_id}"
+    return text
+
+
 # --- Bot commands ---
 
 async def cmd_start(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     """Handle /start command."""
-    await update.message.reply_text(
-        "herdr-remote bot\n\n"
-        "Commands:\n"
-        "/agents — list all agents\n"
-        "/status — relay connection info\n"
-        "/read — read last output from an agent\n"
-        "/send — send text to an agent\n"
-        "/trust — trust all tools for a blocked agent\n"
-        "/interrupt — send Ctrl+C to an agent\n\n"
-        "Pick an agent from the menu, then type — no reply needed.\n"
-        "You'll get notified when agents block or finish.\n\n"
-        f"Chat ID: {update.effective_chat.id}"
-    )
+    if not authorized(update):
+        return
+    text = dashboard_text()
+    if not CHAT_ID:
+        text = text.format(chat_id=update.effective_chat.id)
+    if relay_connected and agents:
+        await update.message.reply_text(text, reply_markup=build_agent_keyboard("select_reply"))
+        return
+    await update.message.reply_text(text)
 
 
 async def cmd_agents(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
@@ -123,6 +245,7 @@ async def cmd_agents(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
     blocked = [a for a in agents if a.get("status") == "blocked"]
     working = [a for a in agents if a.get("status") == "working"]
+    done = [a for a in agents if a.get("status") == "done"]
     idle = [a for a in agents if a.get("status") in ("idle", "unknown")]
 
     lines = []
@@ -134,6 +257,11 @@ async def cmd_agents(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     if working:
         lines.append("WORKING:")
         for a in working:
+            host = f" @{a['host']}" if a.get('host', 'local') != 'local' else ''
+            lines.append(f"  {a['project']} ({a['agent']}){host}")
+    if done:
+        lines.append("DONE:")
+        for a in done:
             host = f" @{a['host']}" if a.get('host', 'local') != 'local' else ''
             lines.append(f"  {a['project']} ({a['agent']}){host}")
     if idle:
@@ -149,13 +277,14 @@ async def cmd_status(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     """Handle /status — show connection info."""
     b = len([a for a in agents if a.get("status") == "blocked"])
     w = len([a for a in agents if a.get("status") == "working"])
+    d = len([a for a in agents if a.get("status") == "done"])
     i = len([a for a in agents if a.get("status") in ("idle", "unknown")])
 
     status = "Connected" if relay_connected else "Disconnected"
     text = (
         f"Relay: {RELAY_WS_SAFE}\n"
         f"Status: {status}\n"
-        f"Agents: {len(agents)} ({b} blocked, {w} working, {i} idle)"
+        f"Agents: {len(agents)} ({b} blocked, {w} working, {d} done, {i} idle)"
     )
     await update.message.reply_text(text)
 
@@ -168,11 +297,7 @@ async def cmd_read(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         if not agents:
             await update.message.reply_text("No agents. Use /agents to check.")
             return
-        keyboard = [[InlineKeyboardButton(
-            f"{a['project']} ({a['agent']})",
-            callback_data=json.dumps({"action": "read", "pane_id": a["pane_id"]})
-        )] for a in agents[:8]]
-        await update.message.reply_text("Read which agent?", reply_markup=InlineKeyboardMarkup(keyboard))
+        await update.message.reply_text("Read which agent?", reply_markup=build_agent_keyboard("read"))
         return
 
     # Find agent by project name
@@ -201,11 +326,10 @@ async def cmd_interrupt(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         if not working:
             await update.message.reply_text("No active agents to interrupt.")
             return
-        keyboard = [[InlineKeyboardButton(
-            f"{a['project']} ({a['agent']})",
-            callback_data=json.dumps({"action": "interrupt", "pane_id": a["pane_id"]})
-        )] for a in working[:8]]
-        await update.message.reply_text("Interrupt which agent?", reply_markup=InlineKeyboardMarkup(keyboard))
+        await update.message.reply_text(
+            "Interrupt which agent?",
+            reply_markup=build_agent_keyboard("interrupt", agent_list=working),
+        )
         return
 
     query = " ".join(args).lower()
@@ -230,11 +354,10 @@ async def cmd_send(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         if not agents:
             await update.message.reply_text("No agents.")
             return
-        keyboard = [[InlineKeyboardButton(
-            f"{a['project']} ({a['agent']})",
-            callback_data=json.dumps({"action": "select_send", "pane_id": a["pane_id"]})
-        )] for a in agents[:8]]
-        await update.message.reply_text("Send to which agent?\n(After selecting, reply with your text)", reply_markup=InlineKeyboardMarkup(keyboard))
+        await update.message.reply_text(
+            "Send to which agent?\n(After selecting, reply with your text)",
+            reply_markup=build_agent_keyboard("select_send"),
+        )
         return
 
     query = args[0].lower()
@@ -269,11 +392,7 @@ async def cmd_reply(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return
 
     if not args:
-        keyboard = [[InlineKeyboardButton(
-            f"{a['project']} ({a['agent']})",
-            callback_data=json.dumps({"action": "select_reply", "pane_id": a["pane_id"]})
-        )] for a in agents[:8]]
-        await update.message.reply_text("Reply to which agent?", reply_markup=InlineKeyboardMarkup(keyboard))
+        await update.message.reply_text("Reply to which agent?", reply_markup=build_agent_keyboard("select_reply"))
         return
 
     query = " ".join(args).lower()
@@ -300,11 +419,10 @@ async def cmd_trust(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return
 
     if not args:
-        keyboard = [[InlineKeyboardButton(
-            f"{a['project']} ({a['agent']})",
-            callback_data=json.dumps({"action": "trust", "pane_id": a["pane_id"]})
-        )] for a in blocked[:8]]
-        await update.message.reply_text("Trust which agent?", reply_markup=InlineKeyboardMarkup(keyboard))
+        await update.message.reply_text(
+            "Trust which agent?",
+            reply_markup=build_agent_keyboard("trust", agent_list=blocked),
+        )
         return
 
     query = " ".join(args).lower()
@@ -339,14 +457,44 @@ async def cmd_digest(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
 async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     """Handle inline keyboard button presses."""
+    global send_target
     query = update.callback_query
     if CHAT_ID and str(update.effective_chat.id) != CHAT_ID:
         await query.answer("Unauthorized")
         return
     await query.answer()
 
+    if not relay_connected:
+        send_target = ""
+        await query.message.reply_text("Relay disconnected. Use /start after it reconnects.")
+        return
+
     data = json.loads(query.data)
     action = data.get("action", "respond")
+
+    if action == "page":
+        menu = data.get("menu", "select_reply")
+        if not agents_for_action(menu):
+            await query.message.reply_text("No eligible agents are available.")
+            return
+        await query.edit_message_reply_markup(
+            reply_markup=build_agent_keyboard(menu, page=data.get("page", 0))
+        )
+        return
+
+    selected_agent = None
+    if action in {"read", "interrupt", "select_send", "select_reply", "trust"}:
+        selected_agent = next(
+            (agent for agent in agents_for_action(action) if agent.get("pane_id") == data.get("pane_id")),
+            None,
+        )
+        if selected_agent is None:
+            send_target = ""
+            await query.message.reply_text(
+                "That agent is no longer available for this action. Refresh the list and choose another agent.",
+                reply_markup=refresh_keyboard(action),
+            )
+            return
 
     if action == "read":
         content = await read_pane(data["pane_id"])
@@ -367,25 +515,21 @@ async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return
 
     if action == "select_send":
-        global send_target
         send_target = data["pane_id"]
-        agent_name = next((a['project'] for a in agents if a['pane_id'] == data['pane_id']), '?')
-        await query.message.reply_text(f"Ready. Type your message — it will be sent to {agent_name}.")
+        await query.message.reply_text(f"Ready. Type your message — it will be sent to {selected_agent['project']}.")
         return
 
     if action == "select_reply":
         send_target = data["pane_id"]
-        agent_name = next((a['project'] for a in agents if a['pane_id'] == data['pane_id']), '?')
         content = await read_pane(data["pane_id"])
         if len(content) > 3000:
             content = content[-3000:]
-        await query.message.reply_text(f"{agent_name}:\n\n{content}\n\n--- Type your response below ---")
+        await query.message.reply_text(f"{selected_agent['project']}:\n\n{content}\n\n--- Type your response below ---")
         return
 
     if action == "trust":
         await send_to_relay(data["pane_id"], "trust, always allow")
-        agent_name = next((a['project'] for a in agents if a['pane_id'] == data['pane_id']), '?')
-        await query.message.reply_text(f"Trusted {agent_name} (always allow)")
+        await query.message.reply_text(f"Trusted {selected_agent['project']} (always allow)")
         return
 
     # Default: confirm a blocked agent's prompt by pressing the option number.
@@ -491,6 +635,45 @@ async def notify_blocked(app: Application, pane_id: str, agent: str, project: st
 
 # --- Relay listener ---
 
+async def track_agent_updates(app: Application, updated_agents: list[dict]):
+    """Track status transitions for full snapshots and pane-level updates."""
+    if not CHAT_ID:
+        return
+
+    import time
+    now = time.time()
+    for agent_data in updated_agents:
+        pane_id = agent_data["pane_id"]
+        new_status = agent_data.get("status", "unknown")
+        old_status = prev_statuses.get(pane_id)
+
+        if pane_id not in daily_stats:
+            daily_stats[pane_id] = {
+                "agent": agent_data.get("agent", ""),
+                "project": agent_data.get("project", ""),
+                "blocked_count": 0,
+                "working_mins": 0,
+                "last_change": now,
+            }
+        stats = daily_stats[pane_id]
+        if old_status == "working" and old_status != new_status:
+            stats["working_mins"] += int((now - stats["last_change"]) / 60)
+        if new_status == "blocked" and old_status != "blocked":
+            stats["blocked_count"] += 1
+        if old_status != new_status:
+            stats["last_change"] = now
+
+        if old_status and old_status != new_status and new_status in ("idle", "done") and old_status in ("working", "blocked"):
+            try:
+                await app.bot.send_message(
+                    chat_id=int(CHAT_ID),
+                    text=f"{agent_data['project']} ({agent_data['agent']}) finished."
+                )
+            except Exception as e:
+                log.warning("Failed to send completion notification: %s", scrub(e))
+        prev_statuses[pane_id] = new_status
+
+
 async def relay_listener(app: Application):
     """Persistent WebSocket connection to relay."""
     import websockets
@@ -509,38 +692,14 @@ async def relay_listener(app: Application):
 
                     if msg.get("type") == "agents":
                         new_agents = msg.get("agents", [])
-                        # Detect status transitions
-                        if CHAT_ID:
-                            import time
-                            now = time.time()
-                            for a in new_agents:
-                                pid = a["pane_id"]
-                                new_status = a.get("status", "unknown")
-                                old_status = prev_statuses.get(pid)
+                        await track_agent_updates(app, new_agents)
+                        agents = apply_agent_message(agents, msg)
 
-                                # Update daily stats
-                                if pid not in daily_stats:
-                                    daily_stats[pid] = {"agent": a.get("agent",""), "project": a.get("project",""), "blocked_count": 0, "working_mins": 0, "last_change": now}
-                                ds = daily_stats[pid]
-                                if old_status == "working" and old_status != new_status:
-                                    elapsed = (now - ds["last_change"]) / 60
-                                    ds["working_mins"] += int(elapsed)
-                                if new_status == "blocked" and old_status != "blocked":
-                                    ds["blocked_count"] += 1
-                                if old_status != new_status:
-                                    ds["last_change"] = now
-
-                                if old_status and old_status != new_status:
-                                    if new_status == "idle" and old_status in ("working", "blocked"):
-                                        try:
-                                            await app.bot.send_message(
-                                                chat_id=int(CHAT_ID),
-                                                text=f"{a['project']} ({a['agent']}) finished."
-                                            )
-                                        except Exception:
-                                            pass
-                                prev_statuses[pid] = new_status
-                        agents = new_agents
+                    elif msg.get("type") == "agent_update":
+                        updated_agent = msg.get("agent") or {}
+                        if updated_agent.get("pane_id"):
+                            await track_agent_updates(app, [updated_agent])
+                            agents = apply_agent_message(agents, msg)
 
                     elif msg.get("type") == "blocked":
                         await notify_blocked(
@@ -553,6 +712,7 @@ async def relay_listener(app: Application):
                         )
         except Exception as e:
             relay_connected = False
+            agents = []
             log.warning(f"Relay connection lost: {e}, reconnecting in 5s...")
             await asyncio.sleep(5)
 
@@ -561,12 +721,12 @@ async def relay_listener(app: Application):
 
 def main():
     app = Application.builder().token(TOKEN).build()
-    app.add_handler(CommandHandler("start", cmd_start))
     if CHAT_ID:
         auth_filter = filters.Chat(chat_id=int(CHAT_ID))
     else:
         auth_filter = filters.ALL  # No restriction in discovery mode
 
+    app.add_handler(CommandHandler("start", cmd_start, filters=auth_filter))
     app.add_handler(CommandHandler("agents", cmd_agents, filters=auth_filter))
     app.add_handler(CommandHandler("status", cmd_status, filters=auth_filter))
     app.add_handler(CommandHandler("read", cmd_read, filters=auth_filter))

--- a/relay/herdr_tui.py
+++ b/relay/herdr_tui.py
@@ -13,6 +13,8 @@ from textual.reactive import reactive
 from textual.message import Message
 from textual import work
 
+from agent_state import apply_agent_message
+
 RELAY_WS = os.environ.get("HERDR_RELAY", "ws://127.0.0.1:8375")
 
 
@@ -157,10 +159,17 @@ class HerdrRemoteTUI(App):
 
     def _handle_msg(self, msg: dict):
         if msg.get("type") == "agents":
-            self._agents_data = msg.get("agents", [])
+            self._agents_data = apply_agent_message(self._agents_data, msg)
             # Clear blocked data for agents no longer blocked
             blocked_ids = {a["pane_id"] for a in self._agents_data if a.get("status") == "blocked"}
             self._blocked_data = [b for b in self._blocked_data if b["pane_id"] in blocked_ids]
+            self.recompose()
+        elif msg.get("type") == "agent_update":
+            self._agents_data = apply_agent_message(self._agents_data, msg)
+            update = msg.get("agent") or {}
+            if update.get("status") != "blocked":
+                pane_id = update.get("pane_id")
+                self._blocked_data = [b for b in self._blocked_data if b.get("pane_id") != pane_id]
             self.recompose()
         elif msg.get("type") == "blocked":
             # Update or add

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -46,29 +46,37 @@ echo "7. telegram bot env vars documented"
 grep -q "HERDR_TG_TOKEN" "$DIR/relay/herdr_telegram.py" && grep -q "HERDR_TG_CHAT_ID" "$DIR/relay/herdr_telegram.py"
 assert_eq "$?" "0" "env vars referenced"
 
+echo "8. telegram dashboard behavior"
+uv run "$DIR/tests/test_telegram.py"
+assert_eq "$?" "0" "telegram dashboard tests"
+
+echo "9. relay agent state behavior"
+python3 "$DIR/tests/test_agent_state.py"
+assert_eq "$?" "0" "agent state tests"
+
 # --- TUI ---
 echo ""
 echo "=== TUI ==="
-echo "8. TUI syntax"
+echo "10. TUI syntax"
 python3 -c "import ast; ast.parse(open('$DIR/relay/herdr_tui.py').read())" 2>/dev/null
 assert_eq "$?" "0" "herdr_tui.py parses"
 
 # --- Web app ---
 echo ""
 echo "=== Web app ==="
-echo "9. web app key elements"
+echo "11. web app key elements"
 WEB="$DIR/web/index.html"
 grep -q "WebSocket" "$WEB" && grep -q "theme" "$WEB" && grep -q "sendKey" "$WEB"
 assert_eq "$?" "0" "has WebSocket, themes, keyboard"
 
-echo "10. web app no hardcoded secrets"
+echo "12. web app no hardcoded secrets"
 ! grep -q "c4a2385e" "$WEB" && ! grep -q "graffold" "$WEB"
 assert_eq "$?" "0" "no secrets in web app"
 
 # --- macOS app ---
 echo ""
 echo "=== macOS app ==="
-echo "11. Swift sources parse"
+echo "13. Swift sources parse"
 if command -v swiftc >/dev/null 2>&1; then
   swiftc -parse "$DIR/herdi-mac/Sources/Agent.swift" "$DIR/herdi-mac/Sources/RelayConnection.swift" 2>/dev/null
   assert_eq "$?" "0" "core Swift parses"
@@ -76,18 +84,18 @@ else
   PASS=$((PASS+1)); echo "  skip: swiftc not available"
 fi
 
-echo "12. build.sh and dmg.sh present"
+echo "14. build.sh and dmg.sh present"
 [ -x "$DIR/herdi-mac/build.sh" ] && [ -f "$DIR/herdi-mac/dmg.sh" ]
 assert_eq "$?" "0" "build scripts present"
 
-echo "13. updater points to correct repo"
+echo "15. updater points to correct repo"
 grep -q "dcolinmorgan/herdr-remote" "$DIR/herdi-mac/Sources/Updater.swift"
 assert_eq "$?" "0" "updater repo correct"
 
 # --- Demo worker ---
 echo ""
 echo "=== Demo worker ==="
-echo "14. demo worker syntax"
+echo "16. demo worker syntax"
 if [ -f "$DIR/demo-worker/src/index.js" ]; then
   node --check "$DIR/demo-worker/src/index.js" 2>/dev/null
   assert_eq "$?" "0" "demo worker parses"
@@ -98,15 +106,15 @@ fi
 # --- Integration ---
 echo ""
 echo "=== Integration ==="
-echo "15. README links to herdr-demo.pages.dev"
+echo "17. README links to herdr-demo.pages.dev"
 grep -q "herdr-demo.pages.dev" "$DIR/README.md"
 assert_eq "$?" "0" "demo URL correct"
 
-echo "16. README links to herdr-push"
+echo "18. README links to herdr-push"
 grep -q "dcolinmorgan/herdr-push" "$DIR/README.md"
 assert_eq "$?" "0" "plugin link present"
 
-echo "17. LICENSE is AGPL"
+echo "19. LICENSE is AGPL"
 grep -q "GNU AFFERO GENERAL PUBLIC LICENSE" "$DIR/LICENSE"
 assert_eq "$?" "0" "AGPL license"
 

--- a/tests/test_agent_state.py
+++ b/tests/test_agent_state.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "relay"))
+
+from agent_state import agent_update_message, apply_agent_message, complete_agent_update_message
+
+
+class AgentStateTests(unittest.TestCase):
+    def setUp(self):
+        self.snapshot = [
+            {
+                "pane_id": "w1:p1",
+                "agent": "opencode",
+                "status": "working",
+                "project": "alpha",
+                "cwd": "/work/alpha",
+                "host": "local",
+                "workspace_id": "w1",
+                "tab_id": "w1:t1",
+            },
+            {
+                "pane_id": "w2:p1",
+                "agent": "pi",
+                "status": "idle",
+                "project": "beta",
+                "cwd": "/work/beta",
+                "host": "local",
+            },
+        ]
+
+    def test_agent_event_uses_distinct_incremental_shape(self):
+        message = agent_update_message({
+            "type": "agent_event",
+            "pane_id": "w1:p1",
+            "agent": "opencode",
+            "status": "blocked",
+            "project": "alpha",
+            "cwd": "/work/alpha",
+            "host": "dev-mac",
+        }, local_hostname="dev-mac.local")
+
+        self.assertEqual(message["type"], "agent_update")
+        self.assertNotIn("agents", message)
+        self.assertEqual(message["agent"]["pane_id"], "w1:p1")
+        self.assertEqual(message["agent"]["host"], "local")
+
+    def test_sparse_event_is_enriched_without_empty_metadata(self):
+        message = complete_agent_update_message({
+            "type": "agent_event",
+            "pane_id": "w1:p1",
+            "agent": "",
+            "status": "blocked",
+            "cwd": "",
+            "project": "",
+            "host": None,
+        }, current=self.snapshot[0])
+
+        self.assertEqual(message["agent"]["agent"], "opencode")
+        self.assertEqual(message["agent"]["project"], "alpha")
+        self.assertEqual(message["agent"]["status"], "blocked")
+        self.assertEqual(message["agent"]["host"], "local")
+
+    def test_unknown_sparse_event_is_not_emitted(self):
+        message = complete_agent_update_message({
+            "type": "agent_event",
+            "pane_id": "w9:p9",
+            "status": "blocked",
+        })
+
+        self.assertIsNone(message)
+
+    def test_incremental_update_preserves_other_agents_and_snapshot_fields(self):
+        result = apply_agent_message(self.snapshot, {
+            "type": "agent_update",
+            "agent": {"pane_id": "w1:p1", "status": "blocked"},
+        })
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["status"], "blocked")
+        self.assertEqual(result[0]["workspace_id"], "w1")
+        self.assertEqual(result[1], self.snapshot[1])
+        self.assertEqual(self.snapshot[0]["status"], "working")
+
+    def test_incremental_update_adds_unknown_agent(self):
+        result = apply_agent_message(self.snapshot, {
+            "type": "agent_update",
+            "agent": {"pane_id": "w3:p1", "agent": "claude", "status": "working"},
+        })
+
+        self.assertEqual([agent["pane_id"] for agent in result], ["w1:p1", "w2:p1", "w3:p1"])
+
+    def test_complete_snapshot_replaces_and_removes_agents(self):
+        replacement = [{"pane_id": "w2:p1", "agent": "pi", "status": "working"}]
+        result = apply_agent_message(self.snapshot, {"type": "agents", "agents": replacement})
+
+        self.assertEqual(result, replacement)
+        self.assertIsNot(result[0], replacement[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["python-telegram-bot>=21.0", "websockets>=14.0"]
+# ///
+import asyncio
+import importlib
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "relay"))
+os.environ.setdefault("HERDR_TG_TOKEN", "test-token")
+
+tg = importlib.import_module("herdr_telegram")
+
+
+def make_agents(count, *, status="idle", project="project"):
+    return [
+        {
+            "pane_id": f"w{i}:p1",
+            "agent": "opencode",
+            "status": status,
+            "project": project,
+            "cwd": f"/work/{project}/{i}",
+            "host": "local",
+        }
+        for i in range(count)
+    ]
+
+
+class FakeMessage:
+    def __init__(self):
+        self.replies = []
+        self.message_id = 10
+        self.reply_markup = None
+        self.reply_to_message = None
+        self.text = ""
+
+    async def reply_text(self, text, **kwargs):
+        sent = SimpleNamespace(message_id=100 + len(self.replies))
+        self.replies.append((text, kwargs, sent))
+        return sent
+
+
+class FakeCallback:
+    def __init__(self, data):
+        self.data = json.dumps(data, separators=(",", ":"))
+        self.message = FakeMessage()
+        self.answers = []
+        self.edited_markup = None
+
+    async def answer(self, text=None):
+        self.answers.append(text)
+
+    async def edit_message_reply_markup(self, reply_markup=None):
+        self.edited_markup = reply_markup
+
+
+def make_update(chat_id=42, callback=None):
+    return SimpleNamespace(
+        effective_chat=SimpleNamespace(id=chat_id),
+        message=FakeMessage(),
+        callback_query=callback,
+    )
+
+
+class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.old_chat_id = tg.CHAT_ID
+        tg.CHAT_ID = "42"
+        tg.agents = []
+        tg.relay_connected = False
+        tg.send_target = ""
+        tg.pending.clear()
+        tg.prev_statuses.clear()
+        tg.daily_stats.clear()
+
+    def tearDown(self):
+        tg.CHAT_ID = self.old_chat_id
+        tg.agents = []
+        tg.relay_connected = False
+        tg.send_target = ""
+        tg.prev_statuses.clear()
+        tg.daily_stats.clear()
+
+    async def test_start_rejects_unauthorized_chat(self):
+        update = make_update(chat_id=7)
+
+        await tg.cmd_start(update, SimpleNamespace(args=[]))
+
+        self.assertEqual(update.message.replies, [])
+
+    async def test_start_preserves_chat_discovery_mode(self):
+        tg.CHAT_ID = ""
+        update = make_update(chat_id=-123)
+
+        await tg.cmd_start(update, SimpleNamespace(args=[]))
+
+        self.assertIn("Chat ID: -123", update.message.replies[0][0])
+
+    async def test_start_reports_disconnected_and_empty_states(self):
+        disconnected = make_update()
+        await tg.cmd_start(disconnected, SimpleNamespace(args=[]))
+        self.assertIn("disconnected", disconnected.message.replies[0][0].lower())
+        self.assertNotIn("reply_markup", disconnected.message.replies[0][1])
+
+        tg.relay_connected = True
+        empty = make_update()
+        await tg.cmd_start(empty, SimpleNamespace(args=[]))
+        self.assertIn("no agents", empty.message.replies[0][0].lower())
+
+    async def test_start_lists_current_sixteen_agent_herd(self):
+        tg.relay_connected = True
+        tg.agents = make_agents(16)
+        update = make_update()
+
+        await tg.cmd_start(update, SimpleNamespace(args=[]))
+
+        markup = update.message.replies[0][1]["reply_markup"]
+        agent_buttons = [row[0] for row in markup.inline_keyboard if row[0].text not in ("Previous", "Next")]
+        self.assertEqual(len(agent_buttons), 16)
+        self.assertTrue(all(json.loads(button.callback_data)["action"] == "select_reply" for button in agent_buttons))
+
+    def test_labels_sort_status_and_disambiguate_duplicate_agents(self):
+        agent_list = [
+            *make_agents(2, status="idle", project="same"),
+            *make_agents(1, status="working", project="work"),
+            *make_agents(1, status="blocked", project="blocked"),
+        ]
+        agent_list[-1]["host"] = "remote.example"
+
+        markup = tg.build_agent_keyboard("read", agent_list=agent_list)
+        labels = [row[0].text for row in markup.inline_keyboard]
+
+        self.assertTrue(labels[0].startswith("[BLOCKED]"))
+        self.assertTrue(labels[1].startswith("[WORKING]"))
+        self.assertIn("remote.example", labels[0])
+        duplicate_labels = [label for label in labels if "same" in label]
+        self.assertEqual(len(set(duplicate_labels)), 2)
+        self.assertTrue(all("w" in label and ":p1" in label for label in duplicate_labels))
+
+    def test_large_keyboard_paginates_without_omitting_agents(self):
+        agent_list = make_agents(tg.AGENT_PAGE_SIZE + 5)
+
+        first = tg.build_agent_keyboard("read", page=0, agent_list=agent_list)
+        second = tg.build_agent_keyboard("read", page=1, agent_list=agent_list)
+        first_ids = [json.loads(row[0].callback_data).get("pane_id") for row in first.inline_keyboard[:-1]]
+        second_ids = [json.loads(row[0].callback_data).get("pane_id") for row in second.inline_keyboard[:-1]]
+
+        self.assertEqual(len(first_ids), tg.AGENT_PAGE_SIZE)
+        self.assertEqual(len(second_ids), 5)
+        self.assertEqual(len(set(first_ids + second_ids)), tg.AGENT_PAGE_SIZE + 5)
+
+    def test_long_labels_remain_unique_and_preserve_remote_host(self):
+        long_prefix = "project-" + "x" * 70
+        agent_list = make_agents(3)
+        agent_list[0]["project"] = long_prefix + "-one"
+        agent_list[1]["project"] = long_prefix + "-two"
+        agent_list[2]["project"] = long_prefix + "-three"
+        agent_list[2]["host"] = "remote-" + "host" * 30 + ".example"
+
+        markup = tg.build_agent_keyboard("read", agent_list=agent_list)
+        labels = [row[0].text for row in markup.inline_keyboard]
+
+        self.assertEqual(len(set(labels)), 3)
+        self.assertTrue(any("@remote-" in label for label in labels))
+        self.assertTrue(all(len(label) <= 64 for label in labels))
+
+    def test_compacted_pane_hash_collision_still_has_unique_labels(self):
+        agent_list = make_agents(2, project="same")
+        agent_list[0]["pane_id"] = "sameprefx-very-long-pane-id-2606"
+        agent_list[1]["pane_id"] = "sameprefx-very-long-pane-id-3604"
+
+        markup = tg.build_agent_keyboard("read", agent_list=agent_list)
+        labels = [row[0].text for row in markup.inline_keyboard]
+
+        self.assertEqual(len(set(labels)), 2)
+        self.assertTrue(all(len(label) <= 64 for label in labels))
+
+    async def test_read_and_filtered_trust_pickers_do_not_truncate(self):
+        tg.agents = make_agents(16)
+        read_update = make_update()
+        await tg.cmd_read(read_update, SimpleNamespace(args=[]))
+        self.assertEqual(len(read_update.message.replies[0][1]["reply_markup"].inline_keyboard), 16)
+
+        tg.agents = make_agents(12, status="blocked") + make_agents(3, status="idle")
+        trust_update = make_update()
+        await tg.cmd_trust(trust_update, SimpleNamespace(args=[]))
+        self.assertEqual(len(trust_update.message.replies[0][1]["reply_markup"].inline_keyboard), 12)
+
+    async def test_done_agent_is_listed_and_sends_finished_notification(self):
+        tg.agents = make_agents(1, status="done", project="completed")
+        update = make_update()
+
+        await tg.cmd_agents(update, SimpleNamespace(args=[]))
+
+        self.assertIn("DONE:", update.message.replies[0][0])
+        app = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()))
+        tg.prev_statuses["w0:p1"] = "working"
+        await tg.track_agent_updates(app, tg.agents)
+        app.bot.send_message.assert_awaited_once_with(
+            chat_id=42,
+            text="completed (opencode) finished.",
+        )
+
+    async def test_page_callback_rebuilds_from_latest_cache(self):
+        tg.relay_connected = True
+        tg.agents = make_agents(tg.AGENT_PAGE_SIZE + 5)
+        callback = FakeCallback({"action": "page", "menu": "read", "page": 1})
+
+        await tg.handle_callback(make_update(callback=callback), SimpleNamespace())
+
+        self.assertEqual(len(callback.edited_markup.inline_keyboard), 6)
+
+    async def test_dashboard_selection_reads_and_arms_one_shot_reply(self):
+        tg.relay_connected = True
+        tg.agents = make_agents(1)
+        callback = FakeCallback({"action": "select_reply", "pane_id": "w0:p1"})
+
+        with patch.object(tg, "read_pane", AsyncMock(return_value="recent output")):
+            await tg.handle_callback(make_update(callback=callback), SimpleNamespace())
+
+        self.assertEqual(tg.send_target, "w0:p1")
+        self.assertIn("recent output", callback.message.replies[0][0])
+
+    async def test_stale_selection_clears_target_and_offers_refresh(self):
+        tg.relay_connected = True
+        tg.send_target = "old:pane"
+        callback = FakeCallback({"action": "select_reply", "pane_id": "gone:pane"})
+
+        await tg.handle_callback(make_update(callback=callback), SimpleNamespace())
+
+        self.assertEqual(tg.send_target, "")
+        text, kwargs, _ = callback.message.replies[0]
+        self.assertIn("no longer available", text.lower())
+        self.assertIn("reply_markup", kwargs)
+
+    async def test_disconnected_callback_cannot_use_stale_agent_cache(self):
+        tg.agents = make_agents(1)
+        callback = FakeCallback({"action": "select_reply", "pane_id": "w0:p1"})
+
+        with patch.object(tg, "read_pane", AsyncMock()) as read_pane:
+            await tg.handle_callback(make_update(callback=callback), SimpleNamespace())
+
+        read_pane.assert_not_awaited()
+        self.assertIn("disconnected", callback.message.replies[0][0].lower())
+
+    async def test_callback_rechecks_command_eligibility(self):
+        tg.relay_connected = True
+        tg.agents = make_agents(1, status="idle")
+        callback = FakeCallback({"action": "trust", "pane_id": "w0:p1"})
+
+        with patch.object(tg, "send_to_relay", AsyncMock()) as send_to_relay:
+            await tg.handle_callback(make_update(callback=callback), SimpleNamespace())
+
+        send_to_relay.assert_not_awaited()
+        self.assertIn("no longer available", callback.message.replies[0][0].lower())
+
+    async def test_callback_rejects_unauthorized_chat(self):
+        tg.relay_connected = True
+        tg.agents = make_agents(1)
+        callback = FakeCallback({"action": "select_reply", "pane_id": "w0:p1"})
+
+        await tg.handle_callback(make_update(chat_id=7, callback=callback), SimpleNamespace())
+
+        self.assertEqual(callback.answers, ["Unauthorized"])
+        self.assertEqual(callback.message.replies, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/index.html
+++ b/web/index.html
@@ -387,6 +387,20 @@ function handleMessage(msg) {
     }
     agents = msg.agents; render();
   }
+  else if (msg.type === 'agent_update') {
+    const update = msg.agent;
+    if (!update || !update.pane_id) return;
+    const existing = agents.find(a => a.pane_id === update.pane_id);
+    const previousStatus = existing?.status || prevStatuses[update.pane_id];
+    if (existing) Object.assign(existing, update);
+    else agents.push({...update});
+    if (previousStatus && previousStatus !== update.status) {
+      timeline.unshift({project: update.project, agent: update.agent, status: update.status, time: new Date()});
+      if (timeline.length > 100) timeline.pop();
+    }
+    prevStatuses[update.pane_id] = update.status;
+    render();
+  }
   else if (msg.type === 'blocked') {
     const a = agents.find(x => x.pane_id === msg.pane_id);
     if (a) { a.status='blocked'; a.prompt=msg.prompt; a.options=msg.options; }


### PR DESCRIPTION
Turn /start into an authorized, paginated agent dashboard and remove fixed picker truncation while keeping duplicate agents identifiable.

Separate authoritative snapshots from incremental updates across all relay clients so single-pane events no longer replace the herd. Handle stale callbacks and done-state completion notifications, and add behavioral coverage and documentation.