### PR TITLE
fix: fail closed on unsafe service configuration

### DIFF
--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -25,15 +25,99 @@ if [ "$OS" = "unsupported" ]; then
     exit 1
 fi
 
+CURRENT_UID="$(id -u)"
+if [ "$CURRENT_UID" -eq 0 ]; then
+    echo "Error: Do not run install-service.sh with sudo or as root."
+    echo "The relay and Telegram run as user services and must own their configuration files."
+    exit 1
+fi
+
+if [ "${1:-}" = "--uninstall" ]; then
+    echo "Uninstalling herdr-remote services..."
+    if [ "$OS" = "macos" ]; then
+        launchctl bootout "gui/$(id -u)/$LABEL_RELAY" 2>/dev/null || true
+        launchctl bootout "gui/$(id -u)/$LABEL_TUNNEL" 2>/dev/null || true
+        launchctl bootout "gui/$(id -u)/$LABEL_TELEGRAM" 2>/dev/null || true
+        rm -f "$HOME/Library/LaunchAgents/$LABEL_RELAY.plist"
+        rm -f "$HOME/Library/LaunchAgents/$LABEL_TUNNEL.plist"
+        rm -f "$HOME/Library/LaunchAgents/$LABEL_TELEGRAM.plist"
+    else
+        systemctl --user stop herdr-relay.service 2>/dev/null || true
+        systemctl --user stop herdr-tunnel.service 2>/dev/null || true
+        systemctl --user stop herdr-telegram.service 2>/dev/null || true
+        systemctl --user disable herdr-relay.service 2>/dev/null || true
+        systemctl --user disable herdr-tunnel.service 2>/dev/null || true
+        systemctl --user disable herdr-telegram.service 2>/dev/null || true
+        rm -f "$HOME/.config/systemd/user/herdr-relay.service"
+        rm -f "$HOME/.config/systemd/user/herdr-tunnel.service"
+        rm -f "$HOME/.config/systemd/user/herdr-telegram.service"
+        systemctl --user daemon-reload
+    fi
+    echo "Done. Configuration and secrets preserved in $CONFIG_DIR"
+    exit 0
+fi
+
+file_owner_uid() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        stat -f '%u' "$1"
+    else
+        stat -c '%u' "$1"
+    fi
+}
+
+file_mode() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        stat -f '%Lp' "$1"
+    else
+        stat -c '%a' "$1"
+    fi
+}
+
 # --- Load existing configuration ---
 
 EXISTING_INSTALL=false
 if [ -f "$CONFIG_FILE" ]; then
+    CONFIG_OWNER_UID="$(file_owner_uid "$CONFIG_FILE")"
+    if [ "$CONFIG_OWNER_UID" != "$CURRENT_UID" ]; then
+        echo "Error: $CONFIG_FILE is not owned by the current user."
+        echo "Repair it with: sudo chown \"$(id -un):$(id -gn)\" \"$CONFIG_FILE\""
+        exit 1
+    fi
+    CONFIG_MODE="$(file_mode "$CONFIG_FILE")"
+    case "$CONFIG_MODE" in
+        600|640|644) ;;
+        *)
+            echo "Error: $CONFIG_FILE must not be group/world writable, found mode 0$CONFIG_MODE."
+            echo "Repair it with: chmod 644 \"$CONFIG_FILE\""
+            exit 1
+            ;;
+    esac
+    if [ ! -r "$CONFIG_FILE" ]; then
+        echo "Error: $CONFIG_FILE is not readable by the current user."
+        exit 1
+    fi
     # shellcheck disable=SC1090
     source "$CONFIG_FILE"
     EXISTING_INSTALL=true
 fi
 if [ -f "$SECRETS_FILE" ]; then
+    SECRETS_OWNER_UID="$(file_owner_uid "$SECRETS_FILE")"
+    if [ "$SECRETS_OWNER_UID" != "$CURRENT_UID" ]; then
+        echo "Error: $SECRETS_FILE is not owned by the current user."
+        echo "Repair it with: sudo chown \"$(id -un):$(id -gn)\" \"$SECRETS_FILE\""
+        exit 1
+    fi
+    SECRETS_MODE="$(file_mode "$SECRETS_FILE")"
+    if [ "$SECRETS_MODE" != "600" ]; then
+        echo "Error: $SECRETS_FILE must have mode 0600, found 0$SECRETS_MODE."
+        echo "Repair it with: chmod 600 \"$SECRETS_FILE\""
+        exit 1
+    fi
+    if [ ! -r "$SECRETS_FILE" ]; then
+        echo "Error: $SECRETS_FILE is not readable by the current user."
+        echo "Repair it with: chmod 600 \"$SECRETS_FILE\""
+        exit 1
+    fi
     # shellcheck disable=SC1090
     source "$SECRETS_FILE"
 fi
@@ -120,11 +204,24 @@ remove_telegram_service() {
     fi
 }
 
+remove_managed_tunnel_service() {
+    if [ "$OS" = "macos" ]; then
+        launchctl bootout "gui/$(id -u)/$LABEL_TUNNEL" 2>/dev/null || true
+        rm -f "$HOME/Library/LaunchAgents/$LABEL_TUNNEL.plist"
+    else
+        systemctl --user stop herdr-tunnel.service 2>/dev/null || true
+        systemctl --user disable herdr-tunnel.service 2>/dev/null || true
+        rm -f "$HOME/.config/systemd/user/herdr-tunnel.service"
+        systemctl --user daemon-reload
+    fi
+}
+
 telegram_api() {
     local method="$1"
     shift
-    curl -fsS --max-time 20 -X POST \
-        "https://api.telegram.org/bot${TELEGRAM_TOKEN}/${method}" "$@"
+    curl -fsS --max-time 20 -X POST --config - "$@" <<EOF
+url = "https://api.telegram.org/bot${TELEGRAM_TOKEN}/${method}"
+EOF
 }
 
 validate_telegram_token() {
@@ -246,31 +343,6 @@ if [ -z "$HERDR_PATH" ]; then
 fi
 
 # --- Handle --uninstall ---
-
-if [ "$1" = "--uninstall" ]; then
-    echo "Uninstalling herdr-remote services..."
-    if [ "$OS" = "macos" ]; then
-        launchctl bootout "gui/$(id -u)/$LABEL_RELAY" 2>/dev/null || true
-        launchctl bootout "gui/$(id -u)/$LABEL_TUNNEL" 2>/dev/null || true
-        launchctl bootout "gui/$(id -u)/$LABEL_TELEGRAM" 2>/dev/null || true
-        rm -f "$HOME/Library/LaunchAgents/$LABEL_RELAY.plist"
-        rm -f "$HOME/Library/LaunchAgents/$LABEL_TUNNEL.plist"
-        rm -f "$HOME/Library/LaunchAgents/$LABEL_TELEGRAM.plist"
-    else
-        systemctl --user stop herdr-relay.service 2>/dev/null || true
-        systemctl --user stop herdr-tunnel.service 2>/dev/null || true
-        systemctl --user stop herdr-telegram.service 2>/dev/null || true
-        systemctl --user disable herdr-relay.service 2>/dev/null || true
-        systemctl --user disable herdr-tunnel.service 2>/dev/null || true
-        systemctl --user disable herdr-telegram.service 2>/dev/null || true
-        rm -f "$HOME/.config/systemd/user/herdr-relay.service"
-        rm -f "$HOME/.config/systemd/user/herdr-tunnel.service"
-        rm -f "$HOME/.config/systemd/user/herdr-telegram.service"
-        systemctl --user daemon-reload
-    fi
-    echo "Done. Configuration and secrets preserved in $CONFIG_DIR"
-    exit 0
-fi
 
 # --- Relay authentication ---
 
@@ -778,7 +850,16 @@ HERDR_TG_USERNAME="${HERDR_TG_USERNAME:-$TELEGRAM_USERNAME}"
 }
 
 mkdir -p "$CONFIG_DIR"
-cat > "$CONFIG_FILE" <<EOF
+CONFIG_TMP="$CONFIG_FILE.tmp.$$"
+SECRETS_TMP="$SECRETS_FILE.tmp.$$"
+cleanup_config_temps() {
+    rm -f "$CONFIG_TMP" "$SECRETS_TMP"
+}
+trap cleanup_config_temps EXIT
+
+(
+    umask 022
+    cat > "$CONFIG_TMP" <<EOF
 # herdr-remote configuration (generated by install-service.sh)
 HERDR_RELAY_PORT=$WS_PORT
 HERDR_BIN=${HERDR_PATH:-herdr}
@@ -793,8 +874,10 @@ HERDR_TG_ENABLED=$TELEGRAM_ENABLED
 HERDR_TG_USERNAME=${HERDR_TG_USERNAME:-}
 HERDR_TG_CHAT_TYPE=${HERDR_TG_CHAT_TYPE:-unknown}
 EOF
+)
+chmod 644 "$CONFIG_TMP"
+mv "$CONFIG_TMP" "$CONFIG_FILE"
 
-SECRETS_TMP="$SECRETS_FILE.tmp"
 (
     umask 077
     cat > "$SECRETS_TMP" <<EOF
@@ -807,6 +890,7 @@ EOF
 )
 chmod 600 "$SECRETS_TMP"
 mv "$SECRETS_TMP" "$SECRETS_FILE"
+trap - EXIT
 
 echo ""
 echo "Config saved to $CONFIG_FILE"
@@ -883,7 +967,7 @@ if [ "$OS" = "macos" ]; then
     <array>
         <string>/bin/bash</string>
         <string>-lc</string>
-        <string>set -a; source "\$HOME/.config/herdr-remote/config.env"; source "\$HOME/.config/herdr-remote/secrets.env"; set +a; exec "\$HERDR_UV_PATH" run "\$HERDR_RELAY_DIR/herdr_relay.py"</string>
+        <string>set -e; set -a; source "\$HOME/.config/herdr-remote/config.env"; source "\$HOME/.config/herdr-remote/secrets.env"; set +a; exec "\$HERDR_UV_PATH" run "\$HERDR_RELAY_DIR/herdr_relay.py"</string>
     </array>
     <key>WorkingDirectory</key>
     <string>$SCRIPT_DIR</string>
@@ -926,7 +1010,7 @@ Restart=always
 RestartSec=5
 Environment=PATH=$SERVICE_PATH
 EnvironmentFile=$CONFIG_FILE
-EnvironmentFile=-$SECRETS_FILE
+EnvironmentFile=$SECRETS_FILE
 
 [Install]
 WantedBy=default.target
@@ -969,7 +1053,7 @@ if [ "$TELEGRAM_ENABLED" = true ]; then
     <array>
         <string>/bin/bash</string>
         <string>-lc</string>
-        <string>set -a; source "\$HOME/.config/herdr-remote/config.env"; source "\$HOME/.config/herdr-remote/secrets.env"; set +a; exec "\$HERDR_UV_PATH" run "\$HERDR_RELAY_DIR/herdr_telegram.py"</string>
+        <string>set -e; set -a; source "\$HOME/.config/herdr-remote/config.env"; source "\$HOME/.config/herdr-remote/secrets.env"; set +a; exec "\$HERDR_UV_PATH" run "\$HERDR_RELAY_DIR/herdr_telegram.py"</string>
     </array>
     <key>WorkingDirectory</key>
     <string>$SCRIPT_DIR</string>
@@ -1007,7 +1091,7 @@ Restart=always
 RestartSec=5
 Environment=PATH=$SERVICE_PATH
 EnvironmentFile=$CONFIG_FILE
-EnvironmentFile=-$SECRETS_FILE
+EnvironmentFile=$SECRETS_FILE
 
 [Install]
 WantedBy=default.target
@@ -1027,9 +1111,12 @@ fi
 
 # --- Install tunnel service (if configured) ---
 
-if [ "$TUNNEL_MODE" = "named-external" ]; then
-    echo "  Tunnel: using existing cloudflared service (not managed by herdr-remote)."
-    echo "  Hostname: ${TUNNEL_HOSTNAME:-unknown}"
+if [ "$TUNNEL_MODE" = "none" ] || [ "$TUNNEL_MODE" = "named-external" ]; then
+    remove_managed_tunnel_service
+    if [ "$TUNNEL_MODE" = "named-external" ]; then
+        echo "  Tunnel: using existing cloudflared service (not managed by herdr-remote)."
+        echo "  Hostname: ${TUNNEL_HOSTNAME:-unknown}"
+    fi
 elif [ "$TUNNEL_MODE" != "none" ] && [ -n "$CLOUDFLARED_PATH" ]; then
     echo "Installing tunnel service (mode: $TUNNEL_MODE)..."
 

--- a/tests/install-service.sh
+++ b/tests/install-service.sh
@@ -22,6 +22,36 @@ fi
 exit 0
 EOF
 
+cat > "$MOCK_BIN/id" <<'EOF'
+#!/bin/sh
+if [ "${HERDR_TEST_ROOT:-0}" = "1" ] && [ "${1:-}" = "-u" ]; then
+    printf '%s\n' '0'
+    exit 0
+fi
+if [ -n "${HERDR_TEST_NONROOT_UID:-}" ] && [ "${1:-}" = "-u" ]; then
+    printf '%s\n' "$HERDR_TEST_NONROOT_UID"
+    exit 0
+fi
+exec /usr/bin/id "$@"
+EOF
+
+cat > "$MOCK_BIN/stat" <<'EOF'
+#!/bin/sh
+case " $* " in
+    *" %u "*)
+        if [ -n "${HERDR_TEST_OWNER_UID:-}" ]; then
+            printf '%s\n' "$HERDR_TEST_OWNER_UID"
+            exit 0
+        fi
+        if [ -n "${HERDR_TEST_NONROOT_UID:-}" ]; then
+            printf '%s\n' "$HERDR_TEST_NONROOT_UID"
+            exit 0
+        fi
+        ;;
+esac
+exec /usr/bin/stat "$@"
+EOF
+
 cat > "$MOCK_BIN/launchctl" <<'EOF'
 #!/bin/sh
 printf 'launchctl %s\n' "$*" >> "$HERDR_TEST_CALLS"
@@ -59,19 +89,28 @@ EOF
 cat > "$MOCK_BIN/curl" <<'EOF'
 #!/bin/sh
 url=""
+printf 'curl %s\n' "$*" >> "$HERDR_TEST_CALLS"
 for arg in "$@"; do
     case "$arg" in
         https://api.telegram.org/*) url="$arg" ;;
     esac
 done
+if [ -z "$url" ]; then
+    config="$(cat)"
+    case "$config" in
+        *'/getMe"'*) url="getMe" ;;
+        *'/getUpdates"'*) url="getUpdates" ;;
+        *'/sendMessage"'*) url="sendMessage" ;;
+    esac
+fi
 case "$url" in
-    */getMe)
+    *getMe)
         printf '%s\n' '{"ok":true,"result":{"id":42,"username":"installer_test_bot"}}'
         ;;
-    */getUpdates)
+    *getUpdates)
         printf '%s\n' '{"ok":true,"result":[{"update_id":1,"message":{"chat":{"id":123456,"type":"private","first_name":"Installer"}}}]}'
         ;;
-    */sendMessage)
+    *sendMessage)
         printf '%s\n' '{"ok":true,"result":{"message_id":1}}'
         ;;
     *)
@@ -96,7 +135,18 @@ run_install() {
         HERDR_INSTALL_SKIP_WEBSOCKET_SMOKE=1 \
         HERDR_INSTALL_SETTLE_SECONDS=0 \
         HERDR_INSTALL_SERVICE_DELAY=0 \
+        HERDR_LOG_DIR= \
+        HERDR_RELAY= \
+        HERDR_RELAY_TOKEN= \
+        HERDR_TG_CHAT_ID= \
+        HERDR_TG_CHAT_TYPE= \
+        HERDR_TG_ENABLED= \
+        HERDR_TG_TOKEN= \
+        HERDR_TG_USERNAME= \
+        HERDR_TEST_NONROOT_UID="${HERDR_TEST_NONROOT_UID:-501}" \
         HERDR_TEST_PGREP="${HERDR_TEST_PGREP:-0}" \
+        HERDR_TEST_ROOT="${HERDR_TEST_ROOT:-0}" \
+        HERDR_TEST_OWNER_UID="${HERDR_TEST_OWNER_UID:-}" \
         bash "$ROOT/relay/install-service.sh"
 }
 
@@ -109,6 +159,9 @@ run_uninstall() {
         HERDR_TEST_CALLS="$CALLS" \
         HERDR_INSTALL_OS="$os" \
         HERDR_INSTALL_SKIP_CLOUDFLARED=1 \
+        HERDR_TEST_NONROOT_UID="${HERDR_TEST_NONROOT_UID:-501}" \
+        HERDR_TEST_OWNER_UID="${HERDR_TEST_OWNER_UID:-}" \
+        HERDR_TEST_ROOT="${HERDR_TEST_ROOT:-0}" \
         bash "$ROOT/relay/install-service.sh" --uninstall
 }
 
@@ -124,7 +177,68 @@ assert_not_contains() {
     ! grep -q "$2" "$1" || { echo "unexpected '$2' in $1" >&2; exit 1; }
 }
 
+ROOT_GUARD_HOME="$TMP/root-guard-home"
+if HERDR_TEST_ROOT=1 run_install macos "$ROOT_GUARD_HOME" '' > "$TMP/root-guard.log" 2>&1; then
+    echo "root installer invocation unexpectedly succeeded" >&2
+    exit 1
+fi
+assert_contains "$TMP/root-guard.log" 'Do not run install-service.sh with sudo or as root'
+
+FOREIGN_HOME="$TMP/foreign-owner-home"
+mkdir -p "$FOREIGN_HOME/.config/herdr-remote"
+printf '%s\n' 'HERDR_RELAY_TOKEN=' > "$FOREIGN_HOME/.config/herdr-remote/secrets.env"
+foreign_uid="$(( $(id -u) + 1 ))"
+if HERDR_TEST_OWNER_UID="$foreign_uid" run_install macos "$FOREIGN_HOME" '' > "$TMP/foreign-owner.log" 2>&1; then
+    echo "foreign-owned secrets unexpectedly accepted" >&2
+    exit 1
+fi
+assert_contains "$TMP/foreign-owner.log" 'is not owned by the current user'
+
+FOREIGN_CONFIG_HOME="$TMP/foreign-config-home"
+mkdir -p "$FOREIGN_CONFIG_HOME/.config/herdr-remote"
+printf '%s\n' 'HERDR_RELAY_PORT=8375' > "$FOREIGN_CONFIG_HOME/.config/herdr-remote/config.env"
+if HERDR_TEST_OWNER_UID="$foreign_uid" run_install macos "$FOREIGN_CONFIG_HOME" '' > "$TMP/foreign-config.log" 2>&1; then
+    echo "foreign-owned config unexpectedly accepted" >&2
+    exit 1
+fi
+assert_contains "$TMP/foreign-config.log" 'config.env is not owned by the current user'
+
+OPEN_CONFIG_HOME="$TMP/open-config-home"
+mkdir -p "$OPEN_CONFIG_HOME/.config/herdr-remote"
+printf '%s\n' 'HERDR_RELAY_PORT=8375' > "$OPEN_CONFIG_HOME/.config/herdr-remote/config.env"
+chmod 666 "$OPEN_CONFIG_HOME/.config/herdr-remote/config.env"
+if run_install macos "$OPEN_CONFIG_HOME" '' > "$TMP/open-config.log" 2>&1; then
+    echo "writable config unexpectedly accepted" >&2
+    exit 1
+fi
+assert_contains "$TMP/open-config.log" 'must not be group/world writable'
+
+OPEN_MODE_HOME="$TMP/open-mode-home"
+mkdir -p "$OPEN_MODE_HOME/.config/herdr-remote"
+printf '%s\n' 'HERDR_RELAY_TOKEN=' > "$OPEN_MODE_HOME/.config/herdr-remote/secrets.env"
+chmod 644 "$OPEN_MODE_HOME/.config/herdr-remote/secrets.env"
+if run_install macos "$OPEN_MODE_HOME" '' > "$TMP/open-mode.log" 2>&1; then
+    echo "overly permissive secrets unexpectedly accepted" >&2
+    exit 1
+fi
+assert_contains "$TMP/open-mode.log" 'must have mode 0600'
+
+BROKEN_UNINSTALL_HOME="$TMP/broken-uninstall-home"
+mkdir -p "$BROKEN_UNINSTALL_HOME/.config/herdr-remote" "$BROKEN_UNINSTALL_HOME/Library/LaunchAgents"
+printf '%s\n' 'HERDR_RELAY_TOKEN=' > "$BROKEN_UNINSTALL_HOME/.config/herdr-remote/secrets.env"
+touch "$BROKEN_UNINSTALL_HOME/Library/LaunchAgents/com.herdr-remote.relay.plist"
+touch "$BROKEN_UNINSTALL_HOME/Library/LaunchAgents/com.herdr-remote.telegram.plist"
+HERDR_TEST_OWNER_UID="$foreign_uid" run_uninstall macos "$BROKEN_UNINSTALL_HOME" > "$TMP/broken-uninstall.log"
+[ ! -f "$BROKEN_UNINSTALL_HOME/Library/LaunchAgents/com.herdr-remote.relay.plist" ] || {
+    echo "relay LaunchAgent was not removed with foreign-owned secrets" >&2
+    exit 1
+}
+assert_file "$BROKEN_UNINSTALL_HOME/.config/herdr-remote/secrets.env"
+assert_contains "$TMP/broken-uninstall.log" 'Configuration and secrets preserved'
+
 MAC_HOME="$TMP/mac-home"
+mkdir -p "$MAC_HOME/Library/LaunchAgents"
+touch "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.tunnel.plist"
 run_install macos "$MAC_HOME" $'yy123456:ABC_def\n\nyn' > "$TMP/mac-new.log" || {
     cat "$TMP/mac-new.log"
     exit 1
@@ -132,10 +246,17 @@ run_install macos "$MAC_HOME" $'yy123456:ABC_def\n\nyn' > "$TMP/mac-new.log" || 
 assert_file "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.relay.plist"
 assert_file "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.telegram.plist"
 assert_file "$MAC_HOME/.config/herdr-remote/secrets.env"
+[ ! -f "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.tunnel.plist" ] || {
+    echo "stale macOS tunnel service was not removed" >&2
+    exit 1
+}
 assert_contains "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.telegram.plist" 'herdr_telegram.py'
 assert_contains "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.relay.plist" 'secrets.env'
+assert_contains "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.relay.plist" 'set -e; set -a; source'
+assert_contains "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.telegram.plist" 'set -e; set -a; source'
 assert_not_contains "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.telegram.plist" '123456:ABC_def'
-python3 -c 'import os, stat, sys; mode = stat.S_IMODE(os.stat(sys.argv[1]).st_mode); raise SystemExit(0 if mode == 0o600 else 1)' "$MAC_HOME/.config/herdr-remote/secrets.env"
+python3 -c 'import os, stat, sys; info = os.stat(sys.argv[1]); mode = stat.S_IMODE(info.st_mode); raise SystemExit(0 if mode == 0o600 and info.st_uid == os.getuid() else 1)' "$MAC_HOME/.config/herdr-remote/secrets.env"
+python3 -c 'import os, stat, sys; info = os.stat(sys.argv[1]); mode = stat.S_IMODE(info.st_mode); raise SystemExit(0 if mode == 0o644 and info.st_uid == os.getuid() else 1)' "$MAC_HOME/.config/herdr-remote/config.env"
 assert_contains "$TMP/mac-new.log" 'Telegram bot verified as @installer_test_bot'
 
 run_install macos "$MAC_HOME" 'yyyyn' > "$TMP/mac-retain.log" || {
@@ -172,10 +293,18 @@ run_install macos "$SKIP_HOME" 'ynn' > "$TMP/skip.log"
 }
 
 LINUX_HOME="$TMP/linux-home"
+mkdir -p "$LINUX_HOME/.config/systemd/user"
+touch "$LINUX_HOME/.config/systemd/user/herdr-tunnel.service"
 run_install linux "$LINUX_HOME" $'yy123456:ABC_def\n\nyn' > "$TMP/linux.log"
 assert_file "$LINUX_HOME/.config/systemd/user/herdr-relay.service"
 assert_file "$LINUX_HOME/.config/systemd/user/herdr-telegram.service"
+[ ! -f "$LINUX_HOME/.config/systemd/user/herdr-tunnel.service" ] || {
+    echo "stale Linux tunnel service was not removed" >&2
+    exit 1
+}
 assert_contains "$LINUX_HOME/.config/systemd/user/herdr-relay.service" 'EnvironmentFile='
+assert_not_contains "$LINUX_HOME/.config/systemd/user/herdr-relay.service" 'EnvironmentFile=-'
+assert_not_contains "$LINUX_HOME/.config/systemd/user/herdr-telegram.service" 'EnvironmentFile=-'
 assert_contains "$LINUX_HOME/.config/systemd/user/herdr-telegram.service" 'After=network-online.target herdr-relay.service'
 assert_not_contains "$LINUX_HOME/.config/systemd/user/herdr-telegram.service" '123456:ABC_def'
 
@@ -211,6 +340,9 @@ assert_contains "$TMP/invalid.log" 'Invalid BotFather token format'
 
 assert_contains "$MAC_HOME/.config/herdr-remote/secrets.env" 'HERDR_RELAY_TOKEN='
 assert_contains "$TMP/calls.log" 'launchctl bootstrap'
+assert_contains "$TMP/calls.log" 'launchctl bootout gui/501/com.herdr-remote.tunnel'
 assert_contains "$TMP/calls.log" 'systemctl --user enable herdr-telegram.service'
+assert_contains "$TMP/calls.log" 'systemctl --user disable herdr-tunnel.service'
+assert_not_contains "$TMP/calls.log" '123456:ABC_def'
 
 echo "installer service tests passed"


### PR DESCRIPTION
Reject root installs and validate config ownership and permissions before sourcing shell environment files. Require launchd and systemd services to load secrets successfully, keep Telegram tokens out of process arguments, and remove stale managed tunnels when local-only access is selected.\n\nExtend installer coverage for unsafe files, test isolation, service definitions, and tunnel cleanup.