### PR TITLE
fix: name spaces and agents by their herdr workspace name

### DIFF
--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -301,17 +301,35 @@ def _mutate_herdr(*args, remote=None):
         return False
 
 
+def get_workspace_labels(remote=None):
+    """Map workspace_id to the workspace name the user chose in herdr."""
+    raw = run_herdr("workspace", "list", remote=remote)
+    try:
+        data = json.loads(raw)
+        workspaces = data.get("result", {}).get("workspaces", [])
+        return {
+            w["workspace_id"]: w.get("label", "")
+            for w in workspaces
+            if w.get("workspace_id") and w.get("label")
+        }
+    except (json.JSONDecodeError, KeyError):
+        return {}
+
+
 def get_agents_from_host(remote=None):
     raw = run_herdr("pane", "list", remote=remote)
     host_label = remote or "local"
     try:
         data = json.loads(raw)
         panes = data.get("result", {}).get("panes", [])
+        workspace_labels = get_workspace_labels(remote=remote) if panes else {}
         return [
             {
                 "pane_id": p["pane_id"],
                 "agent": p.get("agent", ""),
                 "label": p.get("label", ""),
+                # Names the space, and stands in for panes that have no label.
+                "workspace_label": workspace_labels.get(p.get("workspace_id", ""), ""),
                 "status": p.get("agent_status", "unknown"),
                 "cwd": p.get("cwd", ""),
                 "project": os.path.basename(p.get("cwd", "")),

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -185,6 +185,90 @@ class RelayPaneStateTests(unittest.TestCase):
                 {"active-pane": {"pane_id": "active-pane", "remote": None}},
             )
 
+    @staticmethod
+    def _pane_list(label=None):
+        pane = {
+            "pane_id": "w1:p1",
+            "agent": "claude",
+            "agent_status": "idle",
+            "cwd": "/home/user/personal",
+            "workspace_id": "w1",
+            "tab_id": "w1:t1",
+        }
+        if label is not None:
+            pane["label"] = label
+        return json.dumps({"result": {"panes": [pane]}})
+
+    @staticmethod
+    def _workspace_list(label="central AC"):
+        return json.dumps({
+            "result": {"workspaces": [{"workspace_id": "w1", "label": label}]}
+        })
+
+    def test_workspace_name_is_exposed_to_clients(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(
+                relay,
+                "run_herdr",
+                side_effect=[self._pane_list(), self._workspace_list()],
+            ):
+                agents = relay.get_agents_from_host()
+
+            # Without this, clients fall back to the cwd basename ("personal").
+            self.assertEqual(agents[0]["workspace_label"], "central AC")
+
+    def test_workspace_name_does_not_overwrite_the_pane_label(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(
+                relay,
+                "run_herdr",
+                side_effect=[self._pane_list(label="pane name"), self._workspace_list()],
+            ):
+                agents = relay.get_agents_from_host()
+
+            # Tab chips key off label, so it must stay pane-scoped.
+            self.assertEqual(agents[0]["label"], "pane name")
+            self.assertEqual(agents[0]["workspace_label"], "central AC")
+
+    def test_pane_label_stays_empty_when_herdr_gives_none(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(
+                relay,
+                "run_herdr",
+                side_effect=[self._pane_list(), self._workspace_list()],
+            ):
+                agents = relay.get_agents_from_host()
+
+            self.assertEqual(agents[0]["label"], "")
+
+    def test_unusable_workspace_list_leaves_workspace_label_empty(self):
+        for raw in ("", "not json", json.dumps({"result": {}})):
+            with self.subTest(raw=raw):
+                with loaded_relay() as relay:
+                    with mock.patch.object(
+                        relay,
+                        "run_herdr",
+                        side_effect=[self._pane_list(), raw],
+                    ):
+                        agents = relay.get_agents_from_host()
+
+                    self.assertEqual(agents[0]["workspace_label"], "")
+                    self.assertEqual(agents[0]["project"], "personal")
+
+    def test_unusable_pane_list_skips_the_workspace_lookup(self):
+        with loaded_relay() as relay:
+            calls = []
+
+            def record(*args, **kwargs):
+                calls.append(args)
+                return "not json"
+
+            with mock.patch.object(relay, "run_herdr", side_effect=record):
+                self.assertEqual(relay.get_agents_from_host(), [])
+
+            # An unreachable SSH remote should not cost a second timeout.
+            self.assertEqual(calls, [("pane", "list")])
+
 
 class RelayResponseTests(unittest.TestCase):
     def test_respond_sends_correlated_acknowledgement(self):

--- a/web/index.html
+++ b/web/index.html
@@ -677,7 +677,7 @@ function renderWorkspaces(workspaces) {
   for (const wsId of workspaces) {
     const wsAgents = agents.filter(a => a.workspace_id === wsId);
     const hasBlocked = wsAgents.some(a => a.status === 'blocked');
-    const name = wsAgents[0]?.project || wsId.slice(0, 8);
+    const name = wsAgents[0]?.workspace_label || wsAgents[0]?.project || wsId.slice(0, 8);
     html += `<button class="chip${activeWorkspace===wsId?' active':''}${hasBlocked?' alert':''}" onclick="selectWorkspace('${wsId}')">${name}</button>`;
   }
   html += `</div>`;
@@ -758,7 +758,7 @@ function agentCard(a) {
   const pulseClass = a.status==='working'?' pulse':'';
   const host = a.host&&a.host!=='local'?` <span style="color:var(--orange);font-size:0.6rem">@${a.host}</span>`:'';
   const cwd = a.cwd ? `<span style="font-family:monospace;opacity:0.7">${a.cwd.split('/').slice(-2).join('/')}</span>` : '';
-  const label = a.label||a.project||a.agent;
+  const label = a.label||a.workspace_label||a.project||a.agent;
   return `<div class="agent${a.status==='blocked'?' blocked':''}" role="button" tabindex="0" aria-label="${label}, ${a.status}" data-pane-id="${a.pane_id}" data-agent-name="${label}" onclick="openTerminal('${a.pane_id}')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();openTerminal('${a.pane_id}')}">
     <span class="dot${pulseClass}" style="background:${color}" aria-hidden="true"></span>
     <div class="info"><div class="project">${label}${host}</div><div class="meta">${a.agent} · ${cwd}</div></div>
@@ -774,7 +774,7 @@ function section(title, color, list) {
 function openTerminal(paneId) {
   activePane = paneId; paneLines = 200; userScrolledUp = false;
   const a = agents.find(x => x.pane_id===paneId);
-  document.getElementById('termTitle').textContent = a?`${a.label||a.project} · ${a.agent}`:paneId;
+  document.getElementById('termTitle').textContent = a?`${a.label||a.workspace_label||a.project} · ${a.agent}`:paneId;
   document.getElementById('agentListView').style.display = 'none';
   if (refreshInterval) clearInterval(refreshInterval);
   document.getElementById('terminalView').classList.add('active');


### PR DESCRIPTION
Space chips and agent cards both fall back to the cwd basename, so several workspaces open in one repo render identically:

```
Spaces:  [ personal ] [ monitors ] [ personal ]
```

Two causes:

1. `get_agents_from_host()` maps `"label": p.get("label", "")`, but `herdr pane list` returns no `label` for panes, so it is always empty.
2. The space chip (`web/index.html`) reads `wsAgents[0]?.project` only, ignoring any label.

`herdr workspace list` already exposes the name the user chose:

```json
{"workspace_id": "w1", "label": "central AC"}
```

This surfaces it as a new `workspace_label` field and prefers it for both the space chip and the agent card, giving `central AC` / `sub teacher automation` / `herdr-remote`.

### Why a new field rather than filling in `label`

`label` is also what tab chips key off (`tabAgents[0]?.label || "Tab "+(i+1)`). Reusing it made tab chips display the workspace name instead of `Tab 1`. `workspace_label` keeps `label` pane-scoped, so tab chips are unaffected. There is a test pinning this.

### Notes

- A pane-level `label` still wins, so this only fills the gap when panes have none.
- The workspace lookup is skipped when the pane list is unusable, so an unreachable `HERDR_REMOTES` host does not pay a second SSH timeout per poll.
- A malformed or missing workspace list degrades to current behaviour rather than raising.
- `agent_update` merges preserve `workspace_label` from the last snapshot, so incremental UDP push events do not clear it.
- The recent-activity timeline still shows `project`; left alone to keep this focused.

### Testing

6 cases in `RelayPaneStateTests` covering the new field, pane-label precedence, empty pane label, malformed workspace list, and no extra herdr call when the pane list fails to parse. `tests/run.sh` passes 19/19.

Verified live against a running relay — space chips, agent cards, and terminal header all show the workspace name, tab chips still show `Tab N`.