### PR TITLE
fix(web): let the web app answer a blocked pane

### DIFF
--- a/tests/test_client_payloads.py
+++ b/tests/test_client_payloads.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from pathlib import Path
 
@@ -20,6 +21,17 @@ class ClientPayloadTests(unittest.TestCase):
         self.assertIn("type:'question_toggle'", source)
         self.assertIn("type:'question_submit'", source)
         self.assertIn("prompt_id:a.prompt_id", source)
+
+    def test_web_sends_prompt_id_with_every_respond(self):
+        """The relay drops a respond whose prompt_id does not match the pane
+        (herdr_relay.py, "prompt changed; refresh and try again"), so a respond
+        without one can never be delivered."""
+        source = (ROOT / "web" / "index.html").read_text(encoding="utf-8")
+
+        sends = re.findall(r"type:'respond'[^}]*}", source)
+        self.assertTrue(sends, "no respond payload found; the send site moved")
+        for payload in sends:
+            self.assertIn("prompt_id", payload)
 
     def test_swift_models_decode_omp_question_state(self):
         for relative_path in (

--- a/tests/test_client_payloads.py
+++ b/tests/test_client_payloads.py
@@ -33,6 +33,18 @@ class ClientPayloadTests(unittest.TestCase):
         for payload in sends:
             self.assertIn("prompt_id", payload)
 
+    def test_web_free_text_retry_keys_on_the_error_the_relay_emits(self):
+        """respond carries allowlisted answers, plus free text on a question the
+        relay can drive itself. A blocked pane is often neither, so typed text
+        falls back to send_text -- keyed on the relay's rejection, verbatim. If
+        either side reworded it the retry would die silently."""
+        message = "free-text response requires a detected question"
+        relay = (ROOT / "relay" / "herdr_relay.py").read_text(encoding="utf-8")
+        web = (ROOT / "web" / "index.html").read_text(encoding="utf-8")
+
+        self.assertIn(message, relay, "relay no longer emits this; the retry is dead")
+        self.assertIn(message, web, "web no longer matches it; typed text is dropped")
+
     def test_swift_models_decode_omp_question_state(self):
         for relative_path in (
             "herdi-ios/Sources/Models/Agent.swift",

--- a/web/index.html
+++ b/web/index.html
@@ -1385,7 +1385,17 @@ function pressCtrl(label) {
 
 function toggleArrows(){}
 function hideArrows(){}
-function respond(t){if(!ws||!activePane)return;if(window.cue)cue('success');ws.send(JSON.stringify({type:'respond',pane_id:activePane,text:t}));document.getElementById('quickActions').innerHTML='';setTimeout(refreshPane,500);}
+function respond(t){
+  if(!ws||!activePane)return;
+  if(window.cue)cue('success');
+  // The relay drops a respond whose prompt_id does not match what the pane is
+  // showing, so send the one that arrived with the blocked message -- same as
+  // sendText() below and as the Telegram and TUI clients.
+  const agent=agents.find(a=>a.pane_id===activePane);
+  ws.send(JSON.stringify({type:'respond',pane_id:activePane,prompt_id:agent?.prompt_id,text:t}));
+  document.getElementById('quickActions').innerHTML='';
+  setTimeout(refreshPane,500);
+}
 document.getElementById('termInput').addEventListener('keydown',e=>{if(e.key==='Enter'){e.preventDefault();sendText();}});
 document.getElementById('termContent').addEventListener('scroll', function() {
   const el = this;

--- a/web/index.html
+++ b/web/index.html
@@ -605,6 +605,17 @@ function handleMessage(msg) {
     // "switching…" forever. Minimum handling only: no toast UI, since
     // nothing else in this file renders errors.
     switchingSession = false;
+    // respond delivers allowlisted answers, plus free text on a pane whose
+    // question the relay can drive itself. Where it can drive neither, type
+    // into the pane instead: send_text has no allowlist of its own, so the
+    // only thing given up is the staleness check respond just performed.
+    // No Enter afterwards -- a blocked pane may be a multi-select, where
+    // Enter toggles the row under the cursor instead of submitting.
+    if (pendingFreeText && msg.message === 'free-text response requires a detected question') {
+      ws.send(JSON.stringify({type:'send_text', pane_id:pendingFreeText.pane_id, text:pendingFreeText.text}));
+      setTimeout(refreshPane, 500);
+    }
+    pendingFreeText = null;
     render();
     return;
   }
@@ -1229,11 +1240,16 @@ function setupLongPress(el, type, id, name) {
   el.addEventListener('contextmenu', (e) => showContextMenu(e, type, id, name));
 }
 
+// Text sent through respond, kept until the relay accepts or rejects it so a
+// rejection can be retried on the channel that can carry it. See handleMessage.
+let pendingFreeText = null;
+
 function sendText() {
   const i=document.getElementById('termInput');
   if(!i.value||!ws||!activePane)return;
   const agent=agents.find(a=>a.pane_id===activePane);
   if(agent&&agent.status==='blocked') {
+    pendingFreeText={pane_id:activePane,text:i.value};
     ws.send(JSON.stringify({type:'respond',pane_id:activePane,prompt_id:agent.prompt_id,text:i.value}));
   } else {
     ws.send(JSON.stringify({type:'send_text',pane_id:activePane,text:i.value}));
@@ -1388,6 +1404,7 @@ function hideArrows(){}
 function respond(t){
   if(!ws||!activePane)return;
   if(window.cue)cue('success');
+  pendingFreeText=null;   // an option button is not the typed text
   // The relay drops a respond whose prompt_id does not match what the pane is
   // showing, so send the one that arrived with the blocked message -- same as
   // sendText() below and as the Telegram and TUI clients.


### PR DESCRIPTION
Fixes #51.

`respond()` builds `{type:'respond', pane_id, text}` with no `prompt_id`. The relay's `respond` handler opens with

```python
if question_prompt_id(pane_id, content) != msg.get("prompt_id", ""):
    return command_error("prompt changed; refresh and try again")
```

and `msg.get("prompt_id", "")` is `""`, which never equals the digest. Both call sites go through `respond()` — the option buttons built from the `blocked` message, and the y / a / n approval keys — so neither has ever reached an agent.

## Drift, not a design choice

| date | commit | |
|---|---|---|
| 2026-06-24 | `18cca09` | `respond()` written in its current shape; `prompt_id` did not exist yet |
| 2026-07-20 | `98e9f5c` | the guard lands with the OMP ask work |
| — | — | `respond()` never updated |

Every other client sends the field — `herdr_telegram.py:104`, `herdr_tui.py:243`, and `sendText()` six lines below `respond()` in this same file. Only `respond()` was left behind, so the OMP option buttons the guard exists to protect are themselves unreachable from the web app.

## Verification

Against a running relay, same idle pane, same text, only the field differing:

```
{"type":"respond","pane_id":"…","text":"zzz-probe"}
  -> "prompt changed; refresh and try again"

{"type":"respond","pane_id":"…","prompt_id":"<question_prompt_id(...)>","text":"zzz-probe"}
  -> "free-text response requires a detected question"
```

The second error is the probe's own doing — an idle pane has no detected question and `zzz-probe` is not in `SAFE_RESPONSES`. The point is that the guard is passed rather than hit.

`tests/run.sh`: 21 passed, 0 failed.

## Second commit: typed text goes to the channel that refuses it

`sendText()` picks its channel by status — `respond` while blocked, `send_text` otherwise. So the unrestricted channel is reachable only when the pane is **not** blocked, which is when there is nothing to answer.

With no detected question, `respond` needs `custom_editor_active(content)` (which greps for `"Enter your response:"` / `"Custom answer:"`) or a value from `SAFE_RESPONSES`. Those strings are OMP's. Measured on a live Claude Code multi-select with its free-text row selected, both are absent, so typed text returns `free-text response requires a detected question` and is dropped — invisibly, since the error is not rendered.

On that rejection the text is now re-sent as `send_text`. **This grants nothing new**: the `send_text` handler validates only that the pane exists and the text is ≤1000 characters, and every connected client can already call it. The client was choosing the more restrictive of two open channels.

No Enter follows the retry — a blocked pane is often a multi-select, where the footer reads "Enter to select" and Enter toggles the row under the cursor rather than submitting. The keyboard tray already sends Enter where it is wanted.

Verified end to end against a live Claude Code multi-select; typing into the input box while blocked landed the text in the prompt's own field:

```
before   ❯ 5. [✔] Type something
after    ❯ 5. [✔] <typed text>
```

## Tests

Both in `tests/test_client_payloads.py`, beside the existing web-payload assertions:

- walks **every** `respond` payload in the page rather than pinning one line, so a future send site cannot repeat the omission. Fails against the current `index.html`, where it finds two payloads and one without the field.
- pins `free-text response requires a detected question` in both `herdr_relay.py` and `index.html`. That string is the only thing coupling the retry to the rejection, and a reword on either side would disable it in silence.

## Not addressed here

The relay's `error` messages are still not rendered anywhere in the page, so other failures remain silent. Surfacing `command_result` / `error` in the UI is a separate change; happy to open one if wanted.

Claude Code's multi-select prompts are still unanswerable by button — the relay's question machinery is scoped to OMP. Filed separately as #53, with measurements, since that scope call is yours.
