### PR TITLE
fix(web): one socket per connect, so switching relays stops looping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,6 +510,21 @@ session view; `hidePanel` restores exactly that, which is also why closing a pan
 reveals the agent list under a live session. The test proves it with `elementFromPoint` at the
 panel's own centre, at both phone and desktop widths.
 
+**There is one socket, and a handler belongs to the socket that installed it.** `close()` is
+asynchronous, so the socket being replaced fires its `onclose` *after* the replacement is already
+live. While the departing socket kept its handlers, that late close reported offline and scheduled
+a reconnect, which then closed the **healthy** socket, whose own close scheduled the next one:
+switching relays started a permanent offline -> connecting -> live cycle every 3s that a reload
+cleared and the next switch started again. So `connect()` detaches the old socket's four handlers
+before closing it, and each new socket's handlers begin `if (ws !== sock) return` — which also
+keeps a snapshot still in flight from the relay you are leaving out of `handleMessage`, where it
+would merge that relay's panes into the next one's state. There is likewise **one pending
+reconnect** (`reconnectTimer`, cleared at the top of `connect()`): two chains each closing the
+other's socket is the same loop by another route. `tests/test_web_connection.py` measures the
+ordering in a browser against a stand-in socket; four of its five tests fail on the code this
+replaced, and the fifth — a dropped socket still reconnecting — is what stops the guard from
+becoming a way of switching reconnection off.
+
 ## WebSocket Protocol
 
 Messages are JSON with a `type` field:

--- a/tests/test_web_connection.py
+++ b/tests/test_web_connection.py
@@ -1,0 +1,196 @@
+"""Tests for how web/ holds its one WebSocket: switching relays, and reconnecting after a drop.
+
+Every claim is about event ORDER, so it is measured in a browser against a stand-in socket whose
+`close()` fires `onclose` on a later task -- the ordering that made a relay switch cycle
+offline -> connecting -> live every 3s until the page was reloaded.
+
+Skipped, not failed, when playwright or a chromium build is missing.
+"""
+import json
+import os
+from pathlib import Path
+import unittest
+
+
+PAGE = (Path(__file__).resolve().parents[1] / "web" / "index.html").as_uri()
+
+CHROME_CANDIDATES = [
+    os.environ.get("HERDR_TEST_CHROME", ""),
+    os.path.expanduser("~/.cache/ms-playwright/chromium-1223/chrome-linux64/chrome"),
+    "/usr/bin/chromium",
+    "/usr/bin/google-chrome",
+]
+
+PHONE = {"width": 390, "height": 844}
+
+RELAY_A = "ws://relay-a.test:8375"
+RELAY_B = "ws://relay-b.test:8375"
+
+PAST_RECONNECT = 3600  # past the app's own 3s, so "no timer fired" is a real claim
+
+
+def _chrome():
+    for path in CHROME_CANDIDATES:
+        if path and os.path.exists(path):
+            return path
+    return None
+
+
+try:  # pragma: no cover - environment probe
+    from playwright.sync_api import sync_playwright
+except ImportError:  # pragma: no cover
+    sync_playwright = None
+
+
+# One browser for the file, one playwright for the process -- see test_web_keys.py: a second
+# playwright instance under `unittest discover` is what makes `page.goto` time out.
+_shared = {}
+
+
+def setUpModule():  # noqa: N802 - unittest's own name
+    if sync_playwright is None or _chrome() is None:
+        return
+    _shared["playwright"] = sync_playwright().start()
+    _shared["browser"] = _shared["playwright"].chromium.launch(executable_path=_chrome())
+
+
+def tearDownModule():  # noqa: N802 - unittest's own name
+    if "browser" in _shared:
+        _shared["browser"].close()
+        _shared["playwright"].stop()
+    _shared.clear()
+
+
+FAKE_SOCKET = """
+window.__sockets = [];
+class FakeSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0;
+    this.closedByApp = false;
+    this.sent = [];
+    this.onopen = this.onclose = this.onerror = this.onmessage = null;
+    window.__sockets.push(this);
+  }
+  send(data) { this.sent.push(data); }
+  close() {
+    if (this.readyState === 3) return;
+    this.closedByApp = true;
+    this.readyState = 3;
+    setTimeout(() => { if (this.onclose) this.onclose({}); }, 0);
+  }
+}
+FakeSocket.CONNECTING = 0; FakeSocket.OPEN = 1; FakeSocket.CLOSING = 2; FakeSocket.CLOSED = 3;
+window.WebSocket = FakeSocket;
+
+window.__sock = i => window.__sockets[i];
+window.__open = i => { const s = window.__sockets[i]; s.readyState = 1; if (s.onopen) s.onopen({}); };
+window.__drop = i => { const s = window.__sockets[i]; s.readyState = 3; if (s.onclose) s.onclose({}); };
+window.__msg = (i, payload) => {
+  const s = window.__sockets[i];
+  if (s.onmessage) s.onmessage({data: JSON.stringify(payload)});
+};
+window.__conn = () => document.getElementById('connLabel').textContent;
+window.__state = () => window.__sockets.map(s => ({url: s.url, readyState: s.readyState, closedByApp: s.closedByApp}));
+"""
+
+
+def _seed(url, sessions):
+    # A script BODY, not a function: an arrow expression here is never called, and the app then
+    # boots against its own `ws://` fallback instead of the seeded relay.
+    return (
+        "localStorage.setItem('herdr_relay_url', %s);\n"
+        "localStorage.removeItem('herdr_relay_token');\n"
+        "localStorage.setItem('herdr_sessions', %s);\n"
+    ) % (json.dumps(url), json.dumps(json.dumps(sessions)))
+
+
+@unittest.skipIf(sync_playwright is None, "playwright is not installed")
+@unittest.skipIf(_chrome() is None, "no chromium build available")
+class WebConnectionTests(unittest.TestCase):
+    """One live socket at a time, and one pending reconnect at a time."""
+
+    def setUp(self):
+        # A page per test: a reconnect timer left over from one would look just like the bug the
+        # next one is measuring.
+        self.page = _shared["browser"].new_page(viewport=PHONE)
+        self.page.add_init_script(
+            _seed(RELAY_A, [{"name": "A", "url": RELAY_A}, {"name": "B", "url": RELAY_B}])
+        )
+        self.page.add_init_script(FAKE_SOCKET)
+        self.page.goto(PAGE)  # nav.js boots the first connect on a 100ms timer
+        self.page.wait_for_function("() => window.__sockets.length === 1")
+        self.page.evaluate("() => __open(0)")
+        self.assertEqual(self.page.evaluate("() => __conn()"), "live")
+
+    def tearDown(self):
+        self.page.close()
+
+    def switch_to_b(self):
+        """What the reader does: tap the other saved session."""
+        self.page.evaluate("() => switchSession(1)")
+        self.page.wait_for_function("() => window.__sockets.length === 2")
+        self.page.evaluate("() => __open(1)")
+
+    # --- the reported bug ---
+
+    def test_a_relay_switch_leaves_one_live_socket(self):
+        """The old socket's late close must not take the new socket down with it."""
+        self.switch_to_b()
+        self.assertEqual(self.page.evaluate("() => __conn()"), "live")
+        self.page.wait_for_timeout(PAST_RECONNECT)
+        state = self.page.evaluate("() => __state()")
+        self.assertEqual(len(state), 2, "a third socket means a reconnect fired: %s" % state)
+        self.assertEqual(state[1]["url"], RELAY_B)
+        self.assertFalse(state[1]["closedByApp"], "the healthy socket was closed again")
+        self.assertEqual(self.page.evaluate("() => __conn()"), "live")
+
+    def test_the_old_sockets_close_does_not_report_offline(self):
+        """The status after a switch is the NEW socket's, not the departing one's."""
+        self.page.evaluate("() => switchSession(1)")
+        # Let the old socket's queued close land before the new one opens -- the ordering that
+        # used to paint 'offline' over a connecting socket.
+        self.page.wait_for_timeout(50)
+        self.assertEqual(self.page.evaluate("() => __conn()"), "connecting…")
+        self.page.evaluate("() => __open(1)")
+        self.assertEqual(self.page.evaluate("() => __conn()"), "live")
+
+    def test_a_message_from_the_relay_left_behind_is_ignored(self):
+        """A snapshot in flight from relay A must not merge into relay B's state."""
+        self.page.evaluate(
+            "() => __msg(0, {type: 'agents', agents: [{pane_id: 'a:p1', agent: 'claude', status: 'idle'}]})"
+        )
+        self.assertEqual(self.page.evaluate("() => agents.map(a => a.pane_id)"), ["a:p1"])
+        self.switch_to_b()
+        self.page.evaluate(
+            "() => __msg(0, {type: 'agents', agents: [{pane_id: 'stale:p9', agent: 'claude', status: 'idle'}]})"
+        )
+        self.assertEqual(self.page.evaluate("() => agents.map(a => a.pane_id)"), ["a:p1"])
+
+    # --- and the reconnect it must not have broken ---
+
+    def test_a_dropped_socket_reconnects_once(self):
+        """The guard is per socket, not a way of switching reconnection off."""
+        self.page.evaluate("() => __drop(0)")
+        self.assertEqual(self.page.evaluate("() => __conn()"), "offline")
+        self.page.wait_for_function("() => window.__sockets.length === 2", timeout=6000)
+        self.page.evaluate("() => __open(1)")
+        self.assertEqual(self.page.evaluate("() => __conn()"), "live")
+        self.page.wait_for_timeout(PAST_RECONNECT)
+        self.assertEqual(len(self.page.evaluate("() => __state()")), 2)
+
+    def test_a_manual_connect_does_not_fork_the_reconnect_chain(self):
+        """Two chains would each keep closing the other's socket, which is the same loop."""
+        self.page.evaluate("() => __drop(0)")   # schedules a reconnect
+        self.page.evaluate("() => connect()")   # the reader, not waiting for it
+        self.page.wait_for_function("() => window.__sockets.length === 2")
+        self.page.evaluate("() => __open(1)")
+        self.page.wait_for_timeout(PAST_RECONNECT)
+        state = self.page.evaluate("() => __state()")
+        self.assertEqual(len(state), 2, "the scheduled reconnect survived the manual one: %s" % state)
+        self.assertFalse(state[1]["closedByApp"])
+        self.assertEqual(self.page.evaluate("() => __conn()"), "live")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -264,20 +264,37 @@ function renderSessions() {
 }
 
 // Connection
+//
+// `close()` is asynchronous, so the socket being replaced fires its `onclose` after the replacement
+// is already live. Left attached, that late close reported offline and scheduled a reconnect which
+// then closed the healthy socket -- switching relays started a permanent offline/connecting/live
+// cycle. Hence: detach before closing, a per-socket guard, and one pending reconnect at a time.
+let reconnectTimer = null;
+
 function connect() {
   let url = localStorage.getItem('herdr_relay_url') || (isSelfRelay ? autoRelayUrl : (isDemo ? DEMO_RELAY : ''));
   if (!url) { showSetup(); return; }
-  if (ws) ws.close();
+  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+  if (ws) {
+    ws.onopen = ws.onclose = ws.onerror = ws.onmessage = null;
+    ws.close();
+  }
   setStatus('connecting');
   // Append token as query param if stored separately
   const token = localStorage.getItem('herdr_relay_token');
   let wsUrl = url;
   if (token) wsUrl += (url.includes('?') ? '&' : '?') + 'token=' + encodeURIComponent(token);
-  ws = new WebSocket(wsUrl);
-  ws.onopen = () => { setStatus('connected'); if(window.cue) cue('ready'); };
-  ws.onclose = () => { setStatus('disconnected'); setTimeout(connect, 3000); };
-  ws.onerror = () => setStatus('disconnected');
-  ws.onmessage = (e) => handleMessage(JSON.parse(e.data));
+  const sock = new WebSocket(wsUrl);
+  ws = sock;
+  sock.onopen = () => { if (ws !== sock) return; setStatus('connected'); if(window.cue) cue('ready'); };
+  sock.onclose = () => { if (ws !== sock) return; setStatus('disconnected'); scheduleReconnect(); };
+  sock.onerror = () => { if (ws !== sock) return; setStatus('disconnected'); };
+  sock.onmessage = (e) => { if (ws !== sock) return; handleMessage(JSON.parse(e.data)); };
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer) clearTimeout(reconnectTimer);
+  reconnectTimer = setTimeout(() => { reconnectTimer = null; connect(); }, 3000);
 }
 
 function setStatus(s) {


### PR DESCRIPTION
Closes #54.

## The bug

`ws.close()` is asynchronous, so the socket being replaced fires its `onclose` **after** the
replacement has already been created and reported live. Its handler was still attached, and it
scheduled a reconnect — which then closed the *healthy* socket, whose own close scheduled the next
one. Switching relays therefore started a permanent `offline → connecting → live` cycle, one turn
every 3s, that only a reload cleared and that the next switch started again.

| # | what runs on a switch | result |
|---|---|---|
| 1 | `connect()` → `close()` on socket **A** | A's close event is *queued* |
| 2 | socket **B** created, `ws` points at it, B opens | `live` |
| 3 | A's `onclose` fires | `offline` + `setTimeout(connect, 3000)` |
| 4 | that timer runs `connect()` | closes the **healthy** B → `connecting` → C → `live` |
| 5 | B's `onclose` fires | `offline` + another timer, forever |

No relay change is needed to trigger it: saving the *same* URL while a socket is live does it too
(measured below).

## The fix

Three rules, all inside `connect()`:

1. **Detach before closing.** The departing socket's four handlers are nulled before `close()`, so
   its late close cannot report offline, cannot schedule a reconnect, and cannot deliver a snapshot
   still in flight from the relay being left — which used to merge that relay's panes, spaces and
   shell panes into the next relay's state.
2. **A handler belongs to the socket that installed it.** Each one begins `if (ws !== sock) return`,
   so only the current socket can move the UI.
3. **One pending reconnect.** `reconnectTimer` is cleared on entry to `connect()`, so a manual
   connect cancels the scheduled one instead of forking a second chain — two chains each closing
   the other's socket is the same loop by another route, reachable without any switch (a transient
   drop, then Save before the 3s elapses).

Nothing else in the app touches the socket except through the `ws` global, so the change is
contained to that one function plus the timer beside it.

## Tests

`tests/test_web_connection.py` — 5 tests, in chromium via playwright, against a stand-in socket
whose `close()` fires `onclose` on a later task, since every claim here is about that ordering.
Skipped, not failed, where playwright or chromium is missing, and it shares the file-scope browser
convention the other `test_web_*.py` files use.

- a relay switch leaves **one** live socket, and no third socket appears within 3.6s
- the status during a switch is the new socket's, not the departing one's
- a snapshot arriving on the old socket after a switch is ignored
- a dropped socket still reconnects, exactly once ← the guard must not become a way of
  switching reconnection off
- a manual connect does not fork the reconnect chain

**Four of the five fail on the code this replaces.** Their failure output is the loop itself:

```
AssertionError: 3 != 2 : a third socket means a reconnect fired:
  [{'url': 'ws://relay-a.test:8375', 'readyState': 3, 'closedByApp': True},
   {'url': 'ws://relay-b.test:8375', 'readyState': 3, 'closedByApp': True},   <- the live one, closed again
   {'url': 'ws://relay-b.test:8375', 'readyState': 0, 'closedByApp': False}]
AssertionError: 'offline' != 'connecting…'
AssertionError: Lists differ: ['stale:p9'] != ['a:p1']
```

And the same measurement for a plain Save of the URL that is *already* connected, before and after:

| | sockets after 3.6s | label |
|---|---|---|
| before | 3, the live one closed again | `offline` (mid-cycle) |
| after | 2 | `live` |

Full suite: 208 browser tests, `tests/run.sh` 23/23 pass.

`CLAUDE.md` gains a short paragraph in the Web App section recording the invariant, since the
failure mode is invisible in the source — the code looked correct, and the bug lived entirely in
when the close event was delivered.
