### PR TITLE
fix(herdi-mac): capture self weakly inside the concurrent task

### DIFF
--- a/herdi-mac/Sources/HerdiMacApp.swift
+++ b/herdi-mac/Sources/HerdiMacApp.swift
@@ -160,7 +160,7 @@ class HerdiAppDelegate: NSObject, NSApplicationDelegate {
     /// Watch for agents transitioning to blocked state and auto-expand the panel
     private func observeBlockedAgents() {
         Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
+            Task { @MainActor [weak self] in
                 guard let self else { return }
                 let blocked = self.relay.agents.filter { $0.status == .blocked }
 

--- a/herdi-mac/Sources/NotchPanel.swift
+++ b/herdi-mac/Sources/NotchPanel.swift
@@ -158,7 +158,7 @@ final class PanelWindowController: NSObject, NSWindowDelegate, ObservableObject 
             forName: NSApplication.didChangeScreenParametersNotification,
             object: nil, queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in self?.handleScreenChange() }
+            Task { @MainActor [weak self] in self?.handleScreenChange() }
         }
 
         // Fullscreen space detection
@@ -166,7 +166,7 @@ final class PanelWindowController: NSObject, NSWindowDelegate, ObservableObject 
             forName: NSWorkspace.activeSpaceDidChangeNotification,
             object: nil, queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in self?.handleSpaceChange() }
+            Task { @MainActor [weak self] in self?.handleSpaceChange() }
         }
 
         // Global click: collapse expanded panel when clicking outside


### PR DESCRIPTION
`herdi-mac` does not compile on Xcode 15.3 or newer. Three closures capture `self` weakly
and then read that capture from inside a `Task`, which is a separate concurrent context:

```
HerdiMacApp.swift:164:27: error: reference to captured var 'self' in concurrently-executing code
NotchPanel.swift:161:34: error: reference to captured var 'self' in concurrently-executing code
NotchPanel.swift:169:34: error: reference to captured var 'self' in concurrently-executing code
```

Swift 5.10 turned this from a warning into an error, so it builds locally only on Xcode
15.2 or older. It is an error on every GitHub `macos-14` runner, whose default is Xcode
15.4.

The fix is to capture weakly on the `Task` itself rather than reaching outward for the
enclosing capture. Same weak semantics, same `@MainActor` isolation, three lines:

```diff
-            Task { @MainActor in self?.handleScreenChange() }
+            Task { @MainActor [weak self] in self?.handleScreenChange() }
```

Verified by building `herdi-mac/dmg.sh` on a `macos-14` runner: red before, green after.
