### PR TITLE
Fix: echo request_id in agent_prompt ack (fixes #40)

### DIFF
--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1366,19 +1366,29 @@ async def handle_client(ws):
                 run_herdr("pane", "send-text", pane_id, text, remote=remote)
             elif msg_type == "agent_prompt":
                 # Use 'herdr agent prompt' for proper submission (works with Codex, Claude, etc.)
+                request_id = msg.get("request_id")
                 pane_id = msg["pane_id"]
                 if pane_id not in known_panes:
-                    await ws.send(json.dumps({"type": "error", "message": "unknown pane_id"}))
+                    response = {"type": "error", "message": "unknown pane_id"}
+                    if request_id:
+                        response["request_id"] = request_id
+                    await ws.send(json.dumps(response))
                     continue
                 text = msg.get("text", "")
                 if not text or len(text) > 10000:
-                    await ws.send(json.dumps({"type": "error", "message": "text empty or too long"}))
+                    response = {"type": "error", "message": "text empty or too long"}
+                    if request_id:
+                        response["request_id"] = request_id
+                    await ws.send(json.dumps(response))
                     continue
                 remote = pane_remote_map.get(pane_id)
                 log.info("Agent prompt from %s (%s): pane=%s text=%r", ip, device, pane_id, text[:100])
                 audit("agent_prompt", ip, device, pane_id, f"text={text[:100]!r}")
                 run_herdr("agent", "prompt", pane_id, text, remote=remote)
-                await ws.send(json.dumps({"type": "command_result", "command": "agent_prompt", "ok": True}))
+                response = {"type": "command_result", "command": "agent_prompt", "ok": True}
+                if request_id:
+                    response["request_id"] = request_id
+                await ws.send(json.dumps(response))
             elif msg_type == "create_tab":
                 workspace_id = msg.get("workspace_id", "")
                 if workspace_id:


### PR DESCRIPTION
## Problem

The Telegram bot fails on **every** free-form reply with `Failed: relay did not acknowledge agent_prompt`, even though the prompt is actually delivered to the agent (the relay runs `herdr agent prompt` before acking). Fixes #40.

## Root cause

The relay echoes the client's `request_id` in every command acknowledgment — `respond` (`herdr_relay.py:1252-1254`), `send_keys` (`1350-1352`), and all `error` responses — **except the `agent_prompt` handler**, which acked without it.

The Telegram client's `await_command_result` (`herdr_telegram.py:84`) skips any `command_result` whose `request_id` doesn't match, so the agent_prompt ack was always discarded and the client timed out after `COMMAND_ACK_TIMEOUT` (20s).

## Change

Read `request_id` from the incoming message and echo it in the `agent_prompt` success ack and both error responses, mirroring the existing `respond` / `send_keys` handlers. No protocol change — this makes agent_prompt consistent with every other command.

## Verification

- **Reproduction against the real client function:** an ack without `request_id` raises the exact `relay did not acknowledge agent_prompt` error; an ack with `request_id` is accepted.
- **Live check against the running relay (post-fix):** the agent_prompt path now returns `request_id` in its response.
- Deployed to a WSL2 + systemd user-service install; Telegram replies succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
