### PR TITLE
fix(web): unpin the mobile terminal view from stale header heights and iOS zoom

### DIFF
--- a/tests/test_web_layout.py
+++ b/tests/test_web_layout.py
@@ -34,6 +34,40 @@ class TerminalLayoutTests(unittest.TestCase):
     def test_terminal_height_is_not_calculated_from_a_hardcoded_header_height(self):
         self.assertNotRegex(self.page, r"calc\(\s*100dvh\s*-\s*\d+px\s*\)")
 
+    def test_focusable_fields_never_drop_below_16px(self):
+        """iOS Safari zooms the page whenever a focused control is smaller than
+        16px, and the zoom then pans the fixed panes out from under the
+        viewport. This is a floor, not a design choice."""
+        field_rule = re.compile(
+            r"(?m)^[^\n{}]*\b(?:input|select|textarea)\b[^\n{}]*\{([^}]*)\}"
+        )
+        checked = 0
+        for body in field_rule.findall(self.page):
+            declared = re.search(r"font-size:\s*([\d.]+)(px|rem)", body)
+            if not declared:
+                continue
+            checked += 1
+            size = float(declared.group(1))
+            if declared.group(2) == "rem":
+                size *= 16
+            self.assertGreaterEqual(size, 16, f"field under 16px: {body.strip()[:70]}")
+        self.assertGreater(checked, 0, "no field font-size rules matched; selector drifted")
+
+        # The command palette's search box is styled inline, out of reach of
+        # any rule above.
+        inline = re.search(r'id="cmdSearch"[^>]*font-size:\s*([\d.]+)px', self.page)
+        self.assertIsNotNone(inline, "#cmdSearch lost its inline font-size")
+        self.assertGreaterEqual(float(inline.group(1)), 16)
+
+    def test_page_itself_never_pans_sideways(self):
+        # overflow-x on <body> alone does not hold: the viewport scroller is
+        # <html>, and overscroll-behavior stops a swipe inside .chip-strip or
+        # .term-content from rubber-banding the document.
+        html_rule = css_rule(self.page, "html")
+        self.assertIn("overflow-x: hidden", html_rule)
+        self.assertIn("overscroll-behavior: none", html_rule)
+        self.assertIn("overscroll-behavior: none", css_rule(self.page, "body"))
+
     def test_output_wraps_on_phones_and_stays_pre_once_80_columns_fit(self):
         self.assertIn("white-space: pre-wrap", css_rule(self.page, ".term-content"))
         wide = self.page.split("@media (min-width: 640px)", 1)[1]

--- a/tests/test_web_layout.py
+++ b/tests/test_web_layout.py
@@ -1,0 +1,44 @@
+"""Guard the terminal layout against being re-pinned to a header height.
+
+.terminal-view and .term-history were each positioned with a px offset
+measured against .header / .term-header at the time they were written. Both
+headers later grew when buttons gained 44px touch targets, and nothing tied
+the constants back to them, so the offsets silently went stale. These checks
+fail if such an offset comes back.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+WEB_DIR = Path(__file__).resolve().parents[1] / "web"
+
+
+def css_rule(page, selector):
+    """Body of the first `selector { ... }` rule, ignoring compound selectors."""
+    match = re.search(re.escape(selector) + r"\s*\{([^}]*)\}", page)
+    if not match:
+        raise AssertionError(f"no `{selector} {{ ... }}` rule in index.html")
+    return match.group(1)
+
+
+class TerminalLayoutTests(unittest.TestCase):
+    def setUp(self):
+        self.page = (WEB_DIR / "index.html").read_text(encoding="utf-8")
+
+    def test_panels_are_not_offset_by_a_hardcoded_header_height(self):
+        for selector in (".terminal-view", ".term-history"):
+            with self.subTest(selector=selector):
+                self.assertNotRegex(css_rule(self.page, selector), r"top:\s*\d")
+
+    def test_terminal_height_is_not_calculated_from_a_hardcoded_header_height(self):
+        self.assertNotRegex(self.page, r"calc\(\s*100dvh\s*-\s*\d+px\s*\)")
+
+    def test_output_wraps_on_phones_and_stays_pre_on_desktop(self):
+        self.assertIn("white-space: pre-wrap", css_rule(self.page, ".term-content"))
+        desktop = self.page.split("@media (min-width: 768px)", 1)[1]
+        self.assertIn("white-space: pre;", css_rule(desktop, ".term-content"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_layout.py
+++ b/tests/test_web_layout.py
@@ -34,10 +34,10 @@ class TerminalLayoutTests(unittest.TestCase):
     def test_terminal_height_is_not_calculated_from_a_hardcoded_header_height(self):
         self.assertNotRegex(self.page, r"calc\(\s*100dvh\s*-\s*\d+px\s*\)")
 
-    def test_output_wraps_on_phones_and_stays_pre_on_desktop(self):
+    def test_output_wraps_on_phones_and_stays_pre_once_80_columns_fit(self):
         self.assertIn("white-space: pre-wrap", css_rule(self.page, ".term-content"))
-        desktop = self.page.split("@media (min-width: 768px)", 1)[1]
-        self.assertIn("white-space: pre;", css_rule(desktop, ".term-content"))
+        wide = self.page.split("@media (min-width: 640px)", 1)[1]
+        self.assertIn("white-space: pre;", css_rule(wide, ".term-content"))
 
 
 if __name__ == "__main__":

--- a/web/index.html
+++ b/web/index.html
@@ -37,7 +37,11 @@ document.addEventListener('DOMContentLoaded', () => bind());
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
 *:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; border-radius: 4px; }
-body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; background: var(--bg); color: var(--text); min-height: 100dvh; min-height: -webkit-fill-available; display: flex; flex-direction: column; width: 100%; overflow-x: hidden; }
+/* The page itself never pans sideways. overflow-x on <body> alone does not
+   stop it: the viewport scroller is <html>, and overscroll-behavior keeps a
+   swipe inside .chip-strip or .term-content from rubber-banding the document. */
+html { overflow-x: hidden; overscroll-behavior: none; }
+body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; background: var(--bg); color: var(--text); min-height: 100dvh; min-height: -webkit-fill-available; display: flex; flex-direction: column; width: 100%; overflow-x: hidden; overscroll-behavior: none; }
 
 .header { padding: 12px 16px; display: flex; align-items: center; gap: 10px; border-bottom: 1px solid var(--border); position: relative; }
 .header h1 { font-size: 1rem; font-weight: 700; letter-spacing: -0.02em; }
@@ -55,8 +59,11 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 .settings h2 { font-size: 0.9rem; margin-bottom: 12px; }
 .setting-group { background: var(--surface); border-radius: 10px; padding: 12px; margin-bottom: 12px; }
 .setting-group label { font-size: 0.75rem; color: var(--muted); display: block; margin-bottom: 6px; }
-.setting-group input { width: 100%; padding: 8px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 13px; }
-.setting-group select { width: 100%; padding: 8px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 13px; }
+/* 16px is a floor on every focusable field, not a design choice: iOS Safari
+   zooms the page whenever a focused control is smaller, and the zoom then
+   pans the fixed panes out from under the viewport. Do not lower these. */
+.setting-group input { width: 100%; padding: 8px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 16px; }
+.setting-group select { width: 100%; padding: 8px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 16px; }
 .setting-group .hint { font-size: 0.65rem; color: var(--muted); margin-top: 4px; }
 .setting-group button { margin-top: 8px; padding: 8px 16px; border-radius: 6px; border: none; background: var(--green); color: #000; font-weight: 600; font-size: 13px; cursor: pointer; }
 
@@ -122,7 +129,7 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 .term-history .msg-assistant { color: var(--green); }
 .term-history .msg-text { white-space: pre-wrap; word-break: break-word; }
 .term-search { display: flex; align-items: center; gap: 6px; padding: 8px 12px; background: var(--surface); border-bottom: 1px solid var(--border); }
-.term-search input { flex: 1; padding: 6px 10px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 0.85rem; }
+.term-search input { flex: 1; padding: 6px 10px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 16px; }
 .term-search input:focus { outline: none; border-color: var(--blue); }
 .term-search span { font-size: 0.7rem; color: var(--muted); min-width: 40px; text-align: center; }
 .term-search button { background: none; border: none; color: var(--muted); cursor: pointer; padding: 4px; }
@@ -143,7 +150,7 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 .quick-actions button { padding: 10px 14px; border-radius: 8px; border: none; font-size: 0.8rem; font-weight: 600; cursor: pointer; flex: 1; min-width: 70px; display: flex; align-items: center; justify-content: center; gap: 6px; }
 .btn-yes { background: var(--green); color: #fff; } .btn-trust { background: var(--blue); color: #fff; } .btn-no { background: var(--red); color: #fff; }
 .term-input { border-top: 1px solid var(--border); padding: 8px 12px; display: flex; gap: 6px; background: var(--surface); flex-shrink: 0; }
-.term-input input { flex: 1; padding: 10px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 14px; font-family: 'Hack Nerd Font', 'CaskaydiaCove Nerd Font Mono', 'JetBrainsMono Nerd Font Mono', Consolas, monospace; min-width: 0; }
+.term-input input { flex: 1; padding: 10px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 16px; font-family: 'Hack Nerd Font', 'CaskaydiaCove Nerd Font Mono', 'JetBrainsMono Nerd Font Mono', Consolas, monospace; min-width: 0; }
 .term-input button:last-child { padding: 10px 14px; border-radius: 6px; border: none; background: var(--blue); color: #fff; font-weight: 700; font-size: 16px; flex-shrink: 0; }
 .term-keys { border-top: 1px solid var(--border); padding: 8px 12px; display: flex; flex-direction: column; background: var(--surface); flex-shrink: 0; padding-bottom: env(safe-area-inset-bottom, 8px); }
 .nav-key { padding: 10px 4px; border-radius: 8px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 13px; font-weight: 500; cursor: pointer; min-height: 44px; display: flex; align-items: center; justify-content: center; transition: background 0.15s, border-color 0.15s; }
@@ -362,7 +369,7 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
       <span style="font-size:0.8rem;font-weight:600;flex:1">Commands</span>
       <button onclick="closePalette()" aria-label="Close" style="background:none;border:none;color:var(--muted);font-size:1.2rem;cursor:pointer">✕</button>
     </div>
-    <input id="cmdSearch" type="text" placeholder="Search commands…" autocomplete="off" autocorrect="off" style="margin:8px 12px;padding:10px;border-radius:8px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:14px" oninput="filterCommands()" />
+    <input id="cmdSearch" type="text" placeholder="Search commands…" autocomplete="off" autocorrect="off" style="margin:8px 12px;padding:10px;border-radius:8px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:16px" oninput="filterCommands()" />
     <div id="cmdList" style="overflow-y:auto;padding:4px 12px;"></div>
   </div>
 </div>

--- a/web/index.html
+++ b/web/index.html
@@ -164,6 +164,15 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 
 .empty { text-align: center; color: var(--muted); padding: 60px 20px; font-size: 0.85rem; }
 
+/* Terminal output stops wrapping once ~80 columns fit, which happens well
+   before the desktop layout breakpoint: the clamp() above pins the font at
+   12.8px past 474px, so 80 columns need ~641px of content box. Tablets in
+   portrait (iPad mini is 744px) therefore keep alignment and scroll, while
+   phones and iPad Split View (~507px) still wrap. */
+@media (min-width: 640px) {
+  .term-content { white-space: pre; overflow-wrap: normal; }
+}
+
 /* Desktop */
 @media (min-width: 768px) {
   /* Bound the shell so .view / .terminal-view scroll internally instead of
@@ -176,8 +185,7 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
   .agents { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 12px; }
   .section-header { grid-column: 1 / -1; }
   .chip-strip { grid-column: 1 / -1; }
-  /* Wide enough for 80 columns — keep ASCII tables and box drawing aligned. */
-  .term-content { min-height: 400px; white-space: pre; overflow-wrap: normal; }
+  .term-content { min-height: 400px; }
 }
 @media (min-width: 1200px) {
   body { max-width: 1100px; }

--- a/web/index.html
+++ b/web/index.html
@@ -102,7 +102,9 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 .agent .meta { font-size: 0.7rem; color: var(--muted); margin-top: 2px; }
 
 /* Terminal view */
-.terminal-view { display: none; flex-direction: column; position: fixed; inset: 0; top: 49px; background: var(--bg); z-index: 50; }
+/* Full-screen on phones: the term-header carries its own back button, so
+   covering the app header buys ~69px of output instead of guessing its height. */
+.terminal-view { display: none; flex-direction: column; position: fixed; inset: 0; background: var(--bg); z-index: 50; }
 .terminal-view.active { display: flex; }
 .term-header { padding: 10px 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
 .term-header .back { background: none; border: none; color: var(--blue); font-size: 1.4rem; cursor: pointer; padding: 4px 8px; }
@@ -111,7 +113,9 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 .term-header .search-btn { background: none; border: none; color: var(--muted); cursor: pointer; padding: 4px; }
 .term-header .search-btn:hover, .term-header .refresh-btn:hover, .term-header .history-btn:hover { color: var(--text); }
 .term-header .history-btn { background: none; border: none; color: var(--muted); cursor: pointer; padding: 4px; }
-.term-history { position: absolute; top: 45px; left: 0; right: 0; bottom: 0; background: var(--surface); display: flex; flex-direction: column; z-index: 10; }
+/* Covers the term-header too — the panel has its own title bar and close
+   button, so there is no header height to line up with. */
+.term-history { position: absolute; inset: 0; background: var(--surface); display: flex; flex-direction: column; z-index: 10; }
 .term-history .msg { padding: 8px 0; border-bottom: 1px solid var(--border); }
 .term-history .msg-role { font-size: 0.7rem; font-weight: 600; color: var(--muted); text-transform: uppercase; margin-bottom: 4px; }
 .term-history .msg-user { color: var(--blue); }
@@ -134,7 +138,7 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 .session-item.active { border-color: var(--green); background: color-mix(in srgb, var(--green) 10%, var(--bg)); }
 .session-name { font-weight: 500; flex: 1; }
 .session-url { font-size: 0.7rem; color: var(--muted); font-family: monospace; }
-.term-content { flex: 1; min-width: 0; overflow: auto; padding: 10px 12px; background: var(--term-bg); font-family: 'Hack Nerd Font', 'CaskaydiaCove Nerd Font Mono', 'JetBrainsMono Nerd Font Mono', 'SFMono-Regular', Consolas, monospace; font-size: clamp(0.68rem, 2.7vw, 0.8rem); line-height: 1.35; white-space: pre; color: var(--term-text); -webkit-overflow-scrolling: touch; overscroll-behavior: contain; }
+.term-content { flex: 1; min-width: 0; overflow: auto; padding: 10px 12px; background: var(--term-bg); font-family: 'Hack Nerd Font', 'CaskaydiaCove Nerd Font Mono', 'JetBrainsMono Nerd Font Mono', 'SFMono-Regular', Consolas, monospace; font-size: clamp(0.68rem, 2.7vw, 0.8rem); line-height: 1.35; white-space: pre-wrap; overflow-wrap: anywhere; color: var(--term-text); -webkit-overflow-scrolling: touch; overscroll-behavior: contain; }
 .quick-actions { padding: 8px 12px; border-top: 1px solid var(--border); display: flex; gap: 6px; flex-wrap: wrap; flex-shrink: 0; }
 .quick-actions button { padding: 10px 14px; border-radius: 8px; border: none; font-size: 0.8rem; font-weight: 600; cursor: pointer; flex: 1; min-width: 70px; display: flex; align-items: center; justify-content: center; gap: 6px; }
 .btn-yes { background: var(--green); color: #fff; } .btn-trust { background: var(--blue); color: #fff; } .btn-no { background: var(--red); color: #fff; }
@@ -162,13 +166,18 @@ body { font-family: -apple-system, system-ui, -webkit-system-font, sans-serif; b
 
 /* Desktop */
 @media (min-width: 768px) {
-  body { max-width: 960px; margin: 0 auto; padding: 0 16px; }
-  .terminal-view { position: static; display: none; }
-  .terminal-view.active { display: flex; height: calc(100dvh - 49px); }
+  /* Bound the shell so .view / .terminal-view scroll internally instead of
+     growing the page — what their flex:1 + overflow-y:auto already assumed. */
+  body { max-width: 960px; margin: 0 auto; padding: 0 16px; height: 100dvh; }
+  /* relative, not static: .term-history anchors to this. flex instead of a
+     calc() against a hardcoded header height. */
+  .terminal-view { position: relative; display: none; }
+  .terminal-view.active { display: flex; flex: 1; min-height: 0; }
   .agents { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 12px; }
   .section-header { grid-column: 1 / -1; }
   .chip-strip { grid-column: 1 / -1; }
-  .term-content { min-height: 400px; }
+  /* Wide enough for 80 columns — keep ASCII tables and box drawing aligned. */
+  .term-content { min-height: 400px; white-space: pre; overflow-wrap: normal; }
 }
 @media (min-width: 1200px) {
   body { max-width: 1100px; }


### PR DESCRIPTION
Fixes #47.

At 390px, with synthetic pane content so nothing private is in the shot:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/wuqicyber/herdr-remote/assets/issue-47-before.png) | ![after](https://raw.githubusercontent.com/wuqicyber/herdr-remote/assets/issue-47-after.png) |
| Lines cut off at the right edge, horizontal scrollbar, app header eating 69px | Full-width text, no horizontal scroll, pane gets the whole screen |

The table wraps in the "after" shot because at 390px only ~55 of its ~75 columns fit. Above 640px it stays `pre` — see below.

Three CSS offsets in `web/index.html` were each measured against a header that later grew. This drops the constants rather than updating them, so there is nothing left to drift.

## The constants

| | was | why it broke |
|---|---|---|
| `.terminal-view` (`:105`) | `top: 49px` | Correct in 82d361b, when `.header button` was `padding: 4px`. be03b09 (*"accessibility, touch targets"*) added `min-height: 44px` to those buttons → header became **69px**. Covered the header's bottom 20px ever since. |
| `.term-history` (`:114`) | `top: 45px` | `.term-header` measures **54.5px**, so the panel hid 9.5px of it. |
| `.terminal-view.active` (`:167`) | `height: calc(100dvh - 49px)` | Same stale 49px, in the `min-width: 768px` block. |

## What changed

- **`.terminal-view` → `inset: 0`.** Full-screen on phones; `.term-header` already carries a back button, so covering the app header costs nothing and buys back 69px of output.
- **`.term-history` → `inset: 0`.** The panel has its own title bar and close button, so there is no header to line up with.
- **Desktop → `flex: 1; min-height: 0`** against a height-bounded `body`, instead of the `calc()`. `.view` at `:50` already had `flex: 1; overflow-y: auto`, which assumed a bounded shell; `body` only had `min-height`, so that `overflow-y` was inert and the page scrolled instead. `height: 100dvh` is scoped to the desktop breakpoint.
- **`.terminal-view` `static` → `relative`** on desktop, so the absolutely-positioned `.term-history` anchors to it rather than escaping to the viewport.

## Separately: wrapping at phone widths

`.term-content` was `white-space: pre` at every width. Right for ANSI output on a wide screen, unreadable on a phone — at 390px only ~55 of 80 columns fit, so every line ran off-screen behind a horizontal scrollbar.

It now wraps (`pre-wrap` + `overflow-wrap: anywhere`) below **640px** and keeps `pre` above it. That threshold is deliberately *not* the 768px layout breakpoint — "does the phone layout apply" and "does a terminal line fit" are different questions. The `clamp()` on `.term-content` pins the font at 12.8px above a 474px viewport, so 80 columns need ~641px of content box:

| viewport | columns that fit | wraps? |
|---|---|---|
| 390px (iPhone) | 55 | yes |
| 507px (iPad Split View ½) | 62 | yes |
| 744px (iPad mini portrait) | **93** | no |
| 768px (iPad 9.7 portrait) | 96 | no |
| 1280px | 129 | no |

Tying wrapping to 768px would have mangled ASCII tables on an iPad mini that had 93 columns of room. Verified computed `white-space` across 390 / 507 / 600 / 640 / 744 / 768 / 834 / 1024 / 1280.

## Also: 16px as a floor on focusable fields

Every field was under 16px — settings input and select at 13px, the find box at 0.85rem, the terminal input at 14px, `#cmdSearch` at 14px inline. iOS Safari zooms the page whenever a focused control is smaller, and does not zoom back on blur, which is what makes the input row look truncated and the page draggable. Neither is a layout fault: at a true 390px viewport `.term-input` overflows by 0px (children 30/186/40/40/46) and `documentElement.scrollWidth == clientWidth`.

Set unconditionally rather than under `@media (pointer: coarse)`: iPads with a trackpad report `fine` while still showing the on-screen keyboard, and the palette's inline style would beat any rule without `!important`.

The document is also pinned against sideways movement. `overflow-x` was on `<body>` only — the viewport scroller is `<html>` — and `overscroll-behavior` was `auto`, so a swipe inside `.chip-strip` (496px of off-screen chips) or `.term-content` could rubber-band the document.

## Verification

Chrome, measured before and after:

| | before | after |
|---|---|---|
| `.term-content` horizontal overflow @500px | 240px | **0** |
| `.term-content` height @844px tall | 650px | **714px** |
| `.term-history` covering `.term-header` | 9.5px | **0** |
| `.terminal-view` bottom vs viewport @1280×800 | — | **exactly 800**, page does not scroll |

Desktop keeps `white-space: pre` (confirmed via `getComputedStyle`) and ASCII tables render aligned.

`tests/run.sh`: 21 passed, 0 failed.

## Test

`tests/test_web_layout.py` follows the string-assertion style already used in `tests/test_ansi_terminal.py:98`. It asserts no `top: <n>px` inside the `.terminal-view` / `.term-history` rules, no `calc(100dvh - <n>px)` anywhere, that `.term-content` wraps below 640px while staying `pre` above it, that no field rule declares a size under 16px (the inline `#cmdSearch` included), and that `html`/`body` carry the overflow and overscroll pins.

Verified against the pre-fix `index.html`: every assertion fails there, including all five sub-16px fields and the missing `html` rule. It guards rather than decorates.
