### PR TITLE
feat: switch herdr sessions from the UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,9 @@ The web app is a single self-contained HTML file (`web/index.html`) with inline 
 
 Messages are JSON with a `type` field:
 
-**Server → Client:** `agents` (complete state snapshot), `agent_update` (single-pane state merge), `blocked` (approval prompt), `pane_content` (terminal read)
+**Server → Client:** `agents` (complete state snapshot), `agent_update` (single-pane state merge), `blocked` (approval prompt), `pane_content` (terminal read), `sessions` (per-source herdr session lists and the active selection)
 
-**Client → Server:** `respond` (send text to agent), `read_pane` (request terminal content), `send_keys` (send key sequences), `send_text` (raw text without newline)
+**Client → Server:** `respond` (send text to agent), `read_pane` (request terminal content), `send_keys` (send key sequences), `send_text` (raw text without newline), `session_switch` (point one source at a herdr session; `session: null` follows herdr's default)
 
 ## Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,9 @@ cd herdi-ios && xcodegen generate
 | `HERDR_REMOTES` | Comma-separated SSH targets to poll |
 | `HERDR_BIN` | Path to herdr binary (default: `/opt/homebrew/bin/herdr`) |
 | `HERDR_RELAY` | Relay URL used by clients (default: `ws://127.0.0.1:8375`) |
+| `HERDR_SESSION` | Boot-time default herdr session; a client can override it per source at runtime via `session_switch` |
+
+Runtime session overrides (per source) are persisted to `active_sessions.json` inside `HERDR_LOG_DIR`, so they survive relay restarts.
 
 ## Web App
 

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -67,6 +67,36 @@ POLL_INTERVAL = 2
 AUTH_TOKEN = os.environ.get("HERDR_RELAY_TOKEN", "")  # Optional: shared secret for relay auth
 TRUSTED_ORIGINS = [o.strip().lower() for o in os.environ.get("HERDR_TRUSTED_ORIGINS", "").split(",") if o.strip()]
 
+# Session selection per source. Key is None for local, else the "user@host"
+# string from HERDR_REMOTES. Value is a session name, or None to follow
+# herdr's own default session.
+DEFAULT_LOCAL_SESSION = os.environ.get("HERDR_SESSION") or None
+ACTIVE_SESSIONS = {}
+
+
+def active_session_for(remote=None):
+    """Session name for one source, or None for herdr's default session."""
+    if remote in ACTIVE_SESSIONS:
+        return ACTIVE_SESSIONS[remote]
+    return DEFAULT_LOCAL_SESSION if remote is None else None
+
+
+def _herdr_env(session):
+    """Child environment targeting one session.
+
+    Returning the inherited environment is wrong for the default session: the
+    relay's own env pins HERDR_SESSION via config.env, and HERDR_SOCKET_PATH is
+    present whenever the relay runs inside a herdr pane. Both must be removed.
+    """
+    env = os.environ.copy()
+    if session:
+        env["HERDR_SESSION"] = session
+        env.pop("HERDR_SOCKET_PATH", None)
+    else:
+        env.pop("HERDR_SESSION", None)
+        env.pop("HERDR_SOCKET_PATH", None)
+    return env
+
 # VAPID Web Push
 VAPID_PUBLIC_KEY = os.environ.get("HERDR_VAPID_PUBLIC", "")
 VAPID_PRIVATE_KEY = os.environ.get("HERDR_VAPID_PRIVATE", "")
@@ -269,8 +299,13 @@ _load_push_subs()
 
 
 def _invoke_herdr(*args, remote=None):
+    session = active_session_for(remote)
     if remote:
-        cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", remote, REMOTE_HERDR, *args]
+        cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", remote]
+        if session:
+            # An env= would not survive ssh; the remote shell applies this.
+            cmd.append(f"HERDR_SESSION={session}")
+        cmd += [REMOTE_HERDR, *args]
         with _remote_locks_guard:
             remote_lock = _remote_locks.get(remote)
             if remote_lock is None:
@@ -280,7 +315,10 @@ def _invoke_herdr(*args, remote=None):
             return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15)
 
     cmd = [HERDR, *args]
-    return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15)
+    return subprocess.run(
+        cmd, capture_output=True, text=True, encoding="utf-8",
+        errors="replace", timeout=15, env=_herdr_env(session),
+    )
 
 
 def run_herdr_result(*args, remote=None):

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -137,6 +137,7 @@ known_panes = set()
 agent_cache = {}
 _remote_locks = {}
 _remote_locks_guard = threading.Lock()
+_session_list_cache = {}  # source -> (monotonic_timestamp, sessions_list)
 
 
 SAFE_RESPONSES = {
@@ -260,7 +261,19 @@ def _save_push_subs():
 
 
 def _load_active_sessions():
-    """Restore session selection. Mirrors _load_push_subs: never raises."""
+    """Restore session selection. Mirrors _load_push_subs: never raises.
+
+    Values are restricted to str or None: a hand-edited or corrupted entry
+    like {"local": 5} would otherwise land in ACTIVE_SESSIONS[None] as-is,
+    then _herdr_env(5) sets env["HERDR_SESSION"] = 5 and
+    subprocess.run(env=...) raises TypeError -- which run_herdr swallows,
+    so the relay silently reports zero agents forever, surviving every
+    restart. This is also the one place a persisted value reaches
+    _invoke_herdr's remote branch (which interpolates it straight into the
+    ssh argv) without ever passing through apply_session_switch's
+    get_sessions() allowlist, so gating the type on load is the load-time
+    half of keeping that argv interpolation sane.
+    """
     if not os.path.isfile(ACTIVE_SESSIONS_FILE):
         return
     try:
@@ -271,6 +284,8 @@ def _load_active_sessions():
     except Exception:
         return
     for key, value in stored.items():
+        if value is not None and not isinstance(value, str):
+            continue
         ACTIVE_SESSIONS[None if key == "local" else key] = value
 
 
@@ -395,7 +410,20 @@ def get_all_agents():
 
 
 def get_sessions(remote=None):
-    """List herdr sessions for one source as [{"name", "running"}]."""
+    """List herdr sessions for one source as [{"name", "running"}].
+
+    Cached per source for SESSION_LIST_CACHE_TTL: sessions_message() calls
+    this once per source on every client connect, each a blocking
+    subprocess (ssh with up to a 15s timeout for remotes) on the event
+    loop, and herdr_telegram.py opens a fresh WebSocket per button press
+    with no X-Herdr-Remote-Command header -- so every press previously
+    paid N+1 of these. apply_session_switch()'s validation also goes
+    through this cache, which keeps it checking against the same list the
+    user was actually shown rather than a fresher one they never saw.
+    """
+    cached = _session_list_cache.get(remote)
+    if cached is not None and time.monotonic() - cached[0] < SESSION_LIST_CACHE_TTL:
+        return cached[1]
     raw = run_herdr("session", "list", remote=remote)
     sessions = []
     for line in raw.splitlines():
@@ -403,6 +431,7 @@ def get_sessions(remote=None):
         if len(parts) < 2 or parts[0] == "name":
             continue
         sessions.append({"name": parts[0], "running": parts[1] == "running"})
+    _session_list_cache[remote] = (time.monotonic(), sessions)
     return sessions
 
 
@@ -438,6 +467,10 @@ def reset_pane_state():
     Also drains event_queue: a pre-switch agent_event dequeued after this call
     must not be able to re-seed state under a stale pane_id. Must only ever
     be called from the event-loop thread; POLL_GENERATION += 1 is not atomic.
+
+    Also clears _session_list_cache: a real switch must always be validated
+    and displayed against a freshly read session list, never a pre-switch
+    one still inside its TTL.
     """
     global POLL_GENERATION
     known_panes.clear()
@@ -445,6 +478,7 @@ def reset_pane_state():
     pane_remote_map.clear()
     last_statuses.clear()
     last_blocked_prompts.clear()
+    _session_list_cache.clear()
     while True:
         try:
             event_queue.get_nowait()
@@ -463,27 +497,34 @@ def _source_key(host):
 
 
 def apply_session_switch(host, session, ip="", device=""):
-    """Point one source at a session. Returns (ok, error_message)."""
+    """Point one source at a session. Returns (ok, error_message, changed).
+
+    `changed` is False on the no-op path (already-active selection) and on
+    any rejection, True only when ACTIVE_SESSIONS was actually mutated.
+    Callers must skip the broadcast + re-poll when it's False -- that's the
+    expensive part the no-op short-circuit below exists to avoid, and it is
+    defeated if the caller runs it anyway.
+    """
     try:
         source = _source_key(host)
     except KeyError:
-        return False, f"unknown host: {host}"
+        return False, f"unknown host: {host}", False
 
     # Re-selecting the already-active session is a no-op: skip the blocking
     # `herdr session list` call and, crucially, the pane-state reset below.
     # `source in ACTIVE_SESSIONS` (not `.get()`) matters here -- a key that
     # has never been set is not the same thing as an explicit None value.
     if source in ACTIVE_SESSIONS and ACTIVE_SESSIONS[source] == session:
-        return True, ""
+        return True, "", False
 
     if session is not None:
         if not isinstance(session, str):
             # session lands in a set-membership check next; a list/dict is
             # unhashable there and would raise instead of being rejected.
-            return False, f"unknown session: {session}"
+            return False, f"unknown session: {session}", False
         names = {s["name"] for s in get_sessions(remote=source)}
         if session not in names:
-            return False, f"unknown session: {session}"
+            return False, f"unknown session: {session}", False
 
     ACTIVE_SESSIONS[source] = session
     try:
@@ -496,10 +537,11 @@ def apply_session_switch(host, session, ip="", device=""):
     reset_pane_state()
     audit("session_switch", ip, device, "", f"host={host} session={session}")
     log.info("session switch: host=%s session=%s", host, session)
-    return True, ""
+    return True, "", True
 
 
 SESSION_REFRESH_EVERY = 15   # poll cycles; 30s at POLL_INTERVAL=2
+SESSION_LIST_CACHE_TTL = SESSION_REFRESH_EVERY * POLL_INTERVAL   # 30s
 
 
 def sessions_message():
@@ -517,6 +559,18 @@ def sessions_message():
 async def broadcast_sessions():
     gen = POLL_GENERATION
     msg = sessions_message()
+    # This guard cannot fire today: sessions_message -> get_sessions ->
+    # run_herdr -> subprocess.run is entirely synchronous, so nothing can
+    # bump POLL_GENERATION between the two lines above. It stays correct
+    # and becomes load-bearing the moment that chain gains an await (e.g.
+    # a future to_thread fix for the blocking subprocess call).
+    #
+    # It does NOT cover the real staleness window: broadcast() below awaits
+    # ws.send() once per client, so a switch landing mid fan-out can still
+    # let a client late in that loop see a pre-switch `active` value. That
+    # window is shared by every message type, self-heals within one
+    # refresh cycle (~30s), and closing it means touching broadcast()
+    # itself.
     if gen != POLL_GENERATION:
         return          # a switch landed while building this; the message is stale
     await broadcast(msg)
@@ -916,6 +970,12 @@ async def event_push():
                 host,
                 content or agent_data.get("prompt", "Agent is blocked"),
             )
+            # Unreachable with a mismatch today: whichever branch got here
+            # did so with no await since the last gen check (the "agents"
+            # broadcast above already `continue`s on staleness before this
+            # point, and read_pane/blocked_message are synchronous), so gen
+            # cannot have changed. Kept as a guard for a future refactor
+            # that inserts an await between this check and the writes below.
             if gen != POLL_GENERATION:
                 continue        # a switch landed; this event is stale
             last_blocked_prompts[pane_id] = (
@@ -1177,14 +1237,18 @@ async def handle_client(ws):
                 await ws.send(json.dumps(response))
             elif msg_type == "session_switch":
                 request_id = msg.get("request_id")
-                ok, err = apply_session_switch(msg.get("host"), msg.get("session"), ip, device)
+                ok, err, changed = apply_session_switch(msg.get("host"), msg.get("session"), ip, device)
                 if not ok:
                     response = {"type": "error", "message": err}
                     if request_id:
                         response["request_id"] = request_id
                     await ws.send(json.dumps(response))
                 else:
-                    await broadcast_sessions()
+                    # A no-op switch (already-active selection) still acks,
+                    # but must skip the broadcast and re-poll -- that's the
+                    # expensive part `changed` exists to let us avoid.
+                    if changed:
+                        await broadcast_sessions()
                     if request_id:
                         await ws.send(json.dumps({
                             "type": "command_result",
@@ -1192,7 +1256,11 @@ async def handle_client(ws):
                             "request_id": request_id,
                             "ok": True,
                         }))
-                    await _poll_once()
+                    if changed:
+                        try:
+                            await _poll_once()
+                        except Exception:
+                            log.exception("post-switch poll failed")
             elif msg_type == "agent_event":
                 event_queue.put_nowait(msg)
             elif msg_type == "read_pane":

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -515,7 +515,11 @@ def sessions_message():
 
 
 async def broadcast_sessions():
-    await broadcast(sessions_message())
+    gen = POLL_GENERATION
+    msg = sessions_message()
+    if gen != POLL_GENERATION:
+        return          # a switch landed while building this; the message is stale
+    await broadcast(msg)
 
 
 def read_pane(pane_id, remote=None):
@@ -1180,6 +1184,7 @@ async def handle_client(ws):
                         response["request_id"] = request_id
                     await ws.send(json.dumps(response))
                 else:
+                    await broadcast_sessions()
                     if request_id:
                         await ws.send(json.dumps({
                             "type": "command_result",
@@ -1187,7 +1192,6 @@ async def handle_client(ws):
                             "request_id": request_id,
                             "ok": True,
                         }))
-                    await broadcast_sessions()
                     await _poll_once()
             elif msg_type == "agent_event":
                 event_queue.put_nowait(msg)

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -462,22 +462,39 @@ def _source_key(host):
     raise KeyError(host)
 
 
-def apply_session_switch(host, session):
+def apply_session_switch(host, session, ip="", device=""):
     """Point one source at a session. Returns (ok, error_message)."""
     try:
         source = _source_key(host)
     except KeyError:
         return False, f"unknown host: {host}"
 
+    # Re-selecting the already-active session is a no-op: skip the blocking
+    # `herdr session list` call and, crucially, the pane-state reset below.
+    # `source in ACTIVE_SESSIONS` (not `.get()`) matters here -- a key that
+    # has never been set is not the same thing as an explicit None value.
+    if source in ACTIVE_SESSIONS and ACTIVE_SESSIONS[source] == session:
+        return True, ""
+
     if session is not None:
+        if not isinstance(session, str):
+            # session lands in a set-membership check next; a list/dict is
+            # unhashable there and would raise instead of being rejected.
+            return False, f"unknown session: {session}"
         names = {s["name"] for s in get_sessions(remote=source)}
         if session not in names:
             return False, f"unknown session: {session}"
 
     ACTIVE_SESSIONS[source] = session
-    _save_active_sessions()
+    try:
+        _save_active_sessions()
+    except Exception:
+        # A save failure must not half-apply the switch: pane state still
+        # has to reset and the action still has to audit, or stale
+        # pane-keyed state survives under the newly active session.
+        log.exception("failed to persist active sessions: host=%s session=%s", host, session)
     reset_pane_state()
-    audit("session_switch", "", "", "", f"host={host} session={session}")
+    audit("session_switch", ip, device, "", f"host={host} session={session}")
     log.info("session switch: host=%s session=%s", host, session)
     return True, ""
 

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -499,6 +499,25 @@ def apply_session_switch(host, session, ip="", device=""):
     return True, ""
 
 
+SESSION_REFRESH_EVERY = 15   # poll cycles; 30s at POLL_INTERVAL=2
+
+
+def sessions_message():
+    """Per-source session lists and the active selection for each."""
+    sources = []
+    for source in [None, *REMOTES]:
+        sources.append({
+            "host": "local" if source is None else source,
+            "active": active_session_for(source),
+            "sessions": get_sessions(remote=source),
+        })
+    return {"type": "sessions", "sources": sources}
+
+
+async def broadcast_sessions():
+    await broadcast(sessions_message())
+
+
 def read_pane(pane_id, remote=None):
     raw = run_herdr("pane", "read", pane_id, "--lines", "100", "--source", "recent", remote=remote)
     lines = [l for l in raw.splitlines() if l.strip() and not CHROME_RE.search(l)]
@@ -766,6 +785,7 @@ async def broadcast(msg):
     clients.difference_update(dead)
 
 async def send_current_snapshot(ws):
+    await ws.send(json.dumps(sessions_message()))
     agents = get_all_agents()
     update_pane_maps(agents)
     await ws.send(json.dumps({"type": "agents", "agents": agents}))
@@ -783,11 +803,15 @@ async def send_current_snapshot(ws):
 
 
 async def poll_loop():
+    cycle = 0
     while True:
         try:
             await _poll_once()
+            if cycle % SESSION_REFRESH_EVERY == 0:
+                await broadcast_sessions()
         except Exception:
             log.exception("poll cycle failed; retrying")
+        cycle += 1
         await asyncio.sleep(POLL_INTERVAL)
 
 
@@ -1147,6 +1171,24 @@ async def handle_client(ws):
                 if request_id:
                     response["request_id"] = request_id
                 await ws.send(json.dumps(response))
+            elif msg_type == "session_switch":
+                request_id = msg.get("request_id")
+                ok, err = apply_session_switch(msg.get("host"), msg.get("session"), ip, device)
+                if not ok:
+                    response = {"type": "error", "message": err}
+                    if request_id:
+                        response["request_id"] = request_id
+                    await ws.send(json.dumps(response))
+                else:
+                    if request_id:
+                        await ws.send(json.dumps({
+                            "type": "command_result",
+                            "command": "session_switch",
+                            "request_id": request_id,
+                            "ok": True,
+                        }))
+                    await broadcast_sessions()
+                    await _poll_once()
             elif msg_type == "agent_event":
                 event_queue.put_nowait(msg)
             elif msg_type == "read_pane":

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -103,6 +103,7 @@ VAPID_PRIVATE_KEY = os.environ.get("HERDR_VAPID_PRIVATE", "")
 VAPID_SUBJECT = os.environ.get("HERDR_VAPID_SUBJECT", "mailto:herdr@localhost")
 push_subscriptions = []  # list of PushSubscription dicts
 PUSH_SUBS_FILE = os.path.join(LOG_DIR, "push_subs.json")
+ACTIVE_SESSIONS_FILE = os.path.join(LOG_DIR, "active_sessions.json")
 
 if RELAY_HOST not in {"127.0.0.1", "localhost", "::1"} and not AUTH_TOKEN:
     raise SystemExit("HERDR_RELAY_TOKEN is required when HERDR_RELAY_HOST binds beyond loopback")
@@ -258,6 +259,27 @@ def _save_push_subs():
         json.dump(push_subscriptions, f)
 
 
+def _load_active_sessions():
+    """Restore session selection. Mirrors _load_push_subs: never raises."""
+    if not os.path.isfile(ACTIVE_SESSIONS_FILE):
+        return
+    try:
+        with open(ACTIVE_SESSIONS_FILE) as f:
+            stored = json.load(f)
+        if not isinstance(stored, dict):
+            return
+    except Exception:
+        return
+    for key, value in stored.items():
+        ACTIVE_SESSIONS[None if key == "local" else key] = value
+
+
+def _save_active_sessions():
+    payload = {("local" if k is None else k): v for k, v in ACTIVE_SESSIONS.items()}
+    with open(ACTIVE_SESSIONS_FILE, "w") as f:
+        json.dump(payload, f)
+
+
 async def send_web_push(title: str, body: str, url: str = "/", clear: bool = False):
     """Send push notification to all registered subscriptions.
     
@@ -296,6 +318,7 @@ async def send_web_push(title: str, body: str, url: str = "/", clear: bool = Fal
         _save_push_subs()
 
 _load_push_subs()
+_load_active_sessions()
 
 
 def _invoke_herdr(*args, remote=None):

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -333,6 +333,18 @@ def get_all_agents():
     return agents
 
 
+def get_sessions(remote=None):
+    """List herdr sessions for one source as [{"name", "running"}]."""
+    raw = run_herdr("session", "list", remote=remote)
+    sessions = []
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) < 2 or parts[0] == "name":
+            continue
+        sessions.append({"name": parts[0], "running": parts[1] == "running"})
+    return sessions
+
+
 def update_pane_maps(agents):
     current_pane_ids = {agent["pane_id"] for agent in agents}
     for agent in agents:

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -434,6 +434,10 @@ def reset_pane_state():
     prunes only panes absent from the new list, so a pane_id present in both
     sessions would carry its state across a switch — suppressing a real blocked
     notification, or letting a command route to the wrong session's agent.
+
+    Also drains event_queue: a pre-switch agent_event dequeued after this call
+    must not be able to re-seed state under a stale pane_id. Must only ever
+    be called from the event-loop thread; POLL_GENERATION += 1 is not atomic.
     """
     global POLL_GENERATION
     known_panes.clear()
@@ -441,6 +445,11 @@ def reset_pane_state():
     pane_remote_map.clear()
     last_statuses.clear()
     last_blocked_prompts.clear()
+    while True:
+        try:
+            event_queue.get_nowait()
+        except asyncio.QueueEmpty:
+            break
     POLL_GENERATION += 1
 
 
@@ -782,6 +791,7 @@ async def _poll_once():
 async def event_push():
     while True:
         event = await event_queue.get()
+        gen = POLL_GENERATION
         pane_id = event.get("pane_id", "")
         update = None
         if pane_id and event.get("type") == "agent_event":
@@ -813,6 +823,8 @@ async def event_push():
                 })
             update_pane_maps(agents)
             await broadcast({"type": "agents", "agents": agents})
+            if gen != POLL_GENERATION:
+                continue        # a switch landed; this event is stale
             agent_cache[pane_id] = {**agent_cache.get(pane_id, {}), **agent_data}
             if status != "blocked":
                 await broadcast(update)
@@ -830,6 +842,8 @@ async def event_push():
                 host,
                 content or agent_data.get("prompt", "Agent is blocked"),
             )
+            if gen != POLL_GENERATION:
+                continue        # a switch landed; this event is stale
             last_blocked_prompts[pane_id] = (
                 message["prompt_id"],
                 tuple(message["selected_options"]),

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -424,6 +424,26 @@ def update_pane_maps(agents):
             agent_cache.pop(pane_id, None)
 
 
+POLL_GENERATION = 0
+
+
+def reset_pane_state():
+    """Drop all pane-keyed state and invalidate in-flight polls.
+
+    pane_id is session-local: w1:p1 exists in every session. update_pane_maps
+    prunes only panes absent from the new list, so a pane_id present in both
+    sessions would carry its state across a switch — suppressing a real blocked
+    notification, or letting a command route to the wrong session's agent.
+    """
+    global POLL_GENERATION
+    known_panes.clear()
+    agent_cache.clear()
+    pane_remote_map.clear()
+    last_statuses.clear()
+    last_blocked_prompts.clear()
+    POLL_GENERATION += 1
+
+
 def read_pane(pane_id, remote=None):
     raw = run_herdr("pane", "read", pane_id, "--lines", "100", "--source", "recent", remote=remote)
     lines = [l for l in raw.splitlines() if l.strip() and not CHROME_RE.search(l)]
@@ -717,10 +737,13 @@ async def poll_loop():
 
 
 async def _poll_once():
+        gen = POLL_GENERATION
         agents = get_all_agents()
         update_pane_maps(agents)
         # Always broadcast (even empty list) so clients stay in sync
         await broadcast({"type": "agents", "agents": agents})
+        if gen != POLL_GENERATION:
+            return          # a switch landed; this snapshot is stale
         for a in agents:
             pid, status = a["pane_id"], a["status"]
             if status == "blocked":
@@ -747,9 +770,13 @@ async def _poll_once():
                         body=content[:120],
                         url=f"/?pane={pid}",
                     )
+                    if gen != POLL_GENERATION:
+                        return
             else:
                 if last_statuses.get(pid) == "blocked":
                     await send_web_push("", "", clear=True)
+                    if gen != POLL_GENERATION:
+                        return
                 last_blocked_prompts.pop(pid, None)
             last_statuses[pid] = status
 async def event_push():

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -453,6 +453,35 @@ def reset_pane_state():
     POLL_GENERATION += 1
 
 
+def _source_key(host):
+    """Map a client-supplied host to a source key, or raise KeyError."""
+    if host in (None, "", "local"):
+        return None
+    if host in REMOTES:
+        return host
+    raise KeyError(host)
+
+
+def apply_session_switch(host, session):
+    """Point one source at a session. Returns (ok, error_message)."""
+    try:
+        source = _source_key(host)
+    except KeyError:
+        return False, f"unknown host: {host}"
+
+    if session is not None:
+        names = {s["name"] for s in get_sessions(remote=source)}
+        if session not in names:
+            return False, f"unknown session: {session}"
+
+    ACTIVE_SESSIONS[source] = session
+    _save_active_sessions()
+    reset_pane_state()
+    audit("session_switch", "", "", "", f"host={host} session={session}")
+    log.info("session switch: host=%s session=%s", host, session)
+    return True, ""
+
+
 def read_pane(pane_id, remote=None):
     raw = run_herdr("pane", "read", pane_id, "--lines", "100", "--source", "recent", remote=remote)
     lines = [l for l in raw.splitlines() if l.strip() and not CHROME_RE.search(l)]

--- a/relay/herdr_telegram.py
+++ b/relay/herdr_telegram.py
@@ -52,6 +52,7 @@ daily_stats: dict[str, dict] = {}  # pane_id -> {agent, project, blocked_count, 
 AGENT_PAGE_SIZE = 20
 PENDING_LIMIT = 500
 COMMAND_ACK_TIMEOUT = 20
+PANE_READ_TIMEOUT = 20
 STATUS_ORDER = {"blocked": 0, "working": 1, "done": 2, "idle": 3, "unknown": 3}
 STATUS_LABELS = {"blocked": "BLOCKED", "working": "WORKING", "done": "DONE", "idle": "IDLE", "unknown": "IDLE"}
 ACTION_CODES = {
@@ -130,17 +131,21 @@ async def read_pane(pane_id: str, lines: int = 15) -> str:
     try:
         async with websockets.connect(RELAY_WS) as ws:
             await ws.send(json.dumps({"type": "read_pane", "pane_id": pane_id, "lines": lines}))
-            raw = await asyncio.wait_for(ws.recv(), timeout=5)
-            msg = json.loads(raw)
-            # Might get an agents broadcast first, skip to pane_content
-            for _ in range(5):
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + PANE_READ_TIMEOUT
+            # The connect preamble (sessions/agents/one-blocked-per-blocked-
+            # agent) can put any number of unrelated messages ahead of
+            # pane_content. Skip by deadline, not by a fixed message count.
+            while True:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return "(no response)"
+                raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                msg = json.loads(raw)
                 if msg.get("type") == "pane_content":
                     return msg.get("content", "(empty)")
-                raw = await asyncio.wait_for(ws.recv(), timeout=3)
-                msg = json.loads(raw)
     except Exception as e:
         return f"(error reading pane: {scrub(e)})"
-    return "(no response)"
 
 
 async def send_text_to_relay(pane_id: str, text: str):

--- a/relay/herdr_telegram_demo.py
+++ b/relay/herdr_telegram_demo.py
@@ -14,6 +14,7 @@ log = logging.getLogger("herdr-demo-tg")
 
 TOKEN = os.environ.get("HERDR_DEMO_TG_TOKEN", "")
 DEMO_RELAY = "wss://herdr-remote-demo.yyrzrh5wfg.workers.dev"
+PANE_READ_TIMEOUT = 15  # was 5 messages * 3s; kept as one deadline instead
 
 if not TOKEN:
     print("Set HERDR_DEMO_TG_TOKEN")
@@ -94,12 +95,24 @@ async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         try:
             async with websockets.connect(DEMO_RELAY) as ws:
                 await ws.send(json.dumps({"type": "read_pane", "pane_id": data["pane_id"]}))
-                for _ in range(5):
-                    raw = await asyncio.wait_for(ws.recv(), timeout=3)
+                loop = asyncio.get_running_loop()
+                deadline = loop.time() + PANE_READ_TIMEOUT
+                # The connect preamble (sessions/agents/one-blocked-per-blocked-
+                # agent) can put any number of unrelated messages ahead of
+                # pane_content. Skip by deadline, not by a fixed message count
+                # -- same fix as herdr_telegram.py's read_pane; this relay
+                # happens to never emit `sessions` today, but a fixed count
+                # is one relay change away from breaking here too.
+                while True:
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        break
+                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
                     msg = json.loads(raw)
                     if msg.get("type") == "pane_content":
                         await query.message.reply_text(msg.get("content", "(empty)"))
                         return
+            await query.message.reply_text("(demo read timeout)")
         except:
             await query.message.reply_text("(demo read timeout)")
         return

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -75,9 +75,15 @@ WEB="$DIR/web/index.html"
 grep -q "WebSocket" "$WEB" && grep -q "theme" "$WEB" && grep -q "sendKey" "$WEB"
 assert_eq "$?" "0" "has WebSocket, themes, keyboard"
 
-grep -q 'id="sessionSelector"' "$DIR/web/index.html" && \
-grep -q "session_switch" "$DIR/web/index.html"
+echo "9b. web app has session selector"
+grep -q 'id="sessionSelector"' "$WEB" && \
+grep -q "session_switch" "$WEB"
 assert_eq "$?" "0" "web app has session selector"
+
+echo "9c. web app has no duplicate function declarations"
+DUP_FUNCS=$(grep -oE '^[[:space:]]*function [A-Za-z0-9_]+\(' "$WEB" | grep -oE '[A-Za-z0-9_]+\(' | sort | uniq -d)
+[ -z "$DUP_FUNCS" ]
+assert_eq "$?" "0" "no duplicate function declarations"
 
 echo "10. web app no hardcoded secrets"
 ! grep -q "c4a2385e" "$WEB" && ! grep -q "graffold" "$WEB"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -75,6 +75,10 @@ WEB="$DIR/web/index.html"
 grep -q "WebSocket" "$WEB" && grep -q "theme" "$WEB" && grep -q "sendKey" "$WEB"
 assert_eq "$?" "0" "has WebSocket, themes, keyboard"
 
+grep -q 'id="sessionSelector"' "$DIR/web/index.html" && \
+grep -q "session_switch" "$DIR/web/index.html"
+assert_eq "$?" "0" "web app has session selector"
+
 echo "10. web app no hardcoded secrets"
 ! grep -q "c4a2385e" "$WEB" && ! grep -q "graffold" "$WEB"
 assert_eq "$?" "0" "no secrets in web app"

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -623,6 +623,39 @@ class RelaySessionSwitchTests(unittest.TestCase):
             self.assertEqual(err, "")
             self.assertIn("w1:p1", relay.known_panes)
 
+    def test_sessions_message_shape(self):
+        with loaded_relay() as relay:
+            relay.REMOTES.clear()
+            relay.ACTIVE_SESSIONS.clear()
+            relay.ACTIVE_SESSIONS[None] = "personal"
+
+            with mock.patch.object(relay, "get_sessions", return_value=[
+                        {"name": "default", "running": False},
+                        {"name": "personal", "running": True}]):
+                message = relay.sessions_message()
+
+            self.assertEqual(message["type"], "sessions")
+            self.assertEqual(len(message["sources"]), 1)
+            source = message["sources"][0]
+            self.assertEqual(source["host"], "local")
+            self.assertEqual(source["active"], "personal")
+            self.assertEqual(
+                source["sessions"],
+                [{"name": "default", "running": False},
+                 {"name": "personal", "running": True}],
+            )
+
+    def test_sessions_message_includes_each_remote(self):
+        with loaded_relay() as relay:
+            relay.REMOTES[:] = ["user@host"]
+            relay.ACTIVE_SESSIONS.clear()
+
+            with mock.patch.object(relay, "get_sessions", return_value=[]):
+                message = relay.sessions_message()
+
+            self.assertEqual([s["host"] for s in message["sources"]],
+                             ["local", "user@host"])
+
 
 class RelayResponseTests(unittest.TestCase):
     def test_respond_sends_correlated_acknowledgement(self):

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -211,6 +211,68 @@ class RelaySessionSwitchTests(unittest.TestCase):
                     with mock.patch.object(relay, "run_herdr", return_value=raw):
                         self.assertEqual(relay.get_sessions(), [])
 
+    def test_herdr_env_sets_session_when_active(self):
+        with loaded_relay() as relay:
+            env = relay._herdr_env("personal")
+            self.assertEqual(env["HERDR_SESSION"], "personal")
+
+    def test_herdr_env_strips_inherited_session_for_default(self):
+        # The relay's own env pins a session via config.env. Following herdr's
+        # default session means removing it, not inheriting it.
+        with loaded_relay() as relay:
+            with mock.patch.dict(
+                relay.os.environ,
+                {"HERDR_SESSION": "personal", "HERDR_SOCKET_PATH": "/tmp/x.sock"},
+            ):
+                env = relay._herdr_env(None)
+
+            self.assertNotIn("HERDR_SESSION", env)
+            self.assertNotIn("HERDR_SOCKET_PATH", env)
+
+    def test_active_session_falls_back_to_env_default_for_local(self):
+        with loaded_relay() as relay:
+            relay.ACTIVE_SESSIONS.clear()
+            relay.DEFAULT_LOCAL_SESSION = "personal"
+
+            self.assertEqual(relay.active_session_for(None), "personal")
+            # A remote has no env default; it follows its own default session.
+            self.assertIsNone(relay.active_session_for("user@host"))
+
+    def test_active_session_prefers_explicit_selection(self):
+        with loaded_relay() as relay:
+            relay.DEFAULT_LOCAL_SESSION = "personal"
+            relay.ACTIVE_SESSIONS[None] = "default"
+
+            self.assertEqual(relay.active_session_for(None), "default")
+
+    def test_explicit_none_overrides_env_default(self):
+        # Selecting "herdr's default session" must not fall back to the env.
+        with loaded_relay() as relay:
+            relay.DEFAULT_LOCAL_SESSION = "personal"
+            relay.ACTIVE_SESSIONS[None] = None
+
+            self.assertIsNone(relay.active_session_for(None))
+
+    def test_remote_invocation_prefixes_session_assignment(self):
+        with loaded_relay() as relay:
+            relay.ACTIVE_SESSIONS["user@host"] = "personal"
+            captured = {}
+
+            def fake_run(cmd, **kwargs):
+                captured["cmd"] = cmd
+                captured["env"] = kwargs.get("env")
+                return types.SimpleNamespace(stdout="", returncode=0)
+
+            with mock.patch.object(relay.subprocess, "run", side_effect=fake_run):
+                relay._invoke_herdr("pane", "list", remote="user@host")
+
+            self.assertIn("HERDR_SESSION=personal", captured["cmd"])
+            # The assignment must precede the binary in the remote argv.
+            self.assertLess(
+                captured["cmd"].index("HERDR_SESSION=personal"),
+                captured["cmd"].index(relay.REMOTE_HERDR),
+            )
+
 
 class RelayResponseTests(unittest.TestCase):
     def test_respond_sends_correlated_acknowledgement(self):

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -273,6 +273,43 @@ class RelaySessionSwitchTests(unittest.TestCase):
                 captured["cmd"].index(relay.REMOTE_HERDR),
             )
 
+    def test_active_sessions_round_trip_through_state_file(self):
+        with loaded_relay() as relay:
+            with tempfile.TemporaryDirectory() as tmp:
+                path = os.path.join(tmp, "active_sessions.json")
+                with mock.patch.object(relay, "ACTIVE_SESSIONS_FILE", path):
+                    relay.ACTIVE_SESSIONS.clear()
+                    relay.ACTIVE_SESSIONS[None] = "default"
+                    relay.ACTIVE_SESSIONS["user@host"] = "personal"
+                    relay._save_active_sessions()
+
+                    # JSON has no null keys, so local is stored as "local".
+                    with open(path) as f:
+                        self.assertEqual(
+                            json.load(f), {"local": "default", "user@host": "personal"}
+                        )
+
+                    relay.ACTIVE_SESSIONS.clear()
+                    relay._load_active_sessions()
+                    self.assertEqual(
+                        relay.ACTIVE_SESSIONS,
+                        {None: "default", "user@host": "personal"},
+                    )
+
+    def test_load_active_sessions_tolerates_missing_and_corrupt_file(self):
+        for content in (None, "not json", "[1,2,3]"):
+            with self.subTest(content=content):
+                with loaded_relay() as relay:
+                    with tempfile.TemporaryDirectory() as tmp:
+                        path = os.path.join(tmp, "active_sessions.json")
+                        if content is not None:
+                            with open(path, "w") as f:
+                                f.write(content)
+                        with mock.patch.object(relay, "ACTIVE_SESSIONS_FILE", path):
+                            relay.ACTIVE_SESSIONS.clear()
+                            relay._load_active_sessions()
+                            self.assertEqual(relay.ACTIVE_SESSIONS, {})
+
 
 class RelayResponseTests(unittest.TestCase):
     def test_respond_sends_correlated_acknowledgement(self):

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -650,11 +650,114 @@ class RelaySessionSwitchTests(unittest.TestCase):
             relay.REMOTES[:] = ["user@host"]
             relay.ACTIVE_SESSIONS.clear()
 
-            with mock.patch.object(relay, "get_sessions", return_value=[]):
+            with mock.patch.object(relay, "get_sessions", return_value=[]) as get_sessions:
                 message = relay.sessions_message()
 
             self.assertEqual([s["host"] for s in message["sources"]],
                              ["local", "user@host"])
+            # Pins per-source correctness: a call to get_sessions() with no
+            # `remote` (always listing LOCAL) would produce the same host
+            # list above but silently report local sessions under every
+            # remote's host.
+            get_sessions.assert_has_calls(
+                [mock.call(remote=None), mock.call(remote="user@host")]
+            )
+
+    def test_broadcast_sessions_skips_send_when_generation_changes_mid_build(self):
+        # get_sessions() is called synchronously while building the message;
+        # if a switch lands (bumping POLL_GENERATION) during that build, the
+        # message reflects a mix of pre/post-switch state and must not go out.
+        with loaded_relay() as relay:
+            def stale_get_sessions(remote=None):
+                relay.reset_pane_state()  # simulates a switch landing mid-build
+                return []
+
+            with mock.patch.object(relay, "get_sessions", side_effect=stale_get_sessions), \
+                 mock.patch.object(relay, "broadcast", new=mock.AsyncMock()) as broadcast_mock:
+                asyncio.run(relay.broadcast_sessions())
+
+            broadcast_mock.assert_not_awaited()
+
+    def test_session_switch_applies_with_caller_identity_then_broadcasts_acks_and_repolls(self):
+        with loaded_relay() as relay:
+            request_id = "switch-1"
+            ws = _FakeWebSocket(
+                [json.dumps({
+                    "type": "session_switch",
+                    "host": "user@host",
+                    "session": "personal",
+                    "request_id": request_id,
+                })],
+                headers={"X-Herdr-Remote-Command": "1"},
+            )
+            order = []
+
+            def fake_apply(host, session, ip, device):
+                order.append(("apply", host, session, ip, device))
+                return True, ""
+
+            async def fake_broadcast_sessions():
+                order.append(("broadcast_sessions",))
+
+            async def fake_poll_once():
+                order.append(("poll_once",))
+
+            async def record_send(message):
+                order.append(("send", message))
+
+            ws.send = record_send
+
+            with mock.patch.object(relay, "apply_session_switch", side_effect=fake_apply) as apply_mock, \
+                 mock.patch.object(relay, "broadcast_sessions", side_effect=fake_broadcast_sessions), \
+                 mock.patch.object(relay, "_poll_once", side_effect=fake_poll_once):
+                asyncio.run(relay.handle_client(ws))
+
+            apply_mock.assert_called_once_with("user@host", "personal", "127.0.0.1", "script")
+            self.assertEqual(
+                [step[0] for step in order],
+                ["apply", "broadcast_sessions", "send", "poll_once"],
+            )
+            self.assertEqual(
+                json.loads(order[2][1]),
+                {
+                    "type": "command_result",
+                    "command": "session_switch",
+                    "request_id": request_id,
+                    "ok": True,
+                },
+            )
+
+    def test_session_switch_rejected_sends_error_with_request_id_and_skips_broadcast(self):
+        with loaded_relay() as relay:
+            request_id = "switch-2"
+            ws = _FakeWebSocket(
+                [json.dumps({
+                    "type": "session_switch",
+                    "host": "bogus",
+                    "session": "default",
+                    "request_id": request_id,
+                })],
+                headers={"X-Herdr-Remote-Command": "1"},
+            )
+
+            with mock.patch.object(
+                        relay, "apply_session_switch",
+                        return_value=(False, "unknown host: bogus")) as apply_mock, \
+                 mock.patch.object(relay, "broadcast_sessions", new=mock.AsyncMock()) as broadcast_mock, \
+                 mock.patch.object(relay, "_poll_once", new=mock.AsyncMock()) as poll_mock:
+                asyncio.run(relay.handle_client(ws))
+
+            apply_mock.assert_called_once_with("bogus", "default", "127.0.0.1", "script")
+            self.assertEqual(
+                json.loads(ws.sent[-1]),
+                {
+                    "type": "error",
+                    "message": "unknown host: bogus",
+                    "request_id": request_id,
+                },
+            )
+            broadcast_mock.assert_not_awaited()
+            poll_mock.assert_not_awaited()
 
 
 class RelayResponseTests(unittest.TestCase):

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -204,6 +204,39 @@ class RelaySessionSwitchTests(unittest.TestCase):
                  {"name": "personal", "running": True}],
             )
 
+    def test_get_sessions_forwards_remote_to_run_herdr(self):
+        # The one unpinned hop: a regression that dropped `remote=` here
+        # would validate a *remote* switch against *local* session names --
+        # a validation bypass. Not caught by shape alone; pin the call arg.
+        with loaded_relay() as relay:
+            with mock.patch.object(relay, "run_herdr", return_value=self.SESSION_LIST) as run_herdr:
+                relay.get_sessions(remote="user@host")
+
+            run_herdr.assert_called_once_with("session", "list", remote="user@host")
+
+    def test_get_sessions_caches_within_ttl(self):
+        # sessions_message() calls this once per source on every client
+        # connect, each a blocking subprocess; a second call within the TTL
+        # must not pay for another one.
+        with loaded_relay() as relay:
+            with mock.patch.object(relay, "run_herdr", return_value=self.SESSION_LIST) as run_herdr:
+                first = relay.get_sessions(remote="user@host")
+                second = relay.get_sessions(remote="user@host")
+
+            self.assertEqual(first, second)
+            run_herdr.assert_called_once_with("session", "list", remote="user@host")
+
+    def test_reset_pane_state_clears_session_list_cache(self):
+        # A real switch must always validate and display against a freshly
+        # read session list, never a pre-switch one still inside its TTL.
+        with loaded_relay() as relay:
+            with mock.patch.object(relay, "run_herdr", return_value=self.SESSION_LIST) as run_herdr:
+                relay.get_sessions(remote="user@host")
+                relay.reset_pane_state()
+                relay.get_sessions(remote="user@host")
+
+            self.assertEqual(run_herdr.call_count, 2)
+
     def test_get_sessions_returns_empty_on_unusable_output(self):
         for raw in ("", "   ", "name status\n", "garbage"):
             with self.subTest(raw=raw):
@@ -260,7 +293,7 @@ class RelaySessionSwitchTests(unittest.TestCase):
 
             def fake_run(cmd, **kwargs):
                 captured["cmd"] = cmd
-                captured["env"] = kwargs.get("env")
+                captured["kwargs"] = kwargs
                 return types.SimpleNamespace(stdout="", returncode=0)
 
             with mock.patch.object(relay.subprocess, "run", side_effect=fake_run):
@@ -272,6 +305,9 @@ class RelaySessionSwitchTests(unittest.TestCase):
                 captured["cmd"].index("HERDR_SESSION=personal"),
                 captured["cmd"].index(relay.REMOTE_HERDR),
             )
+            # An env= kwarg would not survive ssh; the remote session
+            # assignment must travel via argv only, never the child env.
+            self.assertNotIn("env", captured["kwargs"])
 
     def test_active_sessions_round_trip_through_state_file(self):
         with loaded_relay() as relay:
@@ -295,6 +331,22 @@ class RelaySessionSwitchTests(unittest.TestCase):
                         relay.ACTIVE_SESSIONS,
                         {None: "default", "user@host": "personal"},
                     )
+
+    def test_load_active_sessions_ignores_non_string_values(self):
+        # {"local": 5} parses and is a dict, but 5 would flow into
+        # _herdr_env and make subprocess.run(env=...) raise TypeError,
+        # which run_herdr swallows -- silently zeroing the agent list
+        # forever, surviving every restart. The valid sibling entry must
+        # still load: this isn't a whole-file reject, just a per-value one.
+        with loaded_relay() as relay:
+            with tempfile.TemporaryDirectory() as tmp:
+                path = os.path.join(tmp, "active_sessions.json")
+                with open(path, "w") as f:
+                    json.dump({"local": 5, "user@host": "personal"}, f)
+                with mock.patch.object(relay, "ACTIVE_SESSIONS_FILE", path):
+                    relay.ACTIVE_SESSIONS.clear()
+                    relay._load_active_sessions()
+                    self.assertEqual(relay.ACTIVE_SESSIONS, {"user@host": "personal"})
 
     def test_load_active_sessions_tolerates_missing_and_corrupt_file(self):
         for content in (None, "not json", "[1,2,3]"):
@@ -486,10 +538,11 @@ class RelaySessionSwitchTests(unittest.TestCase):
                  mock.patch.object(relay, "_save_active_sessions",
                                    side_effect=lambda: saved.update(relay.ACTIVE_SESSIONS)), \
                  mock.patch.object(relay, "audit"):
-                ok, err = relay.apply_session_switch("local", "default")
+                ok, err, changed = relay.apply_session_switch("local", "default")
 
             self.assertTrue(ok)
             self.assertEqual(err, "")
+            self.assertTrue(changed)
             self.assertEqual(relay.ACTIVE_SESSIONS[None], "default")
             self.assertEqual(saved[None], "default")
             self.assertEqual(relay.known_panes, set())   # reset happened
@@ -500,9 +553,10 @@ class RelaySessionSwitchTests(unittest.TestCase):
                         {"name": "personal", "running": True}]), \
                  mock.patch.object(relay, "_save_active_sessions"), \
                  mock.patch.object(relay, "audit"):
-                ok, err = relay.apply_session_switch("local", None)
+                ok, err, changed = relay.apply_session_switch("local", None)
 
             self.assertTrue(ok)
+            self.assertTrue(changed)
             self.assertIsNone(relay.ACTIVE_SESSIONS[None])
 
     def test_apply_session_switch_rejects_unknown_session(self):
@@ -517,16 +571,19 @@ class RelaySessionSwitchTests(unittest.TestCase):
             with mock.patch.object(relay, "get_sessions", return_value=[
                         {"name": "personal", "running": True}]), \
                  mock.patch.object(relay, "audit"):
-                ok, err = relay.apply_session_switch("local", "../../etc/passwd")
+                ok, err, changed = relay.apply_session_switch("local", "../../etc/passwd")
                 self.assertFalse(ok)
+                self.assertFalse(changed)
                 self.assertIn("unknown session", err)
 
-                ok, err = relay.apply_session_switch("local", "personal2")
+                ok, err, changed = relay.apply_session_switch("local", "personal2")
                 self.assertFalse(ok)
+                self.assertFalse(changed)
                 self.assertIn("unknown session", err)
 
-                ok, err = relay.apply_session_switch("local", "Personal")
+                ok, err, changed = relay.apply_session_switch("local", "Personal")
                 self.assertFalse(ok)
+                self.assertFalse(changed)
                 self.assertIn("unknown session", err)
 
             self.assertEqual(relay.ACTIVE_SESSIONS, before)
@@ -540,12 +597,14 @@ class RelaySessionSwitchTests(unittest.TestCase):
             with mock.patch.object(relay, "get_sessions", return_value=[
                         {"name": "personal", "running": True}]), \
                  mock.patch.object(relay, "audit"):
-                ok, err = relay.apply_session_switch("local", ["personal"])
+                ok, err, changed = relay.apply_session_switch("local", ["personal"])
                 self.assertFalse(ok)
+                self.assertFalse(changed)
                 self.assertIn("unknown session", err)
 
-                ok, err = relay.apply_session_switch("local", {"name": "personal"})
+                ok, err, changed = relay.apply_session_switch("local", {"name": "personal"})
                 self.assertFalse(ok)
+                self.assertFalse(changed)
                 self.assertIn("unknown session", err)
 
             self.assertEqual(relay.ACTIVE_SESSIONS, before)
@@ -556,9 +615,10 @@ class RelaySessionSwitchTests(unittest.TestCase):
             relay.known_panes.add("w1:p1")
             before = dict(relay.ACTIVE_SESSIONS)
             with mock.patch.object(relay, "audit"):
-                ok, err = relay.apply_session_switch("user@nope", "personal")
+                ok, err, changed = relay.apply_session_switch("user@nope", "personal")
 
             self.assertFalse(ok)
+            self.assertFalse(changed)
             self.assertIn("unknown host", err)
             self.assertEqual(relay.ACTIVE_SESSIONS, before)
             self.assertIn("w1:p1", relay.known_panes)
@@ -569,9 +629,10 @@ class RelaySessionSwitchTests(unittest.TestCase):
                         {"name": "default", "running": False}]), \
                  mock.patch.object(relay, "_save_active_sessions"), \
                  mock.patch.object(relay, "audit"):
-                ok, err = relay.apply_session_switch("local", "default")
+                ok, err, changed = relay.apply_session_switch("local", "default")
 
             self.assertTrue(ok)
+            self.assertTrue(changed)
 
     def test_apply_session_switch_attributes_audit_to_caller(self):
         with loaded_relay() as relay:
@@ -579,10 +640,11 @@ class RelaySessionSwitchTests(unittest.TestCase):
                         {"name": "default", "running": True}]), \
                  mock.patch.object(relay, "_save_active_sessions"), \
                  mock.patch.object(relay, "audit") as audit_mock:
-                ok, err = relay.apply_session_switch(
+                ok, err, changed = relay.apply_session_switch(
                     "local", "default", ip="10.0.0.5", device="phone")
 
             self.assertTrue(ok)
+            self.assertTrue(changed)
             audit_mock.assert_called_once_with(
                 "session_switch", "10.0.0.5", "phone", "",
                 "host=local session=default")
@@ -599,10 +661,11 @@ class RelaySessionSwitchTests(unittest.TestCase):
                  mock.patch.object(relay, "_save_active_sessions",
                                    side_effect=OSError("disk full")), \
                  mock.patch.object(relay, "audit") as audit_mock:
-                ok, err = relay.apply_session_switch("local", "default")
+                ok, err, changed = relay.apply_session_switch("local", "default")
 
             self.assertTrue(ok)
             self.assertEqual(err, "")
+            self.assertTrue(changed)
             self.assertEqual(relay.ACTIVE_SESSIONS[None], "default")
             self.assertEqual(relay.known_panes, set())   # reset still happened
             audit_mock.assert_called_once()
@@ -613,14 +676,16 @@ class RelaySessionSwitchTests(unittest.TestCase):
                         {"name": "default", "running": True}]), \
                  mock.patch.object(relay, "_save_active_sessions"), \
                  mock.patch.object(relay, "audit"):
-                ok, err = relay.apply_session_switch("local", "default")
+                ok, err, changed = relay.apply_session_switch("local", "default")
                 self.assertTrue(ok)
+                self.assertTrue(changed)   # the real switch
 
                 relay.known_panes.add("w1:p1")
-                ok, err = relay.apply_session_switch("local", "default")
+                ok, err, changed = relay.apply_session_switch("local", "default")
 
             self.assertTrue(ok)
             self.assertEqual(err, "")
+            self.assertFalse(changed)   # the no-op re-selection
             self.assertIn("w1:p1", relay.known_panes)
 
     def test_sessions_message_shape(self):
@@ -694,7 +759,7 @@ class RelaySessionSwitchTests(unittest.TestCase):
 
             def fake_apply(host, session, ip, device):
                 order.append(("apply", host, session, ip, device))
-                return True, ""
+                return True, "", True
 
             async def fake_broadcast_sessions():
                 order.append(("broadcast_sessions",))
@@ -742,7 +807,7 @@ class RelaySessionSwitchTests(unittest.TestCase):
 
             with mock.patch.object(
                         relay, "apply_session_switch",
-                        return_value=(False, "unknown host: bogus")) as apply_mock, \
+                        return_value=(False, "unknown host: bogus", False)) as apply_mock, \
                  mock.patch.object(relay, "broadcast_sessions", new=mock.AsyncMock()) as broadcast_mock, \
                  mock.patch.object(relay, "_poll_once", new=mock.AsyncMock()) as poll_mock:
                 asyncio.run(relay.handle_client(ws))
@@ -758,6 +823,44 @@ class RelaySessionSwitchTests(unittest.TestCase):
             )
             broadcast_mock.assert_not_awaited()
             poll_mock.assert_not_awaited()
+
+    def test_session_switch_noop_acks_without_broadcast_or_repoll(self):
+        # apply_session_switch's own no-op short-circuit (skipping the
+        # blocking `herdr session list` call and the pane-state reset) is
+        # defeated if the handler runs the broadcast + re-poll anyway --
+        # those are exactly the expensive part `changed` exists to let the
+        # handler skip.
+        with loaded_relay() as relay:
+            request_id = "switch-3"
+            ws = _FakeWebSocket(
+                [json.dumps({
+                    "type": "session_switch",
+                    "host": "local",
+                    "session": "default",
+                    "request_id": request_id,
+                })],
+                headers={"X-Herdr-Remote-Command": "1"},
+            )
+
+            with mock.patch.object(
+                        relay, "apply_session_switch",
+                        return_value=(True, "", False)) as apply_mock, \
+                 mock.patch.object(relay, "broadcast_sessions", new=mock.AsyncMock()) as broadcast_mock, \
+                 mock.patch.object(relay, "_poll_once", new=mock.AsyncMock()) as poll_mock:
+                asyncio.run(relay.handle_client(ws))
+
+            apply_mock.assert_called_once_with("local", "default", "127.0.0.1", "script")
+            broadcast_mock.assert_not_awaited()
+            poll_mock.assert_not_awaited()
+            self.assertEqual(
+                json.loads(ws.sent[-1]),
+                {
+                    "type": "command_result",
+                    "command": "session_switch",
+                    "request_id": request_id,
+                    "ok": True,
+                },
+            )
 
 
 class RelayResponseTests(unittest.TestCase):

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -475,6 +475,71 @@ class RelaySessionSwitchTests(unittest.TestCase):
             self.assertEqual(relay.agent_cache, {})
             self.assertEqual(relay.last_blocked_prompts, {})
 
+    def test_apply_session_switch_updates_persists_and_resets(self):
+        with loaded_relay() as relay:
+            saved = {}
+            relay.known_panes.add("w1:p1")
+
+            with mock.patch.object(relay, "get_sessions", return_value=[
+                        {"name": "default", "running": True},
+                        {"name": "personal", "running": True}]), \
+                 mock.patch.object(relay, "_save_active_sessions",
+                                   side_effect=lambda: saved.update(relay.ACTIVE_SESSIONS)), \
+                 mock.patch.object(relay, "audit"):
+                ok, err = relay.apply_session_switch("local", "default")
+
+            self.assertTrue(ok)
+            self.assertEqual(err, "")
+            self.assertEqual(relay.ACTIVE_SESSIONS[None], "default")
+            self.assertEqual(saved[None], "default")
+            self.assertEqual(relay.known_panes, set())   # reset happened
+
+    def test_apply_session_switch_accepts_null_for_default_session(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(relay, "get_sessions", return_value=[
+                        {"name": "personal", "running": True}]), \
+                 mock.patch.object(relay, "_save_active_sessions"), \
+                 mock.patch.object(relay, "audit"):
+                ok, err = relay.apply_session_switch("local", None)
+
+            self.assertTrue(ok)
+            self.assertIsNone(relay.ACTIVE_SESSIONS[None])
+
+    def test_apply_session_switch_rejects_unknown_session(self):
+        # The value reaches a subprocess environment; it must be validated
+        # against discovered names, never passed through.
+        with loaded_relay() as relay:
+            before = dict(relay.ACTIVE_SESSIONS)
+            with mock.patch.object(relay, "get_sessions", return_value=[
+                        {"name": "personal", "running": True}]), \
+                 mock.patch.object(relay, "audit"):
+                ok, err = relay.apply_session_switch("local", "../../etc/passwd")
+
+            self.assertFalse(ok)
+            self.assertIn("unknown session", err)
+            self.assertEqual(relay.ACTIVE_SESSIONS, before)
+
+    def test_apply_session_switch_rejects_unknown_host(self):
+        with loaded_relay() as relay:
+            relay.REMOTES.clear()
+            before = dict(relay.ACTIVE_SESSIONS)
+            with mock.patch.object(relay, "audit"):
+                ok, err = relay.apply_session_switch("user@nope", "personal")
+
+            self.assertFalse(ok)
+            self.assertIn("unknown host", err)
+            self.assertEqual(relay.ACTIVE_SESSIONS, before)
+
+    def test_apply_session_switch_allows_stopped_session(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(relay, "get_sessions", return_value=[
+                        {"name": "default", "running": False}]), \
+                 mock.patch.object(relay, "_save_active_sessions"), \
+                 mock.patch.object(relay, "audit"):
+                ok, err = relay.apply_session_switch("local", "default")
+
+            self.assertTrue(ok)
+
 
 class RelayResponseTests(unittest.TestCase):
     def test_respond_sends_correlated_acknowledgement(self):

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -454,6 +454,27 @@ class RelaySessionSwitchTests(unittest.TestCase):
 
             self.assertEqual(relay.last_blocked_prompts, {})
 
+    def test_reset_pane_state_drains_queued_events(self):
+        # An event queued before a switch (never dequeued by event_push)
+        # must not survive the switch to be processed afterward.
+        with loaded_relay() as relay:
+            event = {
+                "type": "agent_event",
+                "pane_id": "w1:p1",
+                "agent": "claude",
+                "status": "blocked",
+                "cwd": "/tmp/x",
+                "project": "x",
+                "host": "local",
+            }
+            relay.event_queue.put_nowait(event)
+
+            relay.reset_pane_state()
+
+            self.assertTrue(relay.event_queue.empty())
+            self.assertEqual(relay.agent_cache, {})
+            self.assertEqual(relay.last_blocked_prompts, {})
+
 
 class RelayResponseTests(unittest.TestCase):
     def test_respond_sends_correlated_acknowledgement(self):

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -186,6 +186,32 @@ class RelayPaneStateTests(unittest.TestCase):
             )
 
 
+class RelaySessionSwitchTests(unittest.TestCase):
+    SESSION_LIST = (
+        "name                 status   directory                socket\n"
+        "default              stopped  /home/u/.config/herdr    /home/u/.config/herdr/herdr.sock\n"
+        "personal             running  /home/u/.config/herdr/s  /home/u/.config/herdr/s/herdr.sock\n"
+    )
+
+    def test_get_sessions_parses_name_and_running_state(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(relay, "run_herdr", return_value=self.SESSION_LIST):
+                sessions = relay.get_sessions()
+
+            self.assertEqual(
+                sessions,
+                [{"name": "default", "running": False},
+                 {"name": "personal", "running": True}],
+            )
+
+    def test_get_sessions_returns_empty_on_unusable_output(self):
+        for raw in ("", "   ", "name status\n", "garbage"):
+            with self.subTest(raw=raw):
+                with loaded_relay() as relay:
+                    with mock.patch.object(relay, "run_herdr", return_value=raw):
+                        self.assertEqual(relay.get_sessions(), [])
+
+
 class RelayResponseTests(unittest.TestCase):
     def test_respond_sends_correlated_acknowledgement(self):
         with loaded_relay() as relay:

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -365,6 +365,95 @@ class RelaySessionSwitchTests(unittest.TestCase):
             # The poll must not repopulate state cleared by the switch.
             self.assertEqual(relay.last_statuses, {})
 
+    def test_stale_poll_bails_after_blocked_broadcast_without_leaking_second_pane(self):
+        # Two blocked panes: the first pane's broadcast is where the switch
+        # lands. Without the post-broadcast/post-push generation check, the
+        # loop would carry on to the second pane and re-seed its fingerprint.
+        with loaded_relay() as relay:
+            agents = [
+                {"pane_id": "w1:p1", "agent": "claude", "status": "blocked",
+                 "cwd": "/tmp/x", "project": "x", "host": "local", "remote": None},
+                {"pane_id": "w1:p2", "agent": "claude", "status": "blocked",
+                 "cwd": "/tmp/y", "project": "y", "host": "local", "remote": None},
+            ]
+            calls = {"blocked_broadcasts": 0}
+
+            async def switch_on_first_blocked_broadcast(message):
+                if message.get("type") == "agents":
+                    return
+                calls["blocked_broadcasts"] += 1
+                if calls["blocked_broadcasts"] == 1:
+                    relay.reset_pane_state()          # simulates a switch landing
+
+            with mock.patch.object(relay, "get_all_agents", return_value=agents), \
+                 mock.patch.object(relay, "read_pane", return_value="Deploy to prod?"), \
+                 mock.patch.object(relay, "broadcast", side_effect=switch_on_first_blocked_broadcast), \
+                 mock.patch.object(relay, "send_web_push", new=mock.AsyncMock()):
+                asyncio.run(relay._poll_once())
+
+            # The switch must stop the poll before it re-seeds a second pane.
+            self.assertEqual(relay.last_blocked_prompts, {})
+
+    def test_stale_poll_bails_after_clear_push_without_restoring_status(self):
+        # last_statuses[pid] == "blocked" pre-set so the poll takes the
+        # clear-push branch; the switch lands during send_web_push. Without
+        # the post-push generation check, the trailing `last_statuses[pid] =
+        # status` line would restore an entry the reset just cleared.
+        with loaded_relay() as relay:
+            relay.last_statuses["w1:p1"] = "blocked"
+            agents = [{"pane_id": "w1:p1", "agent": "claude", "status": "idle",
+                       "cwd": "/tmp/x", "project": "x", "host": "local", "remote": None}]
+
+            async def switch_mid_clear_push(*args, **kwargs):
+                relay.reset_pane_state()          # simulates a switch landing
+
+            with mock.patch.object(relay, "get_all_agents", return_value=agents), \
+                 mock.patch.object(relay, "broadcast", new=mock.AsyncMock()), \
+                 mock.patch.object(relay, "send_web_push", side_effect=switch_mid_clear_push):
+                asyncio.run(relay._poll_once())
+
+            # The switch must stop the poll from restoring last_statuses.
+            self.assertEqual(relay.last_statuses, {})
+
+    def test_stale_event_does_not_reseed_blocked_prompt_after_switch(self):
+        # A queued agent_event that is already in hand (past reset's queue
+        # drain) but whose processing straddles a reset_pane_state() must not
+        # re-seed last_blocked_prompts with a stale fingerprint.
+        with loaded_relay() as relay:
+            event = {
+                "type": "agent_event",
+                "pane_id": "w1:p1",
+                "agent": "claude",
+                "status": "blocked",
+                "cwd": "/tmp/x",
+                "project": "x",
+                "host": "local",
+            }
+
+            async def run_one_event():
+                switched = asyncio.Event()
+
+                async def switch_mid_broadcast(message):
+                    if message.get("type") == "agents":
+                        relay.reset_pane_state()          # simulates a switch landing
+                        switched.set()
+
+                with mock.patch.object(relay, "get_all_agents", return_value=[]), \
+                     mock.patch.object(relay, "read_pane", return_value="Deploy to prod?"), \
+                     mock.patch.object(relay, "broadcast", side_effect=switch_mid_broadcast):
+                    task = asyncio.create_task(relay.event_push())
+                    try:
+                        await relay.event_queue.put(event)
+                        await asyncio.wait_for(switched.wait(), timeout=1)
+                    finally:
+                        task.cancel()
+                        with self.assertRaises(asyncio.CancelledError):
+                            await task
+
+            asyncio.run(run_one_event())
+
+            self.assertEqual(relay.last_blocked_prompts, {})
+
 
 class RelayResponseTests(unittest.TestCase):
     def test_respond_sends_correlated_acknowledgement(self):

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -310,6 +310,61 @@ class RelaySessionSwitchTests(unittest.TestCase):
                             relay._load_active_sessions()
                             self.assertEqual(relay.ACTIVE_SESSIONS, {})
 
+    def test_reset_pane_state_clears_only_pane_keyed_state(self):
+        with loaded_relay() as relay:
+            relay.known_panes.add("w1:p1")
+            relay.agent_cache["w1:p1"] = {"pane_id": "w1:p1"}
+            relay.pane_remote_map["w1:p1"] = None
+            relay.last_statuses["w1:p1"] = "working"
+            relay.last_blocked_prompts["w1:p1"] = ("pid", (), "prompt?")
+            relay.clients.add("sentinel-client")
+            relay.push_subscriptions.append({"endpoint": "x"})
+            before = relay.POLL_GENERATION
+
+            relay.reset_pane_state()
+
+            self.assertEqual(relay.known_panes, set())
+            self.assertEqual(relay.agent_cache, {})
+            self.assertEqual(relay.pane_remote_map, {})
+            self.assertEqual(relay.last_statuses, {})
+            self.assertEqual(relay.last_blocked_prompts, {})
+            # Not pane-keyed; must survive a switch.
+            self.assertIn("sentinel-client", relay.clients)
+            self.assertEqual(len(relay.push_subscriptions), 1)
+            self.assertEqual(relay.POLL_GENERATION, before + 1)
+
+    def test_switch_does_not_leak_blocked_prompt_across_sessions(self):
+        # w1:p1 exists in every session. update_pane_maps only prunes panes
+        # absent from the new list, so without an explicit reset the old
+        # fingerprint survives and suppresses a real notification.
+        with loaded_relay() as relay:
+            fingerprint = ("prompt-1", (), "Deploy to prod?")
+            relay.known_panes.add("w1:p1")
+            relay.last_blocked_prompts["w1:p1"] = fingerprint
+
+            relay.update_pane_maps([{"pane_id": "w1:p1", "remote": None}])
+            self.assertEqual(relay.last_blocked_prompts.get("w1:p1"), fingerprint)
+
+            relay.reset_pane_state()
+            self.assertIsNone(relay.last_blocked_prompts.get("w1:p1"))
+
+    def test_stale_poll_bails_without_mutating_state(self):
+        with loaded_relay() as relay:
+            agents = [{"pane_id": "w1:p1", "agent": "claude", "status": "idle",
+                       "cwd": "/tmp/x", "project": "x", "host": "local",
+                       "remote": None, "label": "", "workspace_label": "",
+                       "workspace_id": "w1", "tab_id": "w1:t1"}]
+
+            async def switch_mid_broadcast(_message):
+                relay.reset_pane_state()          # simulates a switch landing
+
+            with mock.patch.object(relay, "get_all_agents", return_value=agents), \
+                 mock.patch.object(relay, "broadcast", side_effect=switch_mid_broadcast):
+                asyncio.run(relay._poll_once())
+
+            # The poll must not repopulate state cleared by the switch.
+            self.assertEqual(relay.last_statuses, {})
+
 
 class RelayResponseTests(unittest.TestCase):
     def test_respond_sends_correlated_acknowledgement(self):

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -507,21 +507,53 @@ class RelaySessionSwitchTests(unittest.TestCase):
 
     def test_apply_session_switch_rejects_unknown_session(self):
         # The value reaches a subprocess environment; it must be validated
-        # against discovered names, never passed through.
+        # against discovered names, never passed through. Names that merely
+        # differ in case or extend a valid name must also be rejected -- a
+        # denylist (e.g. a traversal/metacharacter filter) would let those
+        # through, so this pins the exact-match allowlist specifically.
         with loaded_relay() as relay:
+            relay.known_panes.add("w1:p1")
             before = dict(relay.ACTIVE_SESSIONS)
             with mock.patch.object(relay, "get_sessions", return_value=[
                         {"name": "personal", "running": True}]), \
                  mock.patch.object(relay, "audit"):
                 ok, err = relay.apply_session_switch("local", "../../etc/passwd")
+                self.assertFalse(ok)
+                self.assertIn("unknown session", err)
 
-            self.assertFalse(ok)
-            self.assertIn("unknown session", err)
+                ok, err = relay.apply_session_switch("local", "personal2")
+                self.assertFalse(ok)
+                self.assertIn("unknown session", err)
+
+                ok, err = relay.apply_session_switch("local", "Personal")
+                self.assertFalse(ok)
+                self.assertIn("unknown session", err)
+
+            self.assertEqual(relay.ACTIVE_SESSIONS, before)
+            self.assertIn("w1:p1", relay.known_panes)
+
+    def test_apply_session_switch_rejects_non_string_session(self):
+        # session ends up in `x not in names` against a set; a list or dict
+        # is unhashable there and must be rejected, not raise.
+        with loaded_relay() as relay:
+            before = dict(relay.ACTIVE_SESSIONS)
+            with mock.patch.object(relay, "get_sessions", return_value=[
+                        {"name": "personal", "running": True}]), \
+                 mock.patch.object(relay, "audit"):
+                ok, err = relay.apply_session_switch("local", ["personal"])
+                self.assertFalse(ok)
+                self.assertIn("unknown session", err)
+
+                ok, err = relay.apply_session_switch("local", {"name": "personal"})
+                self.assertFalse(ok)
+                self.assertIn("unknown session", err)
+
             self.assertEqual(relay.ACTIVE_SESSIONS, before)
 
     def test_apply_session_switch_rejects_unknown_host(self):
         with loaded_relay() as relay:
             relay.REMOTES.clear()
+            relay.known_panes.add("w1:p1")
             before = dict(relay.ACTIVE_SESSIONS)
             with mock.patch.object(relay, "audit"):
                 ok, err = relay.apply_session_switch("user@nope", "personal")
@@ -529,6 +561,7 @@ class RelaySessionSwitchTests(unittest.TestCase):
             self.assertFalse(ok)
             self.assertIn("unknown host", err)
             self.assertEqual(relay.ACTIVE_SESSIONS, before)
+            self.assertIn("w1:p1", relay.known_panes)
 
     def test_apply_session_switch_allows_stopped_session(self):
         with loaded_relay() as relay:
@@ -539,6 +572,56 @@ class RelaySessionSwitchTests(unittest.TestCase):
                 ok, err = relay.apply_session_switch("local", "default")
 
             self.assertTrue(ok)
+
+    def test_apply_session_switch_attributes_audit_to_caller(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(relay, "get_sessions", return_value=[
+                        {"name": "default", "running": True}]), \
+                 mock.patch.object(relay, "_save_active_sessions"), \
+                 mock.patch.object(relay, "audit") as audit_mock:
+                ok, err = relay.apply_session_switch(
+                    "local", "default", ip="10.0.0.5", device="phone")
+
+            self.assertTrue(ok)
+            audit_mock.assert_called_once_with(
+                "session_switch", "10.0.0.5", "phone", "",
+                "host=local session=default")
+
+    def test_apply_session_switch_completes_when_persistence_fails(self):
+        # A save failure must not leave the switch half-applied: pane state
+        # still has to reset and the action still has to audit, or a stale
+        # cache under the new session is exactly the cross-session leak the
+        # reset exists to prevent.
+        with loaded_relay() as relay:
+            relay.known_panes.add("w1:p1")
+            with mock.patch.object(relay, "get_sessions", return_value=[
+                        {"name": "default", "running": True}]), \
+                 mock.patch.object(relay, "_save_active_sessions",
+                                   side_effect=OSError("disk full")), \
+                 mock.patch.object(relay, "audit") as audit_mock:
+                ok, err = relay.apply_session_switch("local", "default")
+
+            self.assertTrue(ok)
+            self.assertEqual(err, "")
+            self.assertEqual(relay.ACTIVE_SESSIONS[None], "default")
+            self.assertEqual(relay.known_panes, set())   # reset still happened
+            audit_mock.assert_called_once()
+
+    def test_apply_session_switch_is_noop_when_already_active(self):
+        with loaded_relay() as relay:
+            with mock.patch.object(relay, "get_sessions", return_value=[
+                        {"name": "default", "running": True}]), \
+                 mock.patch.object(relay, "_save_active_sessions"), \
+                 mock.patch.object(relay, "audit"):
+                ok, err = relay.apply_session_switch("local", "default")
+                self.assertTrue(ok)
+
+                relay.known_panes.add("w1:p1")
+                ok, err = relay.apply_session_switch("local", "default")
+
+            self.assertTrue(ok)
+            self.assertEqual(err, "")
+            self.assertIn("w1:p1", relay.known_panes)
 
 
 class RelayResponseTests(unittest.TestCase):

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -466,6 +466,21 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
             with self.assertRaisesRegex(RuntimeError, "disallowed"):
                 await tg.send_keys_to_relay("w0:p1", ["1"])
 
+    async def test_read_pane_skips_arbitrarily_many_unrelated_messages(self):
+        # The connect preamble (sessions, agents, one `blocked` per blocked
+        # agent) can put any number of messages ahead of pane_content. A
+        # fixed-count skip budget breaks once there are enough blocked
+        # agents; the skip must be bounded by time, not by a message count.
+        preamble = [{"type": "sessions", "sources": []}, {"type": "agents", "agents": []}]
+        preamble += [{"type": "blocked", "pane_id": f"w{i}:p1"} for i in range(8)]
+        preamble.append({"type": "pane_content", "content": "hello from pane"})
+        connection = FakeRelayConnection(preamble)
+
+        with patch("websockets.connect", return_value=connection):
+            content = await tg.read_pane("w0:p1")
+
+        self.assertEqual(content, "hello from pane")
+
     def test_relay_allows_numeric_approval_keys_and_acknowledges_them(self):
         relay_path = ROOT / "relay" / "herdr_relay.py"
         source = relay_path.read_text(encoding="utf-8")

--- a/web/index.html
+++ b/web/index.html
@@ -585,6 +585,14 @@ function handleMessage(msg) {
     renderSessionSelector();
     return;
   }
+  if (msg.type === 'error') {
+    // A rejected session_switch must not leave the UI stuck on
+    // "switching…" forever. Minimum handling only: no toast UI, since
+    // nothing else in this file renders errors.
+    switchingSession = false;
+    render();
+    return;
+  }
   if (msg.type === 'agents') {
     switchingSession = false;
     // Track timeline on status changes
@@ -742,8 +750,11 @@ function renderAgentList(list) {
 
 function emptyStateHtml() {
   if (switchingSession) return '<div class="empty">switching…</div>';
-  const local = sessionState?.sources?.find(s => s.host === 'local');
-  if (local) {
+  // Only meaningful with exactly one source: with remotes configured,
+  // "local" being idle says nothing about why the list is empty overall.
+  const sources = sessionState?.sources || [];
+  if (sources.length === 1) {
+    const local = sources[0];
     const active = local.active || 'default';
     const entry = local.sessions.find(s => s.name === active);
     // Same wording herdr-remote-session prints, so CLI and UI agree.
@@ -782,10 +793,23 @@ function renderSessionSelector() {
   if (total < 2) { btn.style.display = 'none'; menu.style.display = 'none'; return; }
   btn.style.display = '';
 
-  const local = sources.find(s => s.host === 'local') || sources[0];
-  btn.textContent = (local.active || 'default') + ' ▾';
-
   const multiSource = sources.length > 1;
+  if (multiSource) {
+    // The trigger used to show local's session unconditionally, so with
+    // remotes configured switching a remote looked like it did nothing.
+    // Stay neutral instead of naming one specific source's session.
+    btn.textContent = 'sessions ▾';
+  } else {
+    const local = sources[0];
+    const active = local.active || 'default';
+    const entry = local.sessions.find(s => s.name === active);
+    // Fall back to the raw active value when nothing matches, so a
+    // mismatch (e.g. herdr's default session not literally named
+    // "default") degrades to a correct-but-unticked label rather than a
+    // confidently wrong one.
+    btn.textContent = (entry ? entry.name : local.active) + ' ▾';
+  }
+
   const rowTargets = [];
   menu.innerHTML = sources.map(src => {
     const header = multiSource
@@ -828,11 +852,14 @@ function toggleSessionMenu() {
 let switchingSession = false;
 
 function switchHerdrSession(host, session) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
   document.getElementById('sessionMenu').style.display = 'none';
   document.getElementById('sessionSelector').setAttribute('aria-expanded', 'false');
   // A switch clears relay state and re-polls; a bare empty list would read as
   // breakage. Routed through the existing render path, not by poking the DOM —
-  // there is no #agentList element.
+  // there is no #agentList element. Mutate local state only after we know
+  // the send will happen, so a dead socket can't leave the UI stuck showing
+  // "switching…" forever.
   switchingSession = true;
   agents = [];
   render();

--- a/web/index.html
+++ b/web/index.html
@@ -80,6 +80,20 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 .chip:active { transform: scale(0.95); }
 .chip-add { border: 2px dashed var(--border); background: transparent; color: var(--muted); font-size: 1rem; padding: 4px 12px; }
 .chip-add:hover { border-color: var(--blue); color: var(--blue); }
+
+/* Session picker. The wrapper is the positioning context so the menu hangs
+   under the button rather than the header's left edge. */
+.session-picker { position: relative; display: inline-flex; align-items: center; }
+/* Pill styling borrowed from .chip so it reads as a control at rest; the id
+   beats .header button's 44px icon-button sizing. */
+#sessionSelector { min-width: 0; min-height: 0; padding: 5px 12px; border-radius: 9999px; background: var(--border); color: var(--muted); font-size: 0.8rem; font-weight: 500; white-space: nowrap; }
+#sessionSelector:hover { color: var(--text); }
+#sessionSelector:active { transform: scale(0.95); }
+#sessionMenu { display: none; position: absolute; top: 100%; left: 0; margin-top: 6px; z-index: 50; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 4px; min-width: 160px; font-size: 0.8rem; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+#sessionMenu [role="option"] { padding: 6px 8px; border-radius: 6px; cursor: pointer; white-space: nowrap; }
+#sessionMenu [role="option"]:hover { background: var(--border); }
+/* Fixed width so names align whether or not the row is ticked. */
+.session-mark { display: inline-block; width: 1.1em; }
 .agent .info { flex: 1; }
 .agent .project { font-size: 0.9rem; font-weight: 500; }
 .agent .meta { font-size: 0.7rem; color: var(--muted); margin-top: 2px; }
@@ -176,13 +190,11 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
   <span class="dot" id="statusDot"></span>
   <h1>herdr</h1>
   <span id="connLabel" style="font-size:0.65rem;font-weight:500"></span>
-  <button id="sessionSelector" onclick="toggleSessionMenu()" aria-haspopup="listbox"
-          aria-expanded="false" aria-label="Switch herdr session"
-          style="display:none;font-size:0.7rem;font-weight:500;padding:2px 6px"></button>
-  <div id="sessionMenu" role="listbox" aria-label="herdr sessions"
-       style="display:none;position:absolute;top:100%;left:8px;z-index:50;
-              background:var(--bg);border:1px solid var(--border);border-radius:6px;
-              padding:4px;min-width:160px"></div>
+  <span class="session-picker" id="sessionPicker">
+    <button id="sessionSelector" onclick="toggleSessionMenu()" aria-haspopup="listbox"
+            aria-expanded="false" aria-label="Switch herdr session"></button>
+    <div id="sessionMenu" role="listbox" aria-label="herdr sessions"></div>
+  </span>
   <span id="agentCount" style="font-size:0.7rem;color:var(--muted);margin-left:auto"></span>
   <button onclick="toggleTimeline()" aria-label="Timeline"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></button>
   <button onclick="toggleSettings()" aria-label="Settings"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg></button>
@@ -787,11 +799,13 @@ let sessionState = null;
 function renderSessionSelector() {
   const btn = document.getElementById('sessionSelector');
   const menu = document.getElementById('sessionMenu');
+  const picker = document.getElementById('sessionPicker');
   const sources = sessionState?.sources || [];
   const total = sources.reduce((n, s) => n + s.sessions.length, 0);
-  // Nothing to switch between: stay out of the way.
-  if (total < 2) { btn.style.display = 'none'; menu.style.display = 'none'; return; }
-  btn.style.display = '';
+  // Nothing to switch between: stay out of the way. Hide the wrapper, not just
+  // the button, or the header's flex gap leaves a stray space behind.
+  if (total < 2) { picker.style.display = 'none'; menu.style.display = 'none'; return; }
+  picker.style.display = '';
 
   const multiSource = sources.length > 1;
   if (multiSource) {
@@ -813,16 +827,17 @@ function renderSessionSelector() {
   const rowTargets = [];
   menu.innerHTML = sources.map(src => {
     const header = multiSource
-      ? `<div style="font-size:0.6rem;color:var(--muted);padding:2px 6px">${escapeHtml(src.host)}</div>`
+      ? `<div class="chip-label" style="padding:4px 8px">${escapeHtml(src.host)}</div>`
       : '';
     const rows = src.sessions.map(s => {
       const active = (src.active || 'default') === s.name;
       const dim = s.running ? '' : 'opacity:0.55;';
       rowTargets.push({ host: src.host, session: s.name });
-      return `<div role="option" aria-selected="${active}" tabindex="0"
-                   style="padding:4px 6px;cursor:pointer;${dim}">
-                ${active ? '✓' : ' '} ${escapeHtml(s.name)}${s.running ? '' : ' ·'}
-              </div>`;
+      // The tick lives in a fixed-width span so ticked and unticked names
+      // start at the same x. A bare space would collapse in HTML.
+      return `<div role="option" aria-selected="${active}" tabindex="0" style="${dim}"`
+           + `><span class="session-mark">${active ? '✓' : ''}</span>`
+           + `${escapeHtml(s.name)}${s.running ? '' : ' ·'}</div>`;
     }).join('');
     return header + rows;
   }).join('');

--- a/web/index.html
+++ b/web/index.html
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => bind());
 *:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; border-radius: 4px; }
 body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; background: var(--bg); color: var(--text); min-height: 100dvh; min-height: -webkit-fill-available; display: flex; flex-direction: column; width: 100%; overflow-x: hidden; }
 
-.header { padding: 12px 16px; display: flex; align-items: center; gap: 10px; border-bottom: 1px solid var(--border); }
+.header { padding: 12px 16px; display: flex; align-items: center; gap: 10px; border-bottom: 1px solid var(--border); position: relative; }
 .header h1 { font-size: 1rem; font-weight: 700; letter-spacing: -0.02em; }
 .header button { background: none; border: none; color: var(--muted); cursor: pointer; padding: 8px; min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center; border-radius: 8px; transition: color 0.15s, background 0.15s; }
 .header button:hover { color: var(--text); background: var(--border); }
@@ -180,7 +180,7 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
           aria-expanded="false" aria-label="Switch herdr session"
           style="display:none;font-size:0.7rem;font-weight:500;padding:2px 6px"></button>
   <div id="sessionMenu" role="listbox" aria-label="herdr sessions"
-       style="display:none;position:absolute;top:34px;left:8px;z-index:50;
+       style="display:none;position:absolute;top:100%;left:8px;z-index:50;
               background:var(--bg);border:1px solid var(--border);border-radius:6px;
               padding:4px;min-width:160px"></div>
   <span id="agentCount" style="font-size:0.7rem;color:var(--muted);margin-left:auto"></span>

--- a/web/index.html
+++ b/web/index.html
@@ -810,7 +810,7 @@ function renderSessionSelector() {
   menu.querySelectorAll('[role="option"]').forEach((row, i) => {
     row.dataset.host = rowTargets[i].host;
     row.dataset.session = rowTargets[i].session;
-    const activate = () => switchSession(row.dataset.host, row.dataset.session);
+    const activate = () => switchHerdrSession(row.dataset.host, row.dataset.session);
     row.addEventListener('click', activate);
     row.addEventListener('keydown', (event) => {
       if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); activate(); }
@@ -827,7 +827,7 @@ function toggleSessionMenu() {
 
 let switchingSession = false;
 
-function switchSession(host, session) {
+function switchHerdrSession(host, session) {
   document.getElementById('sessionMenu').style.display = 'none';
   document.getElementById('sessionSelector').setAttribute('aria-expanded', 'false');
   // A switch clears relay state and re-polls; a bare empty list would read as

--- a/web/index.html
+++ b/web/index.html
@@ -859,7 +859,10 @@ function renderSessionSelector() {
 
 function toggleSessionMenu() {
   const menu = document.getElementById('sessionMenu');
-  const show = menu.style.display === 'none';
+  // Read the computed style, not the inline one: the menu starts hidden via
+  // the stylesheet, so menu.style.display is '' on the first click and an
+  // inline-only check would silently "close" an already-closed menu.
+  const show = getComputedStyle(menu).display === 'none';
   menu.style.display = show ? 'block' : 'none';
   document.getElementById('sessionSelector').setAttribute('aria-expanded', String(show));
 }

--- a/web/index.html
+++ b/web/index.html
@@ -176,6 +176,13 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
   <span class="dot" id="statusDot"></span>
   <h1>herdr</h1>
   <span id="connLabel" style="font-size:0.65rem;font-weight:500"></span>
+  <button id="sessionSelector" onclick="toggleSessionMenu()" aria-haspopup="listbox"
+          aria-expanded="false" aria-label="Switch herdr session"
+          style="display:none;font-size:0.7rem;font-weight:500;padding:2px 6px"></button>
+  <div id="sessionMenu" role="listbox" aria-label="herdr sessions"
+       style="display:none;position:absolute;top:34px;left:8px;z-index:50;
+              background:var(--bg);border:1px solid var(--border);border-radius:6px;
+              padding:4px;min-width:160px"></div>
   <span id="agentCount" style="font-size:0.7rem;color:var(--muted);margin-left:auto"></span>
   <button onclick="toggleTimeline()" aria-label="Timeline"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></button>
   <button onclick="toggleSettings()" aria-label="Settings"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg></button>
@@ -573,7 +580,13 @@ function ansiFragment(input) {
 }
 
 function handleMessage(msg) {
+  if (msg.type === 'sessions') {
+    sessionState = msg;
+    renderSessionSelector();
+    return;
+  }
   if (msg.type === 'agents') {
+    switchingSession = false;
     // Track timeline on status changes
     for (const a of msg.agents) {
       const prev = prevStatuses[a.pane_id];
@@ -722,9 +735,23 @@ function renderAgentList(list) {
   if (working.length) html += section('Working', 'var(--green)', working);
   if (done.length) html += section('Done', 'var(--muted)', done);
   if (idle.length) html += section('Idle', 'var(--muted)', idle);
-  if (!list.length) html = '<div class="empty">Waiting for agents…</div>';
+  if (!list.length) html = emptyStateHtml();
   document.getElementById('agents').innerHTML = html;
   bindLongPressHandlers();
+}
+
+function emptyStateHtml() {
+  if (switchingSession) return '<div class="empty">switching…</div>';
+  const local = sessionState?.sources?.find(s => s.host === 'local');
+  if (local) {
+    const active = local.active || 'default';
+    const entry = local.sessions.find(s => s.name === active);
+    // Same wording herdr-remote-session prints, so CLI and UI agree.
+    if (entry && !entry.running) {
+      return `<div class="empty">session '${active}' is not running</div>`;
+    }
+  }
+  return '<div class="empty">Waiting for agents…</div>';
 }
 
 function bindLongPressHandlers() {
@@ -743,6 +770,60 @@ function bindLongPressHandlers() {
 }
 
 function selectWorkspace(id) { activeWorkspace = id; activeTab = null; render(); }
+
+let sessionState = null;
+
+function renderSessionSelector() {
+  const btn = document.getElementById('sessionSelector');
+  const menu = document.getElementById('sessionMenu');
+  const sources = sessionState?.sources || [];
+  const total = sources.reduce((n, s) => n + s.sessions.length, 0);
+  // Nothing to switch between: stay out of the way.
+  if (total < 2) { btn.style.display = 'none'; menu.style.display = 'none'; return; }
+  btn.style.display = '';
+
+  const local = sources.find(s => s.host === 'local') || sources[0];
+  btn.textContent = (local.active || 'default') + ' ▾';
+
+  const multiSource = sources.length > 1;
+  menu.innerHTML = sources.map(src => {
+    const header = multiSource
+      ? `<div style="font-size:0.6rem;color:var(--muted);padding:2px 6px">${src.host}</div>`
+      : '';
+    const rows = src.sessions.map(s => {
+      const active = (src.active || 'default') === s.name;
+      const dim = s.running ? '' : 'opacity:0.55;';
+      return `<div role="option" aria-selected="${active}" tabindex="0"
+                   onclick="switchSession('${src.host}','${s.name}')"
+                   style="padding:4px 6px;cursor:pointer;${dim}">
+                ${active ? '✓' : ' '} ${s.name}${s.running ? '' : ' ·'}
+              </div>`;
+    }).join('');
+    return header + rows;
+  }).join('');
+}
+
+function toggleSessionMenu() {
+  const menu = document.getElementById('sessionMenu');
+  const show = menu.style.display === 'none';
+  menu.style.display = show ? 'block' : 'none';
+  document.getElementById('sessionSelector').setAttribute('aria-expanded', String(show));
+}
+
+let switchingSession = false;
+
+function switchSession(host, session) {
+  document.getElementById('sessionMenu').style.display = 'none';
+  document.getElementById('sessionSelector').setAttribute('aria-expanded', 'false');
+  // A switch clears relay state and re-polls; a bare empty list would read as
+  // breakage. Routed through the existing render path, not by poking the DOM —
+  // there is no #agentList element.
+  switchingSession = true;
+  agents = [];
+  render();
+  ws.send(JSON.stringify({ type: 'session_switch', host, session }));
+}
+
 function backToWorkspaces() { activeWorkspace = null; activeTab = null; render(); }
 function selectTab(id) { activeTab = id; render(); }
 

--- a/web/index.html
+++ b/web/index.html
@@ -89,7 +89,10 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 #sessionSelector { min-width: 0; min-height: 0; padding: 5px 12px; border-radius: 9999px; background: var(--border); color: var(--muted); font-size: 0.8rem; font-weight: 500; white-space: nowrap; }
 #sessionSelector:hover { color: var(--text); }
 #sessionSelector:active { transform: scale(0.95); }
-#sessionMenu { display: none; position: absolute; top: 100%; left: 0; margin-top: 6px; z-index: 50; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 4px; min-width: 160px; font-size: 0.8rem; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+/* 60 sits above .terminal-view (50), which starts below the header and so must
+   not cover a menu hanging off it. Deliberately below #cmdPalette (100) and
+   #contextMenu (200) — those are modals that should cover a dropdown. */
+#sessionMenu { display: none; position: absolute; top: 100%; left: 0; margin-top: 6px; z-index: 60; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 4px; min-width: 160px; font-size: 0.8rem; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
 #sessionMenu [role="option"] { padding: 6px 8px; border-radius: 6px; cursor: pointer; white-space: nowrap; }
 #sessionMenu [role="option"]:hover { background: var(--border); }
 /* Fixed width so names align whether or not the row is ticked. */

--- a/web/index.html
+++ b/web/index.html
@@ -786,21 +786,36 @@ function renderSessionSelector() {
   btn.textContent = (local.active || 'default') + ' ▾';
 
   const multiSource = sources.length > 1;
+  const rowTargets = [];
   menu.innerHTML = sources.map(src => {
     const header = multiSource
-      ? `<div style="font-size:0.6rem;color:var(--muted);padding:2px 6px">${src.host}</div>`
+      ? `<div style="font-size:0.6rem;color:var(--muted);padding:2px 6px">${escapeHtml(src.host)}</div>`
       : '';
     const rows = src.sessions.map(s => {
       const active = (src.active || 'default') === s.name;
       const dim = s.running ? '' : 'opacity:0.55;';
+      rowTargets.push({ host: src.host, session: s.name });
       return `<div role="option" aria-selected="${active}" tabindex="0"
-                   onclick="switchSession('${src.host}','${s.name}')"
                    style="padding:4px 6px;cursor:pointer;${dim}">
-                ${active ? '✓' : ' '} ${s.name}${s.running ? '' : ' ·'}
+                ${active ? '✓' : ' '} ${escapeHtml(s.name)}${s.running ? '' : ' ·'}
               </div>`;
     }).join('');
     return header + rows;
   }).join('');
+
+  // Host/session go on via the dataset property setter, not string
+  // interpolation, so a name or host containing quotes or markup can't
+  // break out of an attribute or inject JS. Wired after innerHTML is set,
+  // since the rows above carry no onclick/onkeydown of their own.
+  menu.querySelectorAll('[role="option"]').forEach((row, i) => {
+    row.dataset.host = rowTargets[i].host;
+    row.dataset.session = rowTargets[i].session;
+    const activate = () => switchSession(row.dataset.host, row.dataset.session);
+    row.addEventListener('click', activate);
+    row.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); activate(); }
+    });
+  });
 }
 
 function toggleSessionMenu() {


### PR DESCRIPTION
Adds a session picker to the header, so you can switch which herdr session the relay reports on without editing config and restarting the service.

## Screenshots

<table>
<tr>
<td align="center"><img height="210" alt="Session picker, closed" src="https://github.com/user-attachments/assets/52de3551-e53e-4682-89f6-74cc56fb889a" /></td>
<td align="center"><img height="210" alt="Session picker, open" src="https://github.com/user-attachments/assets/de483f54-0e60-40dc-80ea-d86835786095" /></td>
</tr>
<tr>
<td align="center"><sub>Closed — active session sits in the header</sub></td>
<td align="center"><sub>Open — tick marks the active session</sub></td>
</tr>
</table>

## Why

The session is currently fixed by `HERDR_SESSION` at startup. And if you point the relay at a session that isn't running, `herdr pane list` fails, the error gets swallowed, and the UI just says "waiting for agents" with nothing in any log to explain it.

## How

Discovery via `herdr session list` (cached 30s). The selection is applied by varying how `herdr` is invoked — the same approach the existing `remote=` parameter already uses — so `HERDR_REMOTES` hosts are switchable too, each independently. The choice persists in `active_sessions.json`; `HERDR_SESSION` remains the boot default.

The protocol change is additive (`sessions`, `session_switch`). Other clients ignore unknown message types, so nothing else needed updating — with one exception below.

## Three things worth knowing

**`HERDR_SOCKET_PATH` is now stripped from the child environment.** It overrides `HERDR_SESSION`, so without this a relay running inside a herdr pane would silently ignore every switch. The side effect: such a relay used to follow its own pane's session, and now follows `HERDR_SESSION` or herdr's default.

**`herdr_telegram.py` needed a companion fix.** Its `read_pane` skipped a *fixed count* of messages while waiting for `pane_content`. The new connect-time `sessions` message shifts that count, breaking it at 3 blocked agents — and it was already broken at 4 before this change. It now reads until a deadline instead of counting. Worth noting the "unknown types are ignored" guarantee covers message shape but not message count.

**Switching resets pane state**, so a stale prompt fingerprint can't suppress a real approval notification in the session you land on. The trade-off is that switching re-announces whatever is already blocked there.

## Testing

`tests/run.sh` 21/21 (including a new check for duplicate JS function declarations), relay 63/63, Telegram 42/42. Reverting `relay/herdr_relay.py` to base makes the new tests fail with 36 errors, so they depend on the implementation rather than coexisting with it. Verified live against a running relay through a Cloudflare tunnel.

Independent of #38 — different regions of `web/index.html`.
