### PR TITLE
fix(relay): read conversation history from the session log

### DIFF
--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -4,7 +4,7 @@
 # dependencies = ["websockets>=14.0", "zeroconf>=0.80.0", "pywebpush>=2.0.0", "py-vapid>=1.9.0"]
 # ///
 """herdr-remote relay — polls herdr, accepts push events (HTTP POST + WebSocket + UDP), broadcasts to clients."""
-import asyncio, hashlib, json, logging, os, re, shutil, signal, socket, subprocess, threading, time
+import asyncio, collections, hashlib, json, logging, os, re, shutil, signal, socket, subprocess, threading, time
 
 try:
     from websockets.asyncio.server import serve
@@ -592,6 +592,80 @@ async def broadcast_sessions():
     if gen != POLL_GENERATION:
         return          # a switch landed while building this; the message is stale
     await broadcast(msg)
+
+
+CLAUDE_SESSION_ROOT = os.path.join(
+    os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude"), "projects"
+)
+
+
+def claude_project_slug(cwd):
+    """Claude Code's directory name for a working directory.
+
+    Every non-alphanumeric character becomes '-'. Claude Code additionally
+    truncates names past 200 characters and appends a hash of the full path;
+    those projects simply read as "no history" here rather than mis-resolving
+    to another project's log.
+    https://code.claude.com/docs/en/sessions#where-transcripts-are-stored
+    """
+    return re.sub(r"[^a-zA-Z0-9]", "-", cwd)
+
+
+def read_session_transcript(cwd, limit=40):
+    """Recent conversation turns from Claude Code's session log for `cwd`.
+
+    Claude Code writes one JSONL per session to
+    <session root>/<project slug>/<session-id>.jsonl. Returns
+    [{"role", "content"}] oldest first, or [] when there is no readable log.
+    """
+    if not cwd:
+        return []
+    session_dir = os.path.join(CLAUDE_SESSION_ROOT, claude_project_slug(cwd))
+    try:
+        logs = [
+            os.path.join(session_dir, name)
+            for name in os.listdir(session_dir)
+            if name.endswith(".jsonl")
+        ]
+        # ponytail: newest file wins. Two panes sharing a cwd therefore share a
+        # transcript; key off a session id here if herdr ever exposes one.
+        newest = max(logs, key=os.path.getmtime)
+    except (OSError, ValueError):
+        return []
+
+    try:
+        with open(newest, encoding="utf-8", errors="replace") as handle:
+            # Transcripts reach tens of MB; only the tail is ever displayed, so
+            # stream the file and keep a bounded window instead of reading it.
+            tail = collections.deque(handle, maxlen=400)
+    except OSError:
+        return []
+
+    messages = []
+    for line in tail:
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        role = row.get("type")
+        if role not in ("user", "assistant"):
+            continue
+        content = (row.get("message") or {}).get("content")
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            # Prose only: tool_use and tool_result blocks are not conversation.
+            text = "\n".join(
+                block["text"]
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
+        else:
+            continue
+        text = text.strip()
+        if text:
+            messages.append({"role": role, "content": text})
+    return messages[-limit:]
 
 
 def read_pane(pane_id, remote=None):
@@ -1302,15 +1376,13 @@ async def handle_client(ws):
                 if pane_id not in known_panes:
                     await ws.send(json.dumps({"type": "error", "message": "unknown pane_id"}))
                     continue
-                remote = pane_remote_map.get(pane_id)
-                # Try to read conversation history from agent's session log
-                history = run_herdr("agent", "history", pane_id, "--format", "json", remote=remote)
+                agent = agent_cache.get(pane_id) or {}
                 messages = []
-                try:
-                    data = json.loads(history) if history else {}
-                    messages = data.get("messages", data.get("history", []))
-                except Exception:
-                    pass
+                # ponytail: local Claude panes only. A remote pane's transcript
+                # lives on the remote host, and other agents do not write this
+                # format; both fall through to the client's empty state.
+                if not pane_remote_map.get(pane_id) and agent.get("agent") == "claude":
+                    messages = read_session_transcript(agent.get("cwd", ""))
                 await ws.send(json.dumps({"type": "history", "pane_id": pane_id, "messages": messages}))
             elif msg_type == "send_keys":
                 pane_id = msg["pane_id"]

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -1558,5 +1558,107 @@ class RelaySubprocessConcurrencyTests(unittest.TestCase):
                     self.assertEqual(local.result(timeout=2), "ok")
 
 
+class RelaySessionTranscriptTests(unittest.TestCase):
+    @staticmethod
+    def _write_log(root, slug, name, rows):
+        session_dir = os.path.join(root, slug)
+        os.makedirs(session_dir, exist_ok=True)
+        path = os.path.join(session_dir, name)
+        with open(path, "w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(json.dumps(row) + "\n")
+        return path
+
+    def test_project_slug_replaces_every_non_alphanumeric_character(self):
+        with loaded_relay() as relay:
+            # Underscores and dots are folded too, not just separators -- a
+            # slug built by replacing '/' alone misses these projects entirely.
+            self.assertEqual(
+                relay.claude_project_slug("/home/user/report_draft__final_"),
+                "-home-user-report-draft--final-",
+            )
+            self.assertEqual(
+                relay.claude_project_slug("/home/user/app.v2"), "-home-user-app-v2"
+            )
+
+    def test_transcript_keeps_prose_and_drops_tool_traffic(self):
+        with loaded_relay() as relay, tempfile.TemporaryDirectory() as root:
+            relay.CLAUDE_SESSION_ROOT = root
+            self._write_log(root, "-home-user-project","a.jsonl", [
+                {"type": "user", "message": {"content": "ship the fix"}},
+                {"type": "assistant", "message": {"content": [
+                    {"type": "text", "text": "Done."},
+                    {"type": "tool_use", "name": "Bash", "input": {}},
+                ]}},
+                {"type": "user", "message": {"content": [
+                    {"type": "tool_result", "content": "exit 0"},
+                ]}},
+                {"type": "attachment", "message": {"content": "not conversation"}},
+                {"type": "assistant", "message": {"content": "   "}},
+            ])
+
+            self.assertEqual(
+                relay.read_session_transcript("/home/user/project"),
+                [
+                    {"role": "user", "content": "ship the fix"},
+                    {"role": "assistant", "content": "Done."},
+                ],
+            )
+            # A pane whose project was never opened in Claude Code is normal,
+            # not an error.
+            self.assertEqual(relay.read_session_transcript("/no/such/project"), [])
+            self.assertEqual(relay.read_session_transcript(""), [])
+
+    def test_transcript_prefers_newest_session_and_survives_a_torn_line(self):
+        with loaded_relay() as relay, tempfile.TemporaryDirectory() as root:
+            relay.CLAUDE_SESSION_ROOT = root
+            older = self._write_log(root, "-home-user-project","older.jsonl", [
+                {"type": "user", "message": {"content": "old session"}},
+            ])
+            newer = self._write_log(root, "-home-user-project","newer.jsonl", [
+                {"type": "user", "message": {"content": "new session"}},
+            ])
+            os.utime(older, (1, 1))
+            os.utime(newer, (2, 2))
+            # Claude Code appends live, so the tail can be half-written.
+            with open(newer, "a", encoding="utf-8") as handle:
+                handle.write("{not json\n")
+                handle.write(json.dumps(
+                    {"type": "assistant", "message": {"content": "still here"}}
+                ) + "\n")
+
+            self.assertEqual(
+                [m["content"] for m in relay.read_session_transcript("/home/user/project")],
+                ["new session", "still here"],
+            )
+
+    def test_get_history_serves_the_log_only_for_local_claude_panes(self):
+        with loaded_relay() as relay, tempfile.TemporaryDirectory() as root:
+            relay.CLAUDE_SESSION_ROOT = root
+            self._write_log(root, "-home-user-project","a.jsonl", [
+                {"type": "assistant", "message": {"content": "from the log"}},
+            ])
+
+            cases = [
+                ("local-claude", "claude", None, [{"role": "assistant", "content": "from the log"}]),
+                ("remote-claude", "claude", "build-box", []),
+                ("local-other", "omp", None, []),
+            ]
+            for pane_id, agent, remote, expected in cases:
+                with self.subTest(pane_id=pane_id):
+                    relay.known_panes.add(pane_id)
+                    relay.agent_cache[pane_id] = {"agent": agent, "cwd": "/home/user/project"}
+                    relay.pane_remote_map[pane_id] = remote
+                    ws = _FakeWebSocket([json.dumps({"type": "get_history", "pane_id": pane_id})])
+
+                    with mock.patch.object(relay, "send_current_snapshot", new=mock.AsyncMock()):
+                        asyncio.run(relay.handle_client(ws))
+
+                    self.assertEqual(
+                        json.loads(ws.sent[-1]),
+                        {"type": "history", "pane_id": pane_id, "messages": expected},
+                    )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #49.

`get_history` has always returned an empty list. It shells out to `herdr agent history`, and `herdr agent` has no `history` subcommand — only list, get, read, send-keys, prompt, rename, focus. herdr prints usage to stderr and exits non-zero; `run_herdr` turns that into `""`; `json.loads("")` raises; `except Exception: pass` discards it. Every pane, every host, since bf20a1c.

The comment on that call already named the right source:

```python
# Try to read conversation history from agent's session log
```

So this reads it.

## Where the log is

Claude Code writes one JSONL per session to `<CLAUDE_CONFIG_DIR or ~/.claude>/projects/<project slug>/<session-id>.jsonl` ([docs](https://code.claude.com/docs/en/sessions#where-transcripts-are-stored)). The relay already caches each pane's `cwd` in `agent_cache`, which is all the slug needs — no new herdr call, no new dependency, no protocol change. The client already renders `{role, content}` and escapes it (`index.html:1048`).

## Details worth reviewing

- **The slug folds every non-alphanumeric character to `-`, not just separators.** This is the easy one to get wrong: replacing only `/` silently misses any project whose name contains `_` or `.`. Verified against a real transcript directory, where a project named `report_draft__final_` is stored as `report-draft--final-`. There is a test pinning this.
- **Only `text` blocks are kept.** `tool_use` and `tool_result` blocks dominate the row count and are machine traffic, not conversation.
- **The file is streamed into a bounded `deque`**, not read whole — transcripts reach tens of MB and only the tail is ever displayed.
- **Malformed lines are skipped, not fatal.** Claude Code appends live, so the final line can be half-written.
- **Remote panes and non-Claude agents fall through to the existing empty state.** Their logs are not local and not this format. Marked in-code rather than faked.
- Claude Code truncates slugs past 200 characters and appends a path hash. Those projects read as "no history" rather than resolving to some other project's log; noted in the docstring.

## Verification

End to end against a running relay, same pane before and after:

```python
await ws.send(json.dumps({"type": "get_history", "pane_id": "w8:p1"}))

# before: {"type": "history", "pane_id": "w8:p1", "messages": []}
# after:  25 messages, alternating user/assistant, oldest first
```

Four tests added to `tests/test_herdr_relay.py`, reusing its existing `loaded_relay` / `_FakeWebSocket` helpers: the slug rule, prose-vs-tool-traffic extraction plus the missing-directory case, newest-session-wins plus a torn trailing line, and the handler itself serving local Claude panes while remote and non-Claude panes stay empty.

`tests/run.sh`: 21 passed, 0 failed.
