### PR TITLE
fix: point tunnel config at the UUID credentials file (fixes Error 1033)

### DIFF
--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -1126,9 +1126,30 @@ elif [ "$TUNNEL_MODE" != "none" ] && [ -n "$CLOUDFLARED_PATH" ]; then
         CF_CONFIG_DIR="$HOME/.cloudflared"
         mkdir -p "$CF_CONFIG_DIR"
         CF_CONFIG="$CF_CONFIG_DIR/config-herdr.yml"
+        # cloudflared writes credentials to <UUID>.json, not <name>.json —
+        # resolve the tunnel's UUID so the config points at a file that exists.
+        TUNNEL_UUID=$("$CLOUDFLARED_PATH" tunnel list --output json 2>/dev/null \
+            | NAME="$TUNNEL_NAME" python3 -c '
+import json, os, sys
+name = os.environ["NAME"]
+try:
+    for t in json.load(sys.stdin):
+        if t.get("name") == name:
+            print(t.get("id", ""))
+            break
+except Exception:
+    pass
+')
+        if [ -n "$TUNNEL_UUID" ] && [ -f "$CF_CONFIG_DIR/${TUNNEL_UUID}.json" ]; then
+            CF_CREDS="$CF_CONFIG_DIR/${TUNNEL_UUID}.json"
+        else
+            CF_CREDS="$CF_CONFIG_DIR/${TUNNEL_NAME}.json"
+            echo "  WARNING: could not resolve credentials file for tunnel '$TUNNEL_NAME'." >&2
+            echo "           Falling back to $CF_CREDS (tunnel may fail to start)." >&2
+        fi
         cat > "$CF_CONFIG" <<EOF
 tunnel: $TUNNEL_NAME
-credentials-file: $CF_CONFIG_DIR/${TUNNEL_NAME}.json
+credentials-file: $CF_CREDS
 
 ingress:
   - hostname: $TUNNEL_HOSTNAME


### PR DESCRIPTION
Named-tunnel installs generate a `config-herdr.yml` whose `credentials-file` path never exists, so the tunnel never starts and visitors get **Cloudflare Error 1033**.

## The bug

`cloudflared tunnel create` writes credentials to `~/.cloudflared/<UUID>.json`, but `install-service.sh` wrote:

```yaml
credentials-file: $CF_CONFIG_DIR/${TUNNEL_NAME}.json
```

The installer reports success, then the launchd job crashloops:

```
Tunnel credentials file /Users/me/.cloudflared/herdr-relay.json doesn't exist or is not a file
```

Since the job sets `KeepAlive`, this repeats every ~10s indefinitely. `launchctl list` shows the tunnel with exit status 1 and no PID while the relay itself looks healthy, which makes it read like a Cloudflare-side problem.

Re-running the installer does not help — it regenerates the same broken path each time.

## The fix

Resolve the tunnel UUID from `cloudflared tunnel list --output json` and point `credentials-file` at the file that actually exists. If the UUID cannot be resolved, fall back to the old path but warn on stderr rather than failing silently.

## Testing

- `tests/run.sh` — 20 passed, 0 failed
- Verified on macOS: after the fix the tunnel registers four QUIC connections and the hostname serves normally.

Caveat: I fixed this against an existing broken install and verified the generated config; I have not run a full clean `--uninstall` + reinstall cycle. Linux/systemd paths are untouched.