### PR TITLE
Fix Herdi updater version loop

### DIFF
--- a/herdi-mac/Sources/Updater.swift
+++ b/herdi-mac/Sources/Updater.swift
@@ -6,7 +6,9 @@ import Observation
 final class Updater {
     static let shared = Updater()
 
-    let currentVersion = "0.6.3"
+    let currentVersion = Bundle.main.object(
+        forInfoDictionaryKey: "CFBundleShortVersionString"
+    ) as? String ?? "0.0.0"
     let repo = "dcolinmorgan/herdr-remote"
 
     var latestVersion: String?

--- a/herdi-mac/dmg.sh
+++ b/herdi-mac/dmg.sh
@@ -4,16 +4,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_NAME="Herdi"
 DMG_NAME="Herdi"
-VERSION="0.7.0"
 APP_DIR="$SCRIPT_DIR/dist/$APP_NAME.app"
 DMG_DIR="$SCRIPT_DIR/dist/dmg"
-DMG_PATH="$SCRIPT_DIR/dist/$DMG_NAME-$VERSION.dmg"
 
-# Build first if needed
-if [ ! -d "$APP_DIR" ]; then
-    echo "▸ App not found, building..."
-    bash "$SCRIPT_DIR/build.sh"
-fi
+# Always rebuild so a stale app bundle cannot be shipped under a new DMG name.
+bash "$SCRIPT_DIR/build.sh"
+
+# Name the DMG from the version embedded in the app that will be shipped.
+VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_DIR/Contents/Info.plist")
+DMG_PATH="$SCRIPT_DIR/dist/$DMG_NAME-$VERSION.dmg"
 
 echo "▸ Creating DMG..."
 rm -rf "$DMG_DIR"


### PR DESCRIPTION
## Summary

- read Herdi's current version from `CFBundleShortVersionString` instead of a hard-coded value
- always rebuild `Herdi.app` before packaging a DMG
- derive the DMG filename version from the app bundle that is actually shipped

## Root cause

The `v0.7.0` release asset is named `Herdi-0.7.0.dmg`, but the app inside reports `0.6.3`. The updater also hard-codes `currentVersion` as `0.6.3`, so installing the release succeeds and then immediately reports the same update again.

`dmg.sh` reused an existing `dist/Herdi.app` whenever that directory already existed, allowing a stale app bundle to be published under a newer DMG filename.

## Impact

After the next correctly packaged release, Herdi will compare the GitHub release tag against the installed bundle version and will no longer loop on an update that was already installed.

## Validation

- inspected the official `v0.7.0` DMG and confirmed its bundled app reports `0.6.3`
- confirmed the installed app binary and the release DMG binary have identical SHA-256 hashes
- local build and tests were not run; CI/CD is the verification source of truth for this workspace
