### PR TITLE
Fix Herdi notch interactions

### DIFF
--- a/herdi-mac/Sources/NotchContentView.swift
+++ b/herdi-mac/Sources/NotchContentView.swift
@@ -17,7 +17,7 @@ private enum HoverTiming {
 
 struct NotchPanelView: View {
     let relay: RelayConnection
-    let controller: PanelWindowController
+    @ObservedObject var controller: PanelWindowController
     let hasNotch: Bool
     let notchHeight: CGFloat
     let notchW: CGFloat
@@ -58,7 +58,12 @@ struct NotchPanelView: View {
                         expanded: shouldShowExpanded,
                         notchHeight: notchHeight,
                         blocked: blocked,
-                        working: working
+                        working: working,
+                        onShowUpdate: {
+                            withAnimation(NotchAnimation.open) {
+                                controller.surface = .sessionList
+                            }
+                        }
                     )
                     .frame(height: notchHeight)
                 } else {
@@ -177,6 +182,7 @@ private struct CompactBar: View {
     let notchHeight: CGFloat
     let blocked: [Agent]
     let working: [Agent]
+    let onShowUpdate: () -> Void
     private let updater = Updater.shared
 
     var body: some View {
@@ -223,9 +229,13 @@ private struct CompactBar: View {
             // Right wing: update badge + agent count
             HStack(spacing: 4) {
                 if updater.updateAvailable && !expanded {
-                    Image(systemName: "arrow.down.circle.fill")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.cyan)
+                    Button(action: onShowUpdate) {
+                        Image(systemName: "arrow.down.circle.fill")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.cyan)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Show update")
                 }
                 if !expanded {
                     Text("\(relay.agents.count)")

--- a/herdi-mac/Sources/NotchPanel.swift
+++ b/herdi-mac/Sources/NotchPanel.swift
@@ -110,11 +110,11 @@ enum ScreenDetector {
 // MARK: - Panel Window Controller
 
 @MainActor
-final class PanelWindowController: NSObject, NSWindowDelegate {
+final class PanelWindowController: NSObject, NSWindowDelegate, ObservableObject {
     private var panel: KeyablePanel?
     private var hostingView: NotchHostingView<NotchPanelView>?
     private let relay: RelayConnection
-    var surface: IslandSurface = .collapsed
+    @Published var surface: IslandSurface = .collapsed
     private var globalClickMonitor: Any?
     private var fullscreenLatch = false
 

--- a/herdi-mac/Sources/RelayConnection.swift
+++ b/herdi-mac/Sources/RelayConnection.swift
@@ -85,6 +85,11 @@ final class RelayConnection {
         let id: String, name: String, status: AgentStatus, project: String, cwd: String, host: String
     }
 
+    private struct PaneLocation {
+        let workspaceId: String
+        let tabId: String
+    }
+
     private func parseAgents(from output: String, host: String) -> [ParsedAgent] {
         guard let data = output.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -98,6 +103,16 @@ final class RelayConnection {
             let cwd = p["cwd"] as? String ?? ""
             return ParsedAgent(id: paneId, name: agent, status: status, project: (cwd as NSString).lastPathComponent, cwd: cwd, host: host)
         }
+    }
+
+    private func parsePaneLocation(from output: String) -> PaneLocation? {
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let result = json["result"] as? [String: Any],
+              let pane = result["pane"] as? [String: Any],
+              let workspaceId = pane["workspace_id"] as? String,
+              let tabId = pane["tab_id"] as? String else { return nil }
+        return PaneLocation(workspaceId: workspaceId, tabId: tabId)
     }
 
     private func runSSH(_ remote: String, _ args: String...) -> String {
@@ -235,7 +250,20 @@ final class RelayConnection {
 
     func focusPane(_ paneId: String) {
         DispatchQueue.global(qos: .userInitiated).async { [self] in
-            _ = runHerdr("pane", "focus", paneId)
+            if let agent = agents.first(where: { $0.id == paneId }), agent.host != "local" {
+                let prefix = agent.host + ":"
+                let remotePaneId = paneId.hasPrefix(prefix) ? String(paneId.dropFirst(prefix.count)) : paneId
+                let output = runSSH(agent.host, "herdr", "pane", "get", remotePaneId)
+                guard let location = parsePaneLocation(from: output) else { return }
+                _ = runSSH(agent.host, "herdr", "workspace", "focus", location.workspaceId)
+                _ = runSSH(agent.host, "herdr", "tab", "focus", location.tabId)
+                return
+            }
+
+            let output = runHerdr("pane", "get", paneId)
+            guard let location = parsePaneLocation(from: output) else { return }
+            _ = runHerdr("workspace", "focus", location.workspaceId)
+            _ = runHerdr("tab", "focus", location.tabId)
         }
     }
 


### PR DESCRIPTION
## Summary

- make notch surface changes observable so agent detail and update views render after clicks
- make the collapsed update badge open the update panel
- focus an agent through its workspace and tab instead of calling the incompatible pane-focus CLI

## Root cause

Agent rows and their jump buttons called `herdr pane focus <pane-id>`, but current Herdr requires a direction for that command and rejects a positional pane ID. Herdi discarded stderr, making both controls appear inert.

The panel's `surface` property was also not observed by SwiftUI, so state-only transitions such as opening blocked-agent detail did not trigger a render. The collapsed update icon was a plain image with no action attached.

## Impact

Agent and jump controls now focus the pane's workspace/tab, panel state transitions render, and the compact update badge opens the install panel.

## Validation

- confirmed `herdr pane focus <pane-id>` returns a usage error with Herdr `0.8.0`
- confirmed `herdr workspace focus <id>` and `herdr tab focus <id>` succeed for the same live agent
- inspected the running Herdi accessibility state and corresponding SwiftUI action paths
- local build and tests were not run; CI/CD is the verification source of truth for this workspace
