### PR TITLE
fix: avoid launchd bootstrap race and restore relay on failed install

### DIFF
--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -1126,9 +1126,30 @@ elif [ "$TUNNEL_MODE" != "none" ] && [ -n "$CLOUDFLARED_PATH" ]; then
         CF_CONFIG_DIR="$HOME/.cloudflared"
         mkdir -p "$CF_CONFIG_DIR"
         CF_CONFIG="$CF_CONFIG_DIR/config-herdr.yml"
+        # cloudflared writes credentials to <UUID>.json, not <name>.json —
+        # resolve the tunnel's UUID so the config points at a file that exists.
+        TUNNEL_UUID=$("$CLOUDFLARED_PATH" tunnel list --output json 2>/dev/null \
+            | NAME="$TUNNEL_NAME" python3 -c '
+import json, os, sys
+name = os.environ["NAME"]
+try:
+    for t in json.load(sys.stdin):
+        if t.get("name") == name:
+            print(t.get("id", ""))
+            break
+except Exception:
+    pass
+')
+        if [ -n "$TUNNEL_UUID" ] && [ -f "$CF_CONFIG_DIR/${TUNNEL_UUID}.json" ]; then
+            CF_CREDS="$CF_CONFIG_DIR/${TUNNEL_UUID}.json"
+        else
+            CF_CREDS="$CF_CONFIG_DIR/${TUNNEL_NAME}.json"
+            echo "  WARNING: could not resolve credentials file for tunnel '$TUNNEL_NAME'." >&2
+            echo "           Falling back to $CF_CREDS (tunnel may fail to start)." >&2
+        fi
         cat > "$CF_CONFIG" <<EOF
 tunnel: $TUNNEL_NAME
-credentials-file: $CF_CONFIG_DIR/${TUNNEL_NAME}.json
+credentials-file: $CF_CREDS
 
 ingress:
   - hostname: $TUNNEL_HOSTNAME

--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -897,6 +897,38 @@ echo "Config saved to $CONFIG_FILE"
 echo "Secrets saved to $SECRETS_FILE (mode 0600)"
 echo ""
 
+# --- launchd helpers (macOS) ---
+
+# Wait until a launchd label is fully torn down. Bootstrapping a label that is
+# still unloading fails with the opaque "Bootstrap failed: 5: Input/output error".
+# HERDR_INSTALL_SERVICE_DELAY=0 skips the wait entirely (used by the test suite).
+wait_for_label_gone() {
+    label="$1"
+    [ "${HERDR_INSTALL_SERVICE_DELAY:-1}" = "0" ] && return 0
+    for _i in $(seq 1 25); do
+        launchctl print "gui/$(id -u)/$label" >/dev/null 2>&1 || return 0
+        sleep 0.2
+    done
+    return 1
+}
+
+# Bootstrap with retries; launchd can still report the label as busy briefly
+# even after `launchctl print` stops seeing it.
+bootstrap_with_retry() {
+    plist="$1"
+    label="$2"
+    _err=""
+    for _i in 1 2 3 4 5; do
+        if _err=$(launchctl bootstrap "gui/$(id -u)" "$plist" 2>&1); then
+            return 0
+        fi
+        [ "${HERDR_INSTALL_SERVICE_DELAY:-1}" = "0" ] && break
+        sleep 1
+    done
+    echo "  launchctl bootstrap failed for $label: $_err" >&2
+    return 1
+}
+
 # --- Build PATH for the service ---
 
 SERVICE_PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
@@ -918,6 +950,15 @@ if [ -n "$EXISTING_PID" ]; then
         echo "  Aborting. Stop the existing process first."
         exit 1
     fi
+    # If the port holder is our own managed relay, bootout the job first.
+    # Killing the PID directly leaves launchd restarting it (KeepAlive) and
+    # racing the bootstrap below.
+    if [ "$OS" = "macos" ] && launchctl print "gui/$(id -u)/$LABEL_RELAY" >/dev/null 2>&1; then
+        echo "  Stopping managed relay service..."
+        launchctl bootout "gui/$(id -u)/$LABEL_RELAY" 2>/dev/null || true
+        wait_for_label_gone "$LABEL_RELAY" || true
+    fi
+
     # Try graceful shutdown first (SIGTERM)
     kill "$EXISTING_PID" 2>/dev/null
     for i in 1 2 3 4 5; do
@@ -953,8 +994,16 @@ if [ "$OS" = "macos" ]; then
     PLIST_PATH="$HOME/Library/LaunchAgents/$LABEL_RELAY.plist"
     mkdir -p "$HOME/Library/LaunchAgents"
 
+    # Preserve the current plist so a failed install can be rolled back rather
+    # than leaving the machine with no relay at all.
+    PLIST_BACKUP=""
+    if [ -f "$PLIST_PATH" ]; then
+        PLIST_BACKUP="$PLIST_PATH.prev"
+        cp "$PLIST_PATH" "$PLIST_BACKUP"
+    fi
+
     launchctl bootout "gui/$(id -u)/$LABEL_RELAY" 2>/dev/null || true
-    sleep "${HERDR_INSTALL_SERVICE_DELAY:-1}"
+    wait_for_label_gone "$LABEL_RELAY" || true
 
     cat > "$PLIST_PATH" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -990,7 +1039,23 @@ if [ "$OS" = "macos" ]; then
 </plist>
 EOF
 
-    launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+    if ! bootstrap_with_retry "$PLIST_PATH" "$LABEL_RELAY"; then
+        echo "  ERROR: could not start the relay service." >&2
+        if [ -n "$PLIST_BACKUP" ] && [ -f "$PLIST_BACKUP" ]; then
+            echo "  Restoring previous relay service..." >&2
+            cp "$PLIST_BACKUP" "$PLIST_PATH"
+            wait_for_label_gone "$LABEL_RELAY" || true
+            if bootstrap_with_retry "$PLIST_PATH" "$LABEL_RELAY"; then
+                echo "  Previous relay restored and running." >&2
+            else
+                echo "  Could not restore the previous relay either." >&2
+                echo "  Start it manually with:" >&2
+                echo "    launchctl bootstrap gui/$(id -u) $PLIST_PATH" >&2
+            fi
+        fi
+        exit 1
+    fi
+    rm -f "$PLIST_PATH.prev"
 
 else
     UNIT_DIR="$HOME/.config/systemd/user"
@@ -1075,7 +1140,8 @@ if [ "$TELEGRAM_ENABLED" = true ]; then
 </dict>
 </plist>
 EOF
-        launchctl bootstrap "gui/$(id -u)" "$PLIST_TELEGRAM"
+        wait_for_label_gone "$LABEL_TELEGRAM" || true
+        bootstrap_with_retry "$PLIST_TELEGRAM" "$LABEL_TELEGRAM" || true
     else
         UNIT_TELEGRAM="$UNIT_DIR/herdr-telegram.service"
         cat > "$UNIT_TELEGRAM" <<EOF
@@ -1205,7 +1271,8 @@ $ARGS_XML    </array>
 </plist>
 EOF
 
-        launchctl bootstrap "gui/$(id -u)" "$PLIST_TUNNEL"
+        wait_for_label_gone "$LABEL_TUNNEL" || true
+        bootstrap_with_retry "$PLIST_TUNNEL" "$LABEL_TUNNEL" || true
 
     else
         systemctl --user stop herdr-tunnel.service 2>/dev/null || true


### PR DESCRIPTION
Reinstalling over a running relay can abort with:

```
Installing relay service...
Bootstrap failed: 5: Input/output error
Try re-running the command as root for richer errors.
```

Worse, the relay has already been killed by that point, so the machine is left with **no relay running at all** — and, if a tunnel is configured, a tunnel serving nothing. The user ends up worse off than before running the installer.

> Stacked on #26 — both touch `install-service.sh`. Review that one first; this diff is only the launchd changes.

## Causes

**1. KeepAlive races the bootstrap.** The installer SIGKILLs whatever holds the relay port. When that is our own launchd job, `KeepAlive` restarts it immediately, so the job is still tearing down when `launchctl bootstrap` runs. launchd reports a busy label as `EIO`.

The "re-run as root" hint is a red herring — this is a `gui/` domain agent and must not run as root (the script already refuses to).

**2. Fixed sleep.** `sleep "${HERDR_INSTALL_SERVICE_DELAY:-1}"` after `bootout` is not always long enough.

Both are timing-dependent, which is why the same command often succeeds when run again by hand a moment later.

## Changes

- `wait_for_label_gone` — polls until the label is genuinely gone instead of a blind sleep
- `bootstrap_with_retry` — retries, and surfaces launchd's real stderr instead of discarding it
- Bootout the managed relay job *before* killing the PID, so `KeepAlive` cannot race
- Back up the existing plist; if the new one fails to bootstrap, restore and restart the old one, then exit 1

Applied to the telegram and tunnel services too — same latent race.

`HERDR_INSTALL_SERVICE_DELAY=0` still short-circuits the waits, so `tests/install-service.sh` stays fast.

## Testing

- `tests/run.sh` — 20 passed, 0 failed (including the installer lifecycle test)
- Reproduced the original failure and confirmed the fix: SIGKILL the relay → `bootout` → immediate bootstrap. Before: `Bootstrap failed: 5`. After: label gone, bootstrap OK.

Caveats worth a maintainer's eye:

- I verified the helpers against real launchd, but have not run the full interactive installer end to end, so **the rollback path has never actually fired**.
- macOS only — the systemd branches are untouched and may want parity.