### PR TITLE
chore(wrangler): remove committed .wrangler cache files

### DIFF
--- a/.wrangler/cache/pages.json
+++ b/.wrangler/cache/pages.json
@@ -1,1 +1,0 @@
-{"project_name":"herdr-remote"}

--- a/.wrangler/cache/wrangler-account.json
+++ b/.wrangler/cache/wrangler-account.json
@@ -1,1 +1,0 @@
-{"account_id":"fcea65c3989c4078857c60bf0e0c54c9"}

--- a/web/.wrangler/cache/pages.json
+++ b/web/.wrangler/cache/pages.json
@@ -1,4 +1,0 @@
-{
-  "project_name": "herdr-demo",
-  "account_id": "fcea65c3989c4078857c60bf0e0c54c9"
-}

--- a/web/.wrangler/cache/wrangler-account.json
+++ b/web/.wrangler/cache/wrangler-account.json
@@ -1,7 +1,0 @@
-{
-  "account_id": "fcea65c3989c4078857c60bf0e0c54c9",
-  "account": {
-    "id": "fcea65c3989c4078857c60bf0e0c54c9",
-    "name": "graffold"
-  }
-}


### PR DESCRIPTION
## Summary
- Remove `.wrangler/cache/pages.json` and `.wrangler/cache/wrangler-account.json` (both at repo root and under `web/`) — these were accidentally committed even though `.wrangler/` is already in `.gitignore`
- They only contain a Cloudflare `project_name` and `account_id` used as local defaults for manual `wrangler` CLI runs; Cloudflare Pages' Git-integration auto-deploy doesn't read them at all, so removing them has no effect on deployment
- No secrets are involved (no tokens are stored in these files), but there's no reason to keep account/project metadata checked into a public repo

## Test plan
- [x] Confirmed `.gitignore` already excludes `.wrangler/` so these won't be re-added
- [x] Confirmed Cloudflare Pages Git-integration deploys only read the configured build output directory, not local wrangler cache