### PR TITLE
fix(installer): map uname arch to cloudflared release asset names

### DIFF
--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -501,8 +501,27 @@ if [ -z "$CLOUDFLARED_PATH" ]; then
             echo "  Running: brew install cloudflared"
             brew install cloudflared
         else
-            echo "  Running: curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m) -o /tmp/cloudflared"
-            curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" -o /tmp/cloudflared
+            # cloudflared release assets use Go arch names (amd64/arm64/...),
+            # not uname -m output (x86_64/aarch64/...). Linux assets are bare
+            # binaries; macOS assets are .tgz archives.
+            case "$(uname -m)" in
+                x86_64)        CF_ARCH="amd64" ;;
+                aarch64|arm64) CF_ARCH="arm64" ;;
+                armv7l|armv6l) CF_ARCH="arm" ;;
+                i686|i386)     CF_ARCH="386" ;;
+                *)             CF_ARCH="$(uname -m)" ;;
+            esac
+            CF_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+            CF_ASSET="cloudflared-$CF_OS-$CF_ARCH"
+            [ "$CF_OS" = "darwin" ] && CF_ASSET="$CF_ASSET.tgz"
+            echo "  Running: curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/$CF_ASSET -o /tmp/$CF_ASSET"
+            curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/$CF_ASSET" -o "/tmp/$CF_ASSET"
+            if [ "$CF_OS" = "darwin" ]; then
+                tar -xzf "/tmp/$CF_ASSET" -C /tmp
+                rm -f "/tmp/$CF_ASSET"
+            else
+                mv "/tmp/$CF_ASSET" /tmp/cloudflared
+            fi
             chmod +x /tmp/cloudflared
             if [ -w /usr/local/bin ]; then
                 mv /tmp/cloudflared /usr/local/bin/cloudflared


### PR DESCRIPTION
## Summary

- The cloudflared install fallback in `relay/install-service.sh` built its download URL with `uname -m` verbatim, producing `cloudflared-linux-x86_64` — an asset that does not exist in cloudflared releases (404). This change maps `uname -m` output to the Go arch names the release assets actually use (`x86_64`→`amd64`, `aarch64`/`arm64`→`arm64`, `armv*`→`arm`, `i686`/`i386`→`386`).
- The macOS fallback also fetched a bare binary, but darwin assets are `.tgz` archives. It now downloads the archive, extracts it, and removes the tarball. Linux assets remain bare binaries.
- The echoed command and the actual `curl` now share a single `$CF_ASSET` variable so the printed hint cannot drift from the executed URL.

## Verification

Checked against `releases/latest/download` (following redirects):

| Platform | Asset | Status |
|---|---|---|
| Darwin/x86_64 | `cloudflared-darwin-amd64.tgz` | 200 |
| Darwin/arm64 | `cloudflared-darwin-arm64.tgz` | 200 |
| Linux/x86_64 | `cloudflared-linux-amd64` | 200 |
| Linux/aarch64 | `cloudflared-linux-arm64` | 200 |
| Linux/armv7l | `cloudflared-linux-arm` | 200 |
| (before) Linux/x86_64 | `cloudflared-linux-x86_64` | 404 |

Also verified the darwin `.tgz` contains a top-level `cloudflared` binary (so `tar -xzf` lands it at `/tmp/cloudflared` as the install path expects), and `bash -n` passes on the modified script.