### PR TITLE
build(release): publish every client on tag push, from one version source

### DIFF
--- a/.github/scripts/check-versions.py
+++ b/.github/scripts/check-versions.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Keep the release version in sync across the build scripts, and check it against a tag.
+
+Seven numbers in five files decide what a release is called and what the built-in updaters
+compare against. They live apart because each build runs on its own machine with its own
+toolchain, and they drift: as this was written herdi-win said 0.7.3 while herdi-mac said
+0.7.5, and the two plugin manifests had sat at 0.5.0 through four releases.
+
+Drift is not cosmetic. Both updaters take the version from the release tag and compare it
+against the version compiled into the running app (herdi-win/Services/Updater.cs:112,
+herdi-mac/Sources/Updater.swift:78), so an app built at 0.7.3 and shipped under tag v0.7.4
+offers an update, installs it, and offers it again forever.
+
+    check-versions.py               report what each file says
+    check-versions.py 0.7.5         exit 1 unless every file agrees on 0.7.5
+    check-versions.py --set 0.7.5   rewrite every one of them to 0.7.5
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SELF = Path(__file__).name
+
+# (file, what it is, pattern whose group 1 is the version, how many components it carries)
+SITES = [
+    ("herdi-win/Herdi.Win.csproj", "<Version>", r"<Version>([\d.]+)</Version>", 3),
+    ("herdi-win/Herdi.Win.csproj", "<AssemblyVersion>", r"<AssemblyVersion>([\d.]+)</AssemblyVersion>", 4),
+    ("herdi-win/Herdi.Win.csproj", "<FileVersion>", r"<FileVersion>([\d.]+)</FileVersion>", 4),
+    # Names the zips build.ps1 -Zip hands to the release; Updater matches assets by name.
+    ("herdi-win/build.ps1", "$version", r"^\$version = '([\d.]+)'", 3),
+    # Becomes CFBundleShortVersionString, which dmg.sh then reads back to name the DMG.
+    ("herdi-mac/build.sh", "VERSION", r'^VERSION="([\d.]+)"', 3),
+    # What `herdr plugin` reports for an installed relay. These two are the reason the
+    # list is here rather than in herdi-mac/build.sh: a mac-only `sed` on a BSD-only flag
+    # cannot keep a number that both a Linux relay and a Windows tray also ship.
+    ("herdr-plugin.toml", "version", r'^version = "([\d.]+)"', 3),
+    ("relay/herdr-plugin.toml", "version", r'^version = "([\d.]+)"', 3),
+]
+
+
+def render(version, parts):
+    """0.7.5 as the file wants it: three components, or four with a trailing .0."""
+    return version if parts == 3 else version + ".0"
+
+
+def find(text, path, label, pattern):
+    match = re.search(pattern, text, re.M)
+    if match is None:
+        sys.exit(f"error: no {label} found in {path} — the pattern in {SELF} needs updating")
+    return match
+
+
+def replace(text, match, new):
+    """Splice a new version into group 1, leaving the rest of the matched text alone."""
+    whole, start = match.group(0), match.start(0)
+    rebuilt = whole[: match.start(1) - start] + new + whole[match.end(1) - start :]
+    return text[: start] + rebuilt + text[match.end(0) :]
+
+
+def main(argv):
+    setting = bool(argv) and argv[0] == "--set"
+    if setting:
+        argv = argv[1:]
+    wanted = argv[0] if argv else None
+    if wanted is not None:
+        wanted = wanted.lstrip("v")
+        if not re.fullmatch(r"\d+\.\d+\.\d+", wanted):
+            sys.exit(f"error: expected a version like 0.7.5, got {wanted!r}")
+    elif setting:
+        sys.exit(f"usage: {SELF} --set X.Y.Z")
+
+    texts = {}
+    rows = []
+    for path, label, pattern, parts in SITES:
+        if path not in texts:
+            texts[path] = (ROOT / path).read_text(encoding="utf-8")
+        match = find(texts[path], path, label, pattern)
+        if setting:
+            texts[path] = replace(texts[path], match, render(wanted, parts))
+            rows.append((path, label, render(wanted, parts), True, None))
+        else:
+            found = match.group(1)
+            expected = render(wanted, parts) if wanted else None
+            rows.append((path, label, found, expected is None or found == expected, expected))
+
+    width = max(len(f"{path} {label}") for path, label, *_ in rows)
+    for path, label, found, ok, expected in rows:
+        mark = "" if ok else f"  <- expected {expected}"
+        print(f"{f'{path} {label}':<{width}}  {found}{mark}")
+
+    if setting:
+        for path, text in texts.items():
+            (ROOT / path).write_text(text, encoding="utf-8")
+        print(f"\nSet to {wanted}. Commit these, then tag v{wanted}.")
+        return 0
+
+    if wanted is None:
+        # Nothing to check against, but files that disagree with each other are the
+        # same bug one tag early, so say so rather than printing a tidy table.
+        spread = {".".join(found.split(".")[:3]) for _, _, found, _, _ in rows}
+        if len(spread) > 1:
+            print(f"\nwarning: these do not agree: {', '.join(sorted(spread))}")
+        return 0
+
+    if any(not ok for *_, ok, _ in rows):
+        sys.stdout.flush()
+        print(
+            f"\nerror: the files above disagree with the tag. Run `{SELF} --set {wanted}`,"
+            "\ncommit, and move the tag — shipping a build whose own version differs from"
+            "\nthe tag leaves every install updating in a loop.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+# Build every client and attach it to the GitHub release for a tag.
+#
+# Push a tag and this runs; nothing else triggers it. Both apps ship their own updater
+# pointed at this repo's releases/latest, so a release is not a convenience here -- it is
+# the update channel, and a half-finished one reaches every install within ten minutes.
+# Everything below follows from that:
+#
+#   - The version check runs first and fails the whole thing. An app whose compiled-in
+#     version differs from the tag offers an update, installs it, and offers it again.
+#   - Windows publishes both deployment modes, per architecture. The updater picks per
+#     install (Updater.IsUsableAsset), and an install whose asset is missing gets nothing
+#     -- or worse, a build that cannot start on its machine. See herdi-win/README.md.
+#   - The release is created with its assets in one call, so it is never briefly latest
+#     and empty.
+#   - workflow_dispatch builds everything and skips the release job: a dry run.
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  versions:
+    name: Version check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Every build script must agree with the tag
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$REF_TYPE" = tag ]; then
+            python3 .github/scripts/check-versions.py "$REF_NAME"
+          else
+            python3 .github/scripts/check-versions.py   # dry run: report only
+          fi
+
+  windows:
+    name: Windows
+    needs: versions
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: herdi-win
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '8.0.x'
+      # -Zip builds self-contained and framework-dependent together. Both are uploaded:
+      # the small one strands installs on machines with no .NET 8 Desktop Runtime, the
+      # large one makes every other install's update six times bigger than it needs to be.
+      - name: Build win-x64 (both deployment modes)
+        run: ./build.ps1 -Zip
+      # Cross-published from the x64 runner. Drop this step to stop shipping ARM64; the
+      # updater matches assets by RID, so arm64 installs simply see no update instead of
+      # being handed an x64 build.
+      - name: Build win-arm64 (both deployment modes)
+        run: ./build.ps1 -Zip -Arch win-arm64
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows
+          path: herdi-win/dist/*.zip
+          if-no-files-found: error
+          # These are release assets, not build debris worth keeping for 90 days.
+          retention-days: 7
+
+  macos:
+    name: macOS
+    needs: versions
+    # Pinned, not macos-latest: the app targets macOS 14 and the runner label decides
+    # which SDK and which Swift compile it. An image bump should be a commit, not a
+    # surprise on a release day.
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v7
+      # dmg.sh rebuilds through build.sh itself and names the DMG from the version it
+      # finds in the app it just built, so there is nothing to pass it.
+      - name: Build app and DMG
+        working-directory: herdi-mac
+        run: ./dmg.sh
+      - uses: actions/upload-artifact@v7
+        with:
+          name: macos
+          path: herdi-mac/dist/*.dmg
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish
+    if: github.ref_type == 'tag'
+    needs: [windows, macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: assets
+          merge-multiple: true
+      - name: Attach everything to the tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          ls -l assets
+          # A tag may already have a release (the mac DMG has been published by hand up to
+          # now), so add to it rather than failing. --clobber replaces a same-named asset.
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG" assets/* --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$TAG" assets/* --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" --generate-notes
+          fi
+          {
+            echo "### $TAG"
+            echo
+            cd assets && for f in *; do
+              echo "- \`$f\` ($(du -h "$f" | cut -f1))"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/herdi-mac/build.sh
+++ b/herdi-mac/build.sh
@@ -8,9 +8,6 @@ VERSION="0.7.5"
 BUILD_DIR="$SCRIPT_DIR/.build/release"
 APP_DIR="$SCRIPT_DIR/dist/$APP_NAME.app"
 
-# Sync version to plugin manifests
-sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" "$SCRIPT_DIR/../herdr-plugin.toml" "$SCRIPT_DIR/../relay/herdr-plugin.toml" 2>/dev/null || true
-
 echo "▸ Building release..."
 cd "$SCRIPT_DIR"
 swift build -c release

--- a/herdi-win/Herdi.Win.csproj
+++ b/herdi-win/Herdi.Win.csproj
@@ -17,9 +17,9 @@
     <AssemblyName>Herdi</AssemblyName>
     <RootNamespace>Herdi</RootNamespace>
     <ApplicationIcon>Assets\herdi.ico</ApplicationIcon>
-    <Version>0.7.3</Version>
-    <AssemblyVersion>0.7.3.0</AssemblyVersion>
-    <FileVersion>0.7.3.0</FileVersion>
+    <Version>0.7.5</Version>
+    <AssemblyVersion>0.7.5.0</AssemblyVersion>
+    <FileVersion>0.7.5.0</FileVersion>
     <!-- Lets `dotnet build` run on Linux/macOS for compile verification. -->
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>

--- a/herdi-win/build.ps1
+++ b/herdi-win/build.ps1
@@ -49,7 +49,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$version = '0.7.3'
+$version = '0.7.5'
 $distDir = Join-Path $scriptDir 'dist'
 $outDir = Join-Path $distDir $Arch
 


### PR DESCRIPTION
**Branch:** `nickrunning:pr/1-release-infra` → `main` · 2 commits · 5 files · +257 −7

---

## Why

**A release here is not a convenience — it is the update channel.** Both desktop apps
ship their own updater pointed at this repo's `releases/latest`, so a half-finished
release reaches every install within ten minutes. Today the mac DMG is published by
hand and the Windows client has never been published at all, which is why arm64 and
the framework-dependent build have never appeared on a release.

**And the version numbers that decide update behaviour currently disagree.** Seven
numbers across five files determine what an app reports; right now `herdi-win` says
0.7.3 while `herdi-mac` says 0.7.5. Both updaters compare the *tag* against the
version compiled into the *running app*
(`herdi-win/Services/Updater.cs:112`, `herdi-mac/Sources/Updater.swift:78`), so an app
built at 0.7.3 and shipped under tag `v0.7.5` offers an update, installs it, and
offers it again — forever. The failure is silent and permanent.

**The two plugin manifests are a worked example of how that happens.** They sat at
0.5.0 through four releases. The only thing writing them was a `sed -i ''` line in
`herdi-mac/build.sh` — the BSD spelling, which on Linux reads the empty string as the
script and the next argument as a file, so the line only ever worked on a mac. `|| true`
made that silent. And a mac build is the wrong trigger for a number that a Linux relay
and a Windows tray also ship.

## What

- **`.github/scripts/check-versions.py`** — the single writer for all seven numbers.
  `--set X.Y.Z` rewrites them, a bare run reports them, and a run with a tag exits 1
  unless every one agrees. The plugin manifests move here, out of `build.sh`.
- **`.github/workflows/release.yml`** — tag push builds the mac and Windows clients and
  creates the release **with its assets in one call**, so it is never briefly
  latest-and-empty. Windows publishes both deployment modes per architecture, because
  `Updater.IsUsableAsset` picks per install and an install whose asset is missing gets
  nothing — or a build that cannot start on its machine. `workflow_dispatch` builds
  everything and skips the release job, as a dry run.
- The version check **gates the whole workflow**, which is the point: it catches the one
  failure mode that cannot be undone from the publisher's side.
- All seven numbers now say **0.7.5**.

## Dependency

**None.** Based on `main`, mergeable in any order relative to the other four PRs.

It touches only `.github/`, `herdi-mac/build.sh`, `herdi-win/build.ps1` and
`herdi-win/Herdi.Win.csproj` — **zero file overlap** with `pr/2-relay-core` and its
stack. (Note `pr/2` touches `herdi-mac/Sources/RelayConnection.swift` and
`herdi-win/Services/HerdrPoller.cs`; different files, no conflict.)

## Testing

No runtime code changes. The existing suite is unaffected and green at this branch tip:
`python -m unittest discover -s tests` → **139 tests, OK**; `sh tests/run.sh` unchanged.

The release workflow itself is exercisable without publishing anything via
`workflow_dispatch`, which builds every client and skips the release job.