### PR TITLE
fix(aws-tunnel): self-heal a stale SSH security-group rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Monitor"]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .swiftpm/
 .venv/
 .wrangler/
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,21 @@
 - Write clear, concise commit messages
 - Stage only files related to the current task
 - Do not push to main/master without explicit permission
+
+## Remote access tunnel backends
+
+`HERDR_TUNNEL_MODE` (in `~/.config/herdr-remote/config.env`) selects how
+the relay is reached remotely: `temp`/`named` (Cloudflare Tunnel, the
+default, driven by `relay/install-service.sh`) or `aws` (a reverse SSH
+tunnel to a self-hosted EC2 host, driven by `relay/tunnel-aws.sh`; see
+`infra/aws-tunnel/README.md` for the host definition, cost, and deploy
+steps). `relay/herdr-remote` is the canonical `start/stop/status` wrapper
+and supports both. The relay itself always stays bound to loopback
+(`relay/herdr_relay.py`) regardless of tunnel backend.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,12 @@ steps). `relay/herdr-remote` is the canonical `start/stop/status` wrapper
 and supports both. The relay itself always stays bound to loopback
 (`relay/herdr_relay.py`) regardless of tunnel backend.
 
+In `aws` mode, `relay/aws-fw-heal.sh` finds the tunnel's EC2 instance by
+its CloudFormation tags (`project=herdr-remote`, `Name=herdr-remote-tunnel`)
+rather than a hard-coded instance/security-group id - do the same in any
+future AWS-tunnel tooling. It only ever adds an SSH ingress `/32`, never
+revokes one; see its header comment before changing that.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ herdr-remote is a multi-client system for monitoring and approving [herdr](https
 Clients (web/mac/ios/telegram/tui)
         │ WebSocket
         ▼
-   relay (:8375)  ←── Cloudflare tunnel (public wss://)
+   relay (:8375)  ←── remote tunnel (public wss://)
         │
         ▼
    herdr CLI (local or SSH to HERDR_REMOTES)
@@ -40,7 +40,7 @@ All Python scripts use [PEP 723 inline metadata](https://peps.python.org/pep-072
 # Relay (main server)
 uv run relay/herdr_relay.py
 
-# Full setup with Cloudflare tunnel
+# Full setup with relay + tunnel (Cloudflare by default; aws via HERDR_TUNNEL_MODE)
 relay/start.sh
 
 # Telegram bot
@@ -68,6 +68,11 @@ cd herdi-ios && xcodegen generate
 | `HERDR_REMOTES` | Comma-separated SSH targets to poll |
 | `HERDR_BIN` | Path to herdr binary (default: `/opt/homebrew/bin/herdr`) |
 | `HERDR_RELAY` | Relay URL used by clients (default: `ws://127.0.0.1:8375`) |
+
+The relay always binds to loopback; a tunnel is what makes it reachable
+remotely. `HERDR_TUNNEL_MODE` selects the backend (Cloudflare Tunnel or an
+AWS reverse SSH tunnel) - see `relay/.env.example` for the full set of
+tunnel variables and `infra/aws-tunnel/README.md` for the AWS host.
 
 ## Web App
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -37,7 +37,7 @@ Credentials are stored in `~/.config/herdr-remote/secrets.env` with owner-only p
 
 ## 3. Optional remote web and agent access
 
-Cloudflare is only needed when a browser or agent outside your local network must connect directly to the relay:
+A tunnel is only needed when a browser or agent outside your local network must connect directly to the relay:
 
 ```bash
 cloudflared tunnel --url http://localhost:8375
@@ -51,6 +51,10 @@ herdr plugin install dcolinmorgan/herdr-push
 export HERDR_RELAY="https://your-tunnel.trycloudflare.com"
 herdr server reload-config
 ```
+
+If Cloudflare quick tunnels don't work for you, the README's
+[AWS reverse tunnel](README.md#aws-reverse-tunnel) section covers the
+self-hosted alternative.
 
 ## 4. Monitor
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -62,7 +62,7 @@ self-hosted alternative.
 
 **Telegram:** send `/start` for a clickable dashboard of every running agent. Select an agent, then reply to the generated output prompt. Finished and blocked notifications also provide **Open output & reply**, and larger herds include Previous and Next buttons.
 
-**Web app** (phone): open [herdr-remote.pages.dev](https://herdr-remote.pages.dev), tap ⚙, and paste the tunnel URL.
+**Web app** (phone): run `herdr-remote url` and tap the link it prints - it carries the tunnel URL and token, so the app needs no setup. (The hosted page at herdr-remote.pages.dev is gated behind the upstream author's Cloudflare Access org and is not reachable, so we no longer point you there.)
 
 **Menu bar app** (macOS): download from [Releases](https://github.com/dcolinmorgan/herdr-remote/releases).
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ cd herdr-remote/relay && ./start.sh
 
 Open [herdr-demo.pages.dev](https://herdr-demo.pages.dev) on your phone, paste the tunnel URL.
 
+By default `start.sh` uses a free Cloudflare quick tunnel. If that doesn't
+work for you (or you'd rather run your own rendezvous host), see
+[AWS reverse tunnel](#aws-reverse-tunnel) below.
+
 ### Windows
 
 With Git, [uv](https://docs.astral.sh/uv/), and `herdr` installed:
@@ -119,6 +123,40 @@ The `/start`, `/read`, `/reply`, `/send`, `/interrupt`, and `/trust` pickers kee
 
 Finished and blocked notifications include **Open output & reply**. You can also reply directly to the notification to send a follow-up without returning to the agent list. Blocked notifications retain their one-tap approval controls.
 
+## AWS reverse tunnel
+
+An alternative to Cloudflare Tunnel: a small EC2 host you control
+terminates TLS and forwards to the relay over a reverse SSH tunnel the
+Mac opens outbound. Nothing inbound is ever opened on the Mac or the
+home router, and the relay stays loopback-only, exactly as with
+Cloudflare Tunnel.
+
+1. Deploy the rendezvous host (one-time, by hand — this repo only ships
+   the definition, it does not apply it): see
+   [`infra/aws-tunnel/README.md`](infra/aws-tunnel/README.md) for the
+   CloudFormation template, cost (~$4/mo), and deploy steps.
+2. Generate a tunnel-only SSH keypair and add its public half as the
+   stack's `TunnelPublicKey` parameter (see that README).
+3. Add to `~/.config/herdr-remote/config.env`:
+   ```bash
+   HERDR_TUNNEL_MODE=aws
+   HERDR_AWS_HOST=herdr-remote.example.com
+   HERDR_AWS_SSH_KEY=/Users/you/.ssh/herdr-remote-tunnel
+   ```
+4. `cd relay && ./install-service.sh` (or `./start.sh` for a foreground
+   run) — it detects `HERDR_TUNNEL_MODE=aws` and supervises
+   `tunnel-aws.sh` instead of `cloudflared`. Install
+   [`autossh`](https://formulae.brew.sh/formula/autossh) for fast
+   reconnects after a dropped link; a plain-`ssh` retry loop is used
+   otherwise.
+5. Open `https://<HERDR_AWS_HOST>` on your phone.
+6. To take it down again, use `relay/herdr-remote stop`, not a plain `kill`:
+   the supervised services restart a killed process within seconds. `stop`
+   stops the launchd/systemd services and then re-checks past that restart
+   delay, printing "Stopped" only once it has confirmed the relay port is
+   closed and no tunnel process remains. If it cannot confirm that, it says so
+   and exits non-zero — until then, assume the endpoint is still reachable.
+
 ## Architecture
 
 ```
@@ -134,7 +172,7 @@ Finished and blocked notifications include **Open output & reply**. You can also
        └───── WebSocket ──┴──────────────────┘
                    │
         ┌──────────┴──────────┐
-        │   relay (:8375)     │  <- Cloudflare tunnel
+        │   relay (:8375)     │  <- Cloudflare tunnel, or AWS reverse tunnel
         └──────────┬──────────┘
                    │
      ┌─────────────┼─────────────┐
@@ -174,7 +212,8 @@ uv run relay/herdr_relay.py
 - macOS 14+ (menu bar app)
 - Windows 10+ (relay/web/TUI/Telegram; no tray app)
 - Python 3.10+ with [uv](https://docs.astral.sh/uv/) (relay/TUI/bot)
-- `cloudflared` (for remote access)
+- `cloudflared` (for remote access via Cloudflare Tunnel), or `autossh` +
+  the AWS rendezvous host (see [AWS reverse tunnel](#aws-reverse-tunnel))
 - herdr 0.7+
 - Zero-dep plugin: [`herdr-push`](https://github.com/dcolinmorgan/herdr-push)
 

--- a/infra/aws-tunnel/README.md
+++ b/infra/aws-tunnel/README.md
@@ -121,18 +121,46 @@ curl -sS -o /dev/null -w '%{http_code}\n' https://herdr-remote.example.com/
 ## Updating the SSH-allowed CIDR
 
 Home IPs on residential ISPs are not always static. If `SshAllowedCidr`
-goes stale, the reverse tunnel will fail to connect. Update the security
-group directly rather than re-running the whole stack:
+goes stale, the reverse tunnel will fail to connect - symptoms: `herdr-remote
+status` shows the URL as not reachable, the rendezvous host answers on 443
+(Caddy is up) but port 22 times out or is refused.
+
+**`herdr-remote start` self-heals this automatically** when run in `aws`
+tunnel mode: it determines your current public IP, checks it against the
+security group's port-22 ingress (discovered from the running instance's
+`project=herdr-remote`/`Name=herdr-remote-tunnel` tags, not a hard-coded
+group id), and adds it if missing - see `relay/aws-fw-heal.sh`. It only
+ever *adds* a `/32`; it never revokes or replaces an existing entry, so old
+addresses accumulate rather than getting silently dropped (clean those up
+by hand if you care to). `herdr-remote status` runs the same check
+read-only and names a stale rule as the cause instead of just recommending
+a restart. Both need the AWS CLI with credentials that can read/modify this
+security group - set `HERDR_AWS_PROFILE`/`HERDR_AWS_REGION` in
+`~/.config/herdr-remote/config.env` if the default credential chain isn't
+already pointed at the right account (see `relay/.env.example`). Without
+usable credentials, both commands say so plainly and continue rather than
+pretending the check passed.
+
+To do the same thing by hand instead:
 
 ```bash
-aws ec2 update-security-group-rule-descriptions-ingress ...  # or:
+aws ec2 authorize-security-group-ingress --group-id sg-xxxx \
+  --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges="[{CidrIp=$(curl -s ifconfig.me)/32}]"
+```
+
+or, to also update the CloudFormation parameter so a future stack recreate
+starts from the current address (this does not touch the security group
+itself beyond what the command above already did - `update-stack` only
+changes the *next* deploy's baseline):
+
+```bash
 aws cloudformation deploy ... --parameter-overrides SshAllowedCidr="$(curl -s ifconfig.me)/32" ...
 ```
 
-The second form is simplest - CloudFormation only touches the changed
-rule. (This works because `SshAllowedCidr` maps to a security-group rule,
-which CloudFormation updates in place. The host-config parameters below do
-**not** behave this way - read on before you change one.)
+(This works because `SshAllowedCidr` maps to a security-group rule, which
+CloudFormation updates in place - including *revoking* the old CIDR, unlike
+the self-heal above. The host-config parameters below do **not** behave
+this way - read on before you change one.)
 
 ## Changing a parameter after first boot (IMPORTANT)
 

--- a/infra/aws-tunnel/README.md
+++ b/infra/aws-tunnel/README.md
@@ -88,16 +88,23 @@ aws cloudformation describe-stacks --profile landerafs --region us-east-1 \
 and create an A record for `HostnameFqdn` pointing at the printed
 `ElasticIp` in whatever DNS provider hosts that domain.
 
-Then restart Caddy once, after the A record actually resolves:
+Then restart Caddy once, after the A record actually resolves. The command
+below uses `aws ssm send-command`, which needs nothing beyond the AWS CLI
+you already have:
 
 ```bash
-aws ssm start-session --profile landerafs --region us-east-1 \
-  --target "$(aws cloudformation describe-stacks --profile landerafs \
-    --region us-east-1 --stack-name herdr-remote-tunnel \
-    --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" --output text)"
-# then, in the session:
-sudo systemctl restart caddy
+INSTANCE_ID="$(aws cloudformation describe-stacks --profile landerafs \
+  --region us-east-1 --stack-name herdr-remote-tunnel \
+  --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" --output text)"
+
+aws ssm send-command --profile landerafs --region us-east-1 \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name AWS-RunShellScript \
+  --parameters 'commands=["systemctl restart caddy"]'
 ```
+
+If you would rather get an interactive shell on the host (`aws ssm start-session --target "$INSTANCE_ID"`, then `sudo systemctl restart caddy`), note that `start-session` additionally requires the `session-manager-plugin`, a separate install that is **not** in the Prerequisites above (see <https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html>).
+`send-command` avoids that dependency, which is why it is the form shown here.
 
 This step is not optional housekeeping.
 Caddy is enabled at first boot, which is necessarily before the Elastic IP is associated and long before you have created the A record, so its first few ACME attempts fail and certmagic backs off exponentially.
@@ -123,25 +130,79 @@ aws cloudformation deploy ... --parameter-overrides SshAllowedCidr="$(curl -s if
 ```
 
 The second form is simplest - CloudFormation only touches the changed
-rule.
+rule. (This works because `SshAllowedCidr` maps to a security-group rule,
+which CloudFormation updates in place. The host-config parameters below do
+**not** behave this way - read on before you change one.)
+
+## Changing a parameter after first boot (IMPORTANT)
+
+**`HostnameFqdn`, `TunnelPort`, and `TunnelPublicKey` cannot be changed by re-running the stack.**
+**A stack update that changes one of them reports success and changes nothing on the running host.**
+
+All three land in the instance's UserData (the Caddyfile hostname, the reverse-proxy port, and the `herdr-tunnel` `authorized_keys` line), and cloud-init runs UserData **only on the instance's first boot**.
+An `aws cloudformation deploy` that changes one of these rewrites the UserData attribute and prints `UPDATE_COMPLETE`, but it neither re-runs UserData nor replaces the instance - the box keeps its original config.
+Observed: changing `HostnameFqdn` reported success while `/etc/caddy/Caddyfile` on the host still held the old name and HTTPS stayed down.
+
+**The `TunnelPublicKey` case is a security footgun.**
+Rotating the key looks like it succeeded - `UPDATE_COMPLETE` - but the **old key keeps working** and the new key is never installed.
+A key rotation you believe happened has not happened.
+Do not trust a stack update to revoke a key.
+
+To change any of these three, pick one:
+
+- **Recommended: delete and recreate the stack** so UserData runs fresh with the new value.
+  ```bash
+  aws cloudformation delete-stack --profile landerafs --region us-east-1 \
+    --stack-name herdr-remote-tunnel
+  # wait for DELETE_COMPLETE, then redeploy with the new parameter value.
+  ```
+  Note the Elastic IP is released on delete, so the public address changes unless you allocate and pass a fixed one.
+
+- **In place, without recreating: re-run the instance's own UserData over SSM.**
+  This is the workaround the initial deploy used to apply a hostname change.
+  After a stack update has written the new value into the UserData attribute:
+  ```bash
+  INSTANCE_ID="$(aws cloudformation describe-stacks --profile landerafs \
+    --region us-east-1 --stack-name herdr-remote-tunnel \
+    --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" --output text)"
+
+  # For a TunnelPublicKey rotation or a TunnelUser change, delete the old user
+  # first so the script's `useradd` does not abort:
+  #   userdel -r herdr-tunnel
+  # Then re-execute the (already-updated) UserData:
+  aws ssm send-command --profile landerafs --region us-east-1 \
+    --instance-ids "$INSTANCE_ID" --document-name AWS-RunShellScript \
+    --parameters 'commands=["TOKEN=$(curl -sX PUT http://169.254.169.254/latest/api/token -H \"X-aws-ec2-metadata-token-ttl-seconds: 60\"); curl -s -H \"X-aws-ec2-metadata-token: $TOKEN\" http://169.254.169.254/latest/user-data > /tmp/ud.sh; bash /tmp/ud.sh"]'
+  ```
+
+The proper long-term fix is to move host config into `cfn-init` + `cfn-hup` so stack updates apply in place.
+That is a larger change that needs a live create-then-update test cycle to prove, which is why this template documents the limitation loudly instead of shipping an unverified rewrite.
+The same warning is repeated as a comment above the `TunnelInstance` resource in `cloudformation.yaml`.
 
 ## Cost
 
-All figures are `us-east-1` on-demand, August 2026 pricing, for the
-resources this template creates:
+All figures are `us-east-1` on-demand, verified 2026-08-22 against this
+account's own AWS Price List API (`aws pricing get-products`, region
+`us-east-1`), for the resources this template creates. Monthly figures
+assume 730 hours:
 
-| Resource | Cost |
-|---|---|
-| `t4g.nano` (2 vCPU burstable, 0.5 GiB), running 24/7 | ~$3.00/mo |
-| Elastic IP, attached to a running instance | $0.00/mo (free while associated) |
-| EBS gp3 8 GiB root volume | ~$0.65/mo |
-| Data transfer out (phone/browser traffic; tiny for this use case) | ~$0.10-0.50/mo |
-| Route 53 hosted zone (only if you opt in via `HostedZoneId` and don't already have one) | $0.50/mo |
+| Resource | Rate | Cost |
+|---|---|---|
+| `t4g.nano` (2 vCPU burstable, 0.5 GiB), running 24/7 | $0.0042/hr | ~$3.07/mo |
+| In-use public IPv4 address (the Elastic IP, while associated) | $0.005/hr | ~$3.65/mo |
+| EBS gp3 8 GiB root volume | $0.08/GiB-mo | ~$0.64/mo |
+| Data transfer out (phone/browser traffic; tiny for this use case) | - | ~$0.10-0.50/mo |
+| Route 53 hosted zone (only if you opt in via `HostedZoneId` and don't already have one) | - | $0.50/mo |
 
-**Total: roughly $4/mo**, or ~$4.50/mo if you also stand up a fresh
+**Total: roughly $7.5/mo**, or ~$8/mo if you also stand up a fresh
 Route 53 zone for this. No per-request or bandwidth surprises at this
 traffic level - this is a single phone dashboard polling one relay, not
 a public service.
+
+> The Elastic IP is **not** free.
+> Since 2024-02-01 AWS charges $0.005/hr for every public IPv4 address, in-use addresses included, so an EIP attached to a running instance costs ~$3.65/mo - about as much as the instance itself.
+> An earlier version of this table listed it at $0.00/mo and undercounted the total by roughly half.
+> The rate above was read from the Price List API (`USE1-PublicIPv4:InUseAddress`); confirm the current figure the same way before quoting it.
 
 ## Security model, in one place
 

--- a/infra/aws-tunnel/README.md
+++ b/infra/aws-tunnel/README.md
@@ -1,0 +1,197 @@
+# AWS rendezvous host
+
+Replaces the Cloudflare quick tunnel with a small EC2 host you control.
+The Mac dials **out** to it over a reverse SSH tunnel (`ssh -R`) - no
+inbound port is ever opened on the Mac or the home router - and a phone
+browser reaches it over HTTPS. The relay itself never leaves loopback on
+the Mac.
+
+```
+Phone browser ──HTTPS──▶ Caddy :443 ──▶ 127.0.0.1:9375 (EC2)
+                                              ▲
+                                              │ ssh -R 127.0.0.1:9375:127.0.0.1:8375
+                                              │ (Mac dials out, autossh-supervised)
+                                              │
+                                    relay :8375 (127.0.0.1 only, on the Mac)
+```
+
+## Why CloudFormation, not CDK
+
+`landvera/infra` uses CDK, but that's a multi-stack application with
+shared constructs and a real deploy pipeline. This is one instance, one
+security group, one Elastic IP, and an optional DNS record - a use case
+CloudFormation covers directly, in a single file a reviewer can read
+top to bottom without an `npm install` or a `cdk synth`. That fits this
+repo's existing style (`web/index.html` is one file with no build step)
+better than standing up a second CDK app for four resources. If this
+grows more stacks or more logic, revisit.
+
+## What this does NOT do
+
+This PR ships the template only. Nothing is applied, no instance is
+launched, no hostname is registered. That is a deliberate, separate step
+the captain runs by hand (see below) - not something this change does
+for you.
+
+## Prerequisites
+
+- AWS CLI configured with the `landerafs` profile against account
+  `450730497623`, region `us-east-1`.
+- A domain you control, in whatever DNS provider you like. Route 53 is
+  optional (see `HostedZoneId` below) - the template works with any DNS
+  host, since it only needs an A record pointing at the Elastic IP.
+- An SSH keypair generated **just for this tunnel** - do not reuse an
+  existing identity:
+  ```bash
+  ssh-keygen -t ed25519 -f ~/.ssh/herdr-remote-tunnel -C herdr-remote-tunnel -N ""
+  ```
+  The private key never leaves the Mac and never enters this repo. Only
+  the `.pub` file's contents go into the stack, as the `TunnelPublicKey`
+  parameter.
+- Your current public IP, for `SshAllowedCidr` (`curl -s ifconfig.me`).
+- A **default VPC** in the target region. The template omits `VpcId` and
+  `SubnetId`, so EC2 places the instance and security group in the region's
+  default VPC. Accounts hardened by deleting it fail at stack creation with
+  the opaque `No default VPC for this request`. Check with:
+  ```bash
+  aws ec2 describe-vpcs --profile landerafs --region us-east-1 \
+    --filters Name=isDefault,Values=true --query "Vpcs[].VpcId" --output text
+  ```
+  An empty result means you need to recreate a default VPC
+  (`aws ec2 create-default-vpc`) or add explicit `VpcId`/`SubnetId`
+  parameters to the template first.
+
+## Deploy (run by a human, not by this PR)
+
+```bash
+aws cloudformation deploy \
+  --profile landerafs --region us-east-1 \
+  --stack-name herdr-remote-tunnel \
+  --template-file infra/aws-tunnel/cloudformation.yaml \
+  --parameter-overrides \
+      HostnameFqdn=herdr-remote.example.com \
+      TunnelPublicKey="$(cat ~/.ssh/herdr-remote-tunnel.pub)" \
+      SshAllowedCidr="$(curl -s ifconfig.me)/32" \
+  --capabilities CAPABILITY_IAM
+```
+
+Add `HostedZoneId=Z0123456789ABC` to the overrides if the domain's
+hosted zone lives in this same account and you want the template to
+create the A record for you. Otherwise, after deploy:
+
+```bash
+aws cloudformation describe-stacks --profile landerafs --region us-east-1 \
+  --stack-name herdr-remote-tunnel \
+  --query "Stacks[0].Outputs"
+```
+
+and create an A record for `HostnameFqdn` pointing at the printed
+`ElasticIp` in whatever DNS provider hosts that domain.
+
+Then restart Caddy once, after the A record actually resolves:
+
+```bash
+aws ssm start-session --profile landerafs --region us-east-1 \
+  --target "$(aws cloudformation describe-stacks --profile landerafs \
+    --region us-east-1 --stack-name herdr-remote-tunnel \
+    --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" --output text)"
+# then, in the session:
+sudo systemctl restart caddy
+```
+
+This step is not optional housekeeping.
+Caddy is enabled at first boot, which is necessarily before the Elastic IP is associated and long before you have created the A record, so its first few ACME attempts fail and certmagic backs off exponentially.
+Without the restart, HTTPS can stay down for many minutes after DNS is already correct, and the stack looks broken when it is not.
+Restarting clears the backoff and Caddy issues the certificate on its next attempt, usually within a minute.
+
+DNS must resolve and Caddy must hold a certificate before the Mac's
+tunnel or a phone browser can reach it over HTTPS. Check with:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' https://herdr-remote.example.com/
+```
+
+## Updating the SSH-allowed CIDR
+
+Home IPs on residential ISPs are not always static. If `SshAllowedCidr`
+goes stale, the reverse tunnel will fail to connect. Update the security
+group directly rather than re-running the whole stack:
+
+```bash
+aws ec2 update-security-group-rule-descriptions-ingress ...  # or:
+aws cloudformation deploy ... --parameter-overrides SshAllowedCidr="$(curl -s ifconfig.me)/32" ...
+```
+
+The second form is simplest - CloudFormation only touches the changed
+rule.
+
+## Cost
+
+All figures are `us-east-1` on-demand, August 2026 pricing, for the
+resources this template creates:
+
+| Resource | Cost |
+|---|---|
+| `t4g.nano` (2 vCPU burstable, 0.5 GiB), running 24/7 | ~$3.00/mo |
+| Elastic IP, attached to a running instance | $0.00/mo (free while associated) |
+| EBS gp3 8 GiB root volume | ~$0.65/mo |
+| Data transfer out (phone/browser traffic; tiny for this use case) | ~$0.10-0.50/mo |
+| Route 53 hosted zone (only if you opt in via `HostedZoneId` and don't already have one) | $0.50/mo |
+
+**Total: roughly $4/mo**, or ~$4.50/mo if you also stand up a fresh
+Route 53 zone for this. No per-request or bandwidth surprises at this
+traffic level - this is a single phone dashboard polling one relay, not
+a public service.
+
+## Security model, in one place
+
+- The relay stays bound to `127.0.0.1` on the Mac. This stack cannot
+  reach it directly - only the tunnel the Mac opens can.
+- SSH accepts exactly one identity: the forwarding-only `herdr-tunnel`
+  user, and the restriction is split across two layers because OpenSSH
+  cannot express all of it in one.
+  Its authorized_keys options are
+  `restrict,port-forwarding,permitlisten="127.0.0.1:<TunnelPort>"` - no shell,
+  no command execution, no agent/X11 forwarding, and `permitlisten` narrows
+  the remote side so the only bind this key may request is the single
+  `127.0.0.1:<TunnelPort>` the relay tunnel exists for, not an arbitrary port
+  of the holder's choosing.
+  `port-forwarding` is required there for `-R` to work at all, but it also
+  re-enables `-L`/`-D`, and authorized_keys has no option that denies them
+  (`permitopen` accepts only `host:port`). So the local-forward block lives in
+  sshd_config instead, in a `Match User herdr-tunnel` stanza that sets
+  `AllowTcpForwarding remote` and `PermitOpen none`. Without that stanza the
+  key would let its holder use this host as a general TCP proxy for anything
+  its egress reaches, the instance metadata service among them.
+- The instance requires IMDSv2 (`HttpTokens: required`, hop limit 1), so
+  even a future forwarding mistake cannot be turned into a simple
+  unauthenticated read of the instance role's credentials.
+- `GatewayPorts no` (the default, set explicitly) means the tunnel's
+  remote port binds to the EC2 host's loopback only - nothing but Caddy,
+  running on that same host, can reach it.
+- The security group opens only 443 (public) and 22 (restricted to
+  `SshAllowedCidr`). Port 80 is never opened; Caddy issues its
+  Let's-Encrypt certificate over TLS-ALPN-01 on 443 alone.
+- Admin access to the host itself is via AWS Systems Manager Session
+  Manager (`aws ssm start-session`), not a general SSH login - the IAM
+  instance profile grants only `AmazonSSMManagedInstanceCore`.
+- `HERDR_RELAY_TOKEN` is required for this path, but be precise about where
+  that is enforced.
+  The relay process itself does not demand a token: bound to loopback it
+  accepts an empty `HERDR_RELAY_TOKEN` and then skips auth on every request,
+  and its own hard guard only fires when `HERDR_RELAY_HOST` is moved off
+  loopback - which this design deliberately never does.
+  What makes the public HTTPS endpoint require a token is a refusal at the
+  three entry points that can raise this tunnel: `install-service.sh` will
+  not install the tunnel service, and `start.sh` and `tunnel-aws.sh` will not
+  start the forward, when `HERDR_RELAY_TOKEN` is unset or empty.
+  There is no flag or config knob to bypass that refusal.
+  So do not assume the relay would reject an unauthenticated request on its
+  own - if you ever expose port 8375 by some other route, nothing behind
+  these three checks protects it.
+- Stopping is verified, not assumed. `herdr-remote stop` tells launchd/systemd
+  to stop the supervised relay and tunnel services (a plain kill is undone by
+  `KeepAlive`/`Restart=always` within seconds), then re-checks past the restart
+  delay and only reports "Stopped" once it has confirmed the relay port is not
+  listening and no tunnel process is running. If it cannot confirm that, it says
+  so and exits non-zero - treat that as "still publicly reachable".

--- a/infra/aws-tunnel/cloudformation.yaml
+++ b/infra/aws-tunnel/cloudformation.yaml
@@ -132,10 +132,13 @@ Resources:
           ToPort: 22
           CidrIp: !Ref SshAllowedCidr
           Description: Reverse tunnel from the Mac only
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          CidrIp: 0.0.0.0/0
-          Description: Outbound for package installs and ACME
+      # No SecurityGroupEgress here on purpose. This template omits VpcId so the
+      # group lands in the region's default VPC (see README), and EC2 rejects
+      # "SecurityGroupEgress cannot be specified without VpcId" - so declaring it
+      # made every stack create fail and roll back. Omitting the block lets EC2
+      # add its own default egress rule (allow all traffic to 0.0.0.0/0), which is
+      # byte-for-byte the allow-all-outbound rule we would otherwise write for
+      # package installs and ACME. Egress posture is unchanged.
 
   TunnelEip:
     Type: AWS::EC2::EIP
@@ -159,6 +162,21 @@ Resources:
       ResourceRecords:
         - !Ref TunnelEip
 
+  # !!! UPDATE SEMANTICS - READ BEFORE CHANGING A PARAMETER ON A LIVE STACK !!!
+  # All host configuration (the Caddyfile hostname, the tunnel port, and the
+  # herdr-tunnel authorized_keys line) is baked into UserData below, and
+  # cloud-init runs UserData ONLY on the instance's first boot. A stack UPDATE
+  # rewrites the UserData attribute but does NOT re-run it and does NOT replace
+  # the instance, so changing HostnameFqdn, TunnelPort, or TunnelPublicKey on an
+  # existing stack reports "UPDATE_COMPLETE" while the running host keeps its old
+  # config. This is a SILENT no-op.
+  #   - HostnameFqdn / TunnelPort change  -> HTTPS stays on the old name/port.
+  #   - TunnelPublicKey rotation          -> SECURITY RELEVANT: the OLD key keeps
+  #     working and the NEW key is never installed. A rotation you believe
+  #     succeeded has not happened.
+  # To actually change any of these, DELETE and RECREATE the stack (or, if you
+  # cannot, re-run the instance's UserData over SSM by hand - see the README
+  # section "Changing a parameter after first boot").
   TunnelInstance:
     Type: AWS::EC2::Instance
     CreationPolicy:

--- a/infra/aws-tunnel/cloudformation.yaml
+++ b/infra/aws-tunnel/cloudformation.yaml
@@ -1,0 +1,301 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  herdr-remote AWS rendezvous host. A single t4g.nano EC2 instance that
+  terminates TLS (Caddy) and forwards to a loopback port that the Mac
+  populates over an outbound `ssh -R` reverse tunnel. No secret material
+  lives in this template: the relay token never touches this stack, and
+  the only credential accepted is a public key pasted in at deploy time.
+  See infra/aws-tunnel/README.md before applying this template.
+
+Parameters:
+  HostnameFqdn:
+    Type: String
+    Description: >
+      The stable hostname that will point at this host's Elastic IP
+      (e.g. herdr-remote.example.com). You create the DNS A record
+      yourself, in whatever provider hosts that domain (see README) -
+      this template does not require Route 53. Used only to configure
+      Caddy's automatic HTTPS for the right hostname.
+
+  TunnelPublicKey:
+    Type: String
+    Description: >
+      The PUBLIC key (e.g. contents of ~/.ssh/herdr-remote-tunnel.pub)
+      the Mac will use to open the reverse tunnel. Paste the public key
+      only - never a private key. This is not treated as a secret, but
+      review it is the value you expect before applying. The pattern below
+      accepts only an OpenSSH public key line, so a pasted private key or a
+      truncated key is rejected at deploy time rather than being written
+      verbatim into authorized_keys and failing later as "Permission denied".
+    AllowedPattern: ^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(256|384|521)) +[A-Za-z0-9+/]+=*( .*)?$
+    ConstraintDescription: >
+      must be a single OpenSSH PUBLIC key line - "ssh-ed25519 AAAA... comment"
+      (or ssh-rsa / ecdsa-sha2-nistp256|384|521). A private key, a key file
+      with headers, or a truncated value is rejected.
+
+  SshAllowedCidr:
+    Type: String
+    Description: >
+      CIDR allowed to reach port 22 (e.g. your home IP as "203.0.113.5/32").
+      Required - there is no default, and this template refuses a
+      world-open value. If your ISP rotates your IP, update the security
+      group rule after it changes (see README).
+    AllowedPattern: ^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}/([1-9]|[12][0-9]|3[0-2])$
+    ConstraintDescription: >
+      must be a well-formed IPv4 CIDR with a prefix length of /1 to /32
+      (e.g. 203.0.113.5/32). /0 is rejected outright - SSH must never be
+      world-open.
+
+  TunnelPort:
+    Type: Number
+    Default: 9375
+    MinValue: 1024
+    MaxValue: 65535
+    Description: >
+      Loopback port on the EC2 host that the Mac's reverse tunnel
+      populates, and that Caddy reverse-proxies to. Restricted to the
+      unprivileged range, which also keeps it clear of 443, 80 and 22 -
+      Caddy proxying to its own listener would deadlock the host.
+    ConstraintDescription: must be an unprivileged port between 1024 and 65535.
+
+  TunnelUser:
+    Type: String
+    Default: herdr-tunnel
+    Description: Unprivileged user the Mac's SSH key logs in as. No shell, forwarding only.
+
+  InstanceType:
+    Type: String
+    Default: t4g.nano
+    AllowedValues: [t4g.nano, t4g.micro, t4g.small, t4g.medium, t4g.large]
+    Description: >
+      Smallest Graviton instance class that comfortably runs Caddy + sshd.
+      Restricted to t4g.* because ImageId below resolves the arm64 AMI
+      alias - an x86_64 type would fail at launch.
+    ConstraintDescription: must be a t4g.* (Graviton/arm64) type, to match the arm64 AMI.
+
+  HostedZoneId:
+    Type: String
+    Default: ""
+    Description: >
+      OPTIONAL. A Route 53 hosted zone ID to create the A record in. Leave
+      blank to manage DNS yourself elsewhere (any provider - Route 53 is
+      not required). If set, HostnameFqdn must be a name within that zone.
+
+Conditions:
+  HasHostedZone: !Not [!Equals [!Ref HostedZoneId, ""]]
+
+Resources:
+  TunnelInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      Policies:
+        - PolicyName: SignalOwnStackResource
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: cloudformation:SignalResource
+                Resource: !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+      Description: >
+        Grants only AWS Systems Manager Session Manager access, so the
+        host can be administered without opening a general-purpose SSH
+        login - the only SSH key accepted is the forwarding-restricted
+        tunnel key below.
+
+  TunnelInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref TunnelInstanceRole
+
+  TunnelSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: herdr-remote rendezvous host - 443 public, SSH restricted
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+          Description: HTTPS from phone/browser clients
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref SshAllowedCidr
+          Description: Reverse tunnel from the Mac only
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          CidrIp: 0.0.0.0/0
+          Description: Outbound for package installs and ACME
+
+  TunnelEip:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+
+  TunnelEipAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      AllocationId: !GetAtt TunnelEip.AllocationId
+      InstanceId: !Ref TunnelInstance
+
+  TunnelDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Condition: HasHostedZone
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref HostnameFqdn
+      Type: A
+      TTL: "60"
+      ResourceRecords:
+        - !Ref TunnelEip
+
+  TunnelInstance:
+    Type: AWS::EC2::Instance
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT10M
+    Properties:
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref TunnelInstanceProfile
+      SecurityGroupIds:
+        - !Ref TunnelSecurityGroup
+      ImageId: "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}"
+      MetadataOptions:
+        HttpTokens: required
+        HttpPutResponseHopLimit: 1
+      Tags:
+        - Key: Name
+          Value: herdr-remote-tunnel
+        - Key: project
+          Value: herdr-remote
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -euxo pipefail
+
+          dnf install -y aws-cfn-bootstrap
+          trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource TunnelInstance --region ${AWS::Region}' ERR
+
+          # --- Unprivileged, forwarding-only user for the Mac's reverse tunnel ---
+          useradd --create-home --shell /usr/sbin/nologin "${TunnelUser}"
+          install -d -m 700 -o "${TunnelUser}" -g "${TunnelUser}" "/home/${TunnelUser}/.ssh"
+          cat > "/home/${TunnelUser}/.ssh/authorized_keys" <<'KEYS'
+          restrict,port-forwarding,permitlisten="127.0.0.1:${TunnelPort}" ${TunnelPublicKey}
+          KEYS
+          chown "${TunnelUser}:${TunnelUser}" "/home/${TunnelUser}/.ssh/authorized_keys"
+          chmod 600 "/home/${TunnelUser}/.ssh/authorized_keys"
+
+          # `restrict` (OpenSSH >= 7.2) disables pty/agent/X11 forwarding, user-rc
+          # execution, and command execution, but it also disables the -R this
+          # account exists for, so `port-forwarding` has to come back - and that
+          # re-enables BOTH -L and -R. `permitlisten` narrows the -R side to the
+          # single bind we want, but there is no authorized_keys option that
+          # denies the -L side (`permitopen` takes host:port only; `none` is an
+          # sshd_config keyword and putting it here makes sshd reject the whole
+          # key line). So the local-forward block lives in the Match stanza
+          # below, which is where OpenSSH can actually express it. Without it,
+          # this host would be a general TCP proxy for anything its egress
+          # reaches - the instance metadata service among them.
+          install -d -m 755 /etc/ssh/sshd_config.d
+          cat > /etc/ssh/sshd_config.d/99-herdr-tunnel.conf <<'SSHD'
+          GatewayPorts no
+          AllowTcpForwarding yes
+
+          Match User ${TunnelUser}
+              AllowTcpForwarding remote
+              PermitOpen none
+
+          Match all
+          SSHD
+          systemctl reload sshd
+
+          # --- Caddy: static binary, pinned version, reverse-proxies to the
+          # loopback port the tunnel populates. Port 80 is never opened on
+          # the security group, so Caddy issues its cert via TLS-ALPN-01
+          # entirely over 443. ---
+          # Digests are the published ones from the release's own
+          # caddy_2.8.4_checksums.txt (sha512, as upstream publishes). Caddy
+          # terminates TLS in front of the relay, so the bytes are verified
+          # before anything is unpacked into /usr/bin as root.
+          CADDY_VERSION="2.8.4"
+          CADDY_SHA512_arm64="5466234be3e988071cef937aedbdd94c15b6f75cf7307397e67c2641219ac9bfe2c2bb3b31fc05bc68d3b6398bbe50abfa16ccf3b127318ccac31115ad26507c"
+          CADDY_SHA512_amd64="b8bec15d14fb033562af9f207850027bcbaa1f891edc9efe00d38bf39e1bf9944f8b6b8eba041ddd4c171cd70c905174c704d705be2f23bc678fe1eaf37a2485"
+          ARCH="$(uname -m)"
+          case "$ARCH" in
+            aarch64) CADDY_ARCH="arm64"; CADDY_SHA512="${!CADDY_SHA512_arm64}" ;;
+            x86_64) CADDY_ARCH="amd64"; CADDY_SHA512="${!CADDY_SHA512_amd64}" ;;
+            *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+          esac
+          curl -fsSL -o /tmp/caddy.tar.gz \
+            "https://github.com/caddyserver/caddy/releases/download/v${!CADDY_VERSION}/caddy_${!CADDY_VERSION}_linux_${!CADDY_ARCH}.tar.gz"
+          echo "${!CADDY_SHA512}  /tmp/caddy.tar.gz" | sha512sum -c -
+          tar -xzf /tmp/caddy.tar.gz -C /usr/bin caddy
+          chmod +x /usr/bin/caddy
+          rm -f /tmp/caddy.tar.gz
+
+          useradd --system --home /var/lib/caddy --shell /usr/sbin/nologin caddy || true
+          install -d -o caddy -g caddy /var/lib/caddy /etc/caddy
+
+          cat > /etc/caddy/Caddyfile <<'CADDYFILE'
+          ${HostnameFqdn} {
+              reverse_proxy 127.0.0.1:${TunnelPort}
+          }
+          CADDYFILE
+
+          cat > /etc/systemd/system/caddy.service <<'UNIT'
+          [Unit]
+          Description=Caddy - reverse proxy for herdr-remote
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          User=caddy
+          Group=caddy
+          ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile
+          ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile --force
+          TimeoutStopSec=5s
+          LimitNOFILE=1048576
+          AmbientCapabilities=CAP_NET_BIND_SERVICE
+          Restart=on-failure
+          RestartSec=2s
+
+          [Install]
+          WantedBy=multi-user.target
+          UNIT
+
+          systemctl daemon-reload
+          systemctl enable --now caddy
+
+          /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource TunnelInstance --region ${AWS::Region}
+
+Outputs:
+  ElasticIp:
+    Description: >
+      Public IP to point HostnameFqdn's A record at (skip if HostedZoneId
+      was supplied - the record already exists).
+    Value: !Ref TunnelEip
+
+  InstanceId:
+    Value: !Ref TunnelInstance
+
+  TunnelUserOutput:
+    Description: SSH user the Mac's reverse tunnel connects as
+    Value: !Ref TunnelUser
+
+  TunnelPortOutput:
+    Description: Loopback port on this host the Mac's tunnel must forward to
+    Value: !Ref TunnelPort
+
+  HttpsUrl:
+    Value: !Sub "https://${HostnameFqdn}"

--- a/relay/.env.example
+++ b/relay/.env.example
@@ -11,3 +11,13 @@ HERDR_RELAY_TOKEN=64-lowercase-hex-characters
 
 # Remote herdr instances polled by the relay over SSH (comma-separated).
 HERDR_REMOTES=user@server1,user@server2
+
+# --- AWS reverse tunnel (alternative to Cloudflare Tunnel) ---
+# See infra/aws-tunnel/README.md. Set HERDR_TUNNEL_MODE=aws in
+# ~/.config/herdr-remote/config.env to select this backend.
+HERDR_TUNNEL_MODE=aws
+HERDR_AWS_HOST=herdr-remote.example.com
+HERDR_AWS_SSH_USER=herdr-tunnel
+HERDR_AWS_SSH_PORT=22
+HERDR_AWS_SSH_KEY=/Users/you/.ssh/herdr-remote-tunnel
+HERDR_AWS_TUNNEL_PORT=9375

--- a/relay/.env.example
+++ b/relay/.env.example
@@ -21,3 +21,10 @@ HERDR_AWS_SSH_USER=herdr-tunnel
 HERDR_AWS_SSH_PORT=22
 HERDR_AWS_SSH_KEY=/Users/you/.ssh/herdr-remote-tunnel
 HERDR_AWS_TUNNEL_PORT=9375
+
+# Optional: only needed if the AWS CLI's default credential chain doesn't
+# already resolve to the right profile/region. Used by relay/aws-fw-heal.sh
+# (self-heals the SSH security-group rule on `herdr-remote start`, and
+# diagnoses it in `herdr-remote status`) - see infra/aws-tunnel/README.md.
+HERDR_AWS_PROFILE=landerafs
+HERDR_AWS_REGION=us-east-1

--- a/relay/aws-fw-heal.sh
+++ b/relay/aws-fw-heal.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# relay/aws-fw-heal.sh - verify (and, in heal mode, repair) the AWS reverse
+# tunnel's SSH security-group rule for the current public IP.
+#
+# Home IPs on residential ISPs rotate. When the rotated IP is not in the
+# security group's port-22 ingress, the reverse tunnel's ssh/autossh cannot
+# connect - the relay and tunnel processes look "running" locally, but the
+# public URL answers 502 (Caddy up, nothing on the far end). See
+# infra/aws-tunnel/README.md "Updating the SSH-allowed CIDR".
+#
+# Usage: aws-fw-heal.sh check|heal
+#   check - read-only. Reports whether the current IP is allowed.
+#   heal  - like check, and if the current IP is missing, ADDS it.
+#           Never removes or replaces an existing rule (see the ticket this
+#           shipped with: a rule this script did not create is not this
+#           script's to delete).
+#
+# Discovery is by the CloudFormation stack's own tags (project=herdr-remote,
+# Name=herdr-remote-tunnel) on the running instance, not a hard-coded
+# instance/security-group id - a hard-coded id would just be a second thing
+# that can go stale.
+#
+# Output contract:
+#   check mode prints exactly one line to stdout:
+#     RESULT=<ok|absent|error> IP=<ip|-> GROUP=<sgid|-> RULE=<ruleid|-> REASON=<text>
+#   heal mode prints a human-readable line only when it added a rule or
+#   could not verify/repair; it is silent (no stdout) for the no-op case.
+# Exit codes (both modes): 0 ok/added, 10 absent (check only), 20 could not
+# verify/repair.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=relay/config-lib.sh
+source "$SCRIPT_DIR/config-lib.sh"
+
+CONFIG_FILE="$HOME/.config/herdr-remote/config.env"
+SECRETS_FILE="$HOME/.config/herdr-remote/secrets.env"
+load_config_file "$CONFIG_FILE"
+load_config_file "$SECRETS_FILE"
+
+MODE="${1:-check}"
+case "$MODE" in
+  check|heal) ;;
+  *) echo "usage: aws-fw-heal.sh [check|heal]" >&2; exit 20 ;;
+esac
+
+AWS_ARGS=(--cli-connect-timeout 5 --cli-read-timeout 15)
+[ -n "${HERDR_AWS_PROFILE:-}" ] && AWS_ARGS+=(--profile "$HERDR_AWS_PROFILE")
+[ -n "${HERDR_AWS_REGION:-}" ] && AWS_ARGS+=(--region "$HERDR_AWS_REGION")
+
+# report RESULT IP GROUP RULE REASON - prints per the output contract above,
+# then exits with the code that matches RESULT. Every exit from this script
+# goes through here, so the contract cannot drift between call sites.
+report() {
+  local result="$1" ip="${2:--}" group="${3:--}" rule="${4:--}" reason="${5:-}"
+  if [ "$MODE" = check ]; then
+    printf 'RESULT=%s IP=%s GROUP=%s RULE=%s REASON=%s\n' "$result" "$ip" "$group" "$rule" "$reason"
+  else
+    case "$result" in
+      added) printf 'herdr-remote: added %s/32 to security group %s for SSH ingress (rule %s)\n' "$ip" "$group" "$rule" ;;
+      error) printf 'herdr-remote: could not verify SSH firewall rule: %s\n' "$reason" >&2 ;;
+      ok) : ;; # already covered - silence is correct here
+    esac
+  fi
+  case "$result" in
+    ok|added) exit 0 ;;
+    absent)   exit 10 ;;
+    *)        exit 20 ;;
+  esac
+}
+
+# ip_to_int DOTTED_IP
+ip_to_int() {
+  local IFS=.
+  local -a o
+  read -r -a o <<< "$1"
+  [ "${#o[@]}" -eq 4 ] || { echo -1; return 1; }
+  echo $(( (o[0] << 24) + (o[1] << 16) + (o[2] << 8) + o[3] ))
+}
+
+# ip_in_cidr IP CIDR - true if IP falls inside CIDR (bare IP treated as /32).
+ip_in_cidr() {
+  local ip="$1" cidr="$2" net bits ipi neti mask
+  net="${cidr%%/*}"
+  bits="${cidr#*/}"
+  [ "$bits" = "$cidr" ] && bits=32
+  case "$bits" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$bits" -ge 0 ] && [ "$bits" -le 32 ] || return 1
+  ipi=$(ip_to_int "$ip") || return 1
+  neti=$(ip_to_int "$net") || return 1
+  if [ "$bits" -eq 0 ]; then mask=0; else mask=$(( (0xFFFFFFFF << (32 - bits)) & 0xFFFFFFFF )); fi
+  [ $(( ipi & mask )) -eq $(( neti & mask )) ]
+}
+
+command -v aws  >/dev/null 2>&1 || report error - - - "aws CLI not found on PATH"
+command -v curl >/dev/null 2>&1 || report error - - - "curl not found (needed to detect the current public IP)"
+
+CURRENT_IP=""
+for ip_svc in https://checkip.amazonaws.com https://ifconfig.me/ip; do
+  ip=$(curl -fsS --max-time 5 "$ip_svc" 2>/dev/null | tr -d ' \t\r\n')
+  if [[ "$ip" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then CURRENT_IP="$ip"; break; fi
+done
+[ -n "$CURRENT_IP" ] || report error - - - "could not determine the current public IP (checkip.amazonaws.com and ifconfig.me both failed)"
+
+ERRFILE=$(mktemp)
+trap 'rm -f "$ERRFILE"' EXIT
+
+if ! INSTANCE_IDS=$(aws ec2 describe-instances "${AWS_ARGS[@]}" \
+  --filters "Name=tag:project,Values=herdr-remote" "Name=tag:Name,Values=herdr-remote-tunnel" \
+            "Name=instance-state-name,Values=running,pending" \
+  --query 'Reservations[].Instances[].InstanceId' --output text 2>"$ERRFILE"); then
+  report error "$CURRENT_IP" - - "aws ec2 describe-instances failed: $(tr '\n' ' ' < "$ERRFILE" | cut -c1-300)"
+fi
+# shellcheck disable=SC2206
+INSTANCE_ARR=($INSTANCE_IDS)
+case "${#INSTANCE_ARR[@]}" in
+  0) report error "$CURRENT_IP" - - "no running EC2 instance tagged project=herdr-remote,Name=herdr-remote-tunnel found (wrong profile/region, or the stack is not deployed here)" ;;
+  1) ;;
+  *) report error "$CURRENT_IP" - - "multiple EC2 instances match tag Name=herdr-remote-tunnel (${INSTANCE_ARR[*]}) - ambiguous, not touching any of them" ;;
+esac
+INSTANCE_ID="${INSTANCE_ARR[0]}"
+
+if ! SG_IDS=$(aws ec2 describe-instances "${AWS_ARGS[@]}" --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].SecurityGroups[].GroupId' --output text 2>"$ERRFILE") || [ -z "$SG_IDS" ]; then
+  report error "$CURRENT_IP" - - "could not read security groups for instance $INSTANCE_ID: $(tr '\n' ' ' < "$ERRFILE" | cut -c1-300)"
+fi
+
+SSH_GROUPS=()
+for sg in $SG_IDS; do
+  if ! has22=$(aws ec2 describe-security-groups "${AWS_ARGS[@]}" --group-ids "$sg" \
+    --query "SecurityGroups[0].IpPermissions[?ToPort==\`22\` && FromPort==\`22\` && IpProtocol=='tcp']" \
+    --output text 2>"$ERRFILE"); then
+    report error "$CURRENT_IP" - - "could not read security group $sg: $(tr '\n' ' ' < "$ERRFILE" | cut -c1-300)"
+  fi
+  [ -n "$has22" ] && SSH_GROUPS+=("$sg")
+done
+case "${#SSH_GROUPS[@]}" in
+  0) report error "$CURRENT_IP" - - "instance $INSTANCE_ID has no security group with a port-22 ingress rule" ;;
+  1) ;;
+  *) report error "$CURRENT_IP" - - "instance $INSTANCE_ID has multiple security groups with a port-22 rule (${SSH_GROUPS[*]}) - ambiguous, not touching any of them" ;;
+esac
+GROUP="${SSH_GROUPS[0]}"
+
+if ! CIDRS=$(aws ec2 describe-security-groups "${AWS_ARGS[@]}" --group-ids "$GROUP" \
+  --query "SecurityGroups[0].IpPermissions[?ToPort==\`22\` && FromPort==\`22\` && IpProtocol=='tcp'].IpRanges[].CidrIp" \
+  --output text 2>"$ERRFILE"); then
+  report error "$CURRENT_IP" "$GROUP" - "could not read ingress rules for $GROUP: $(tr '\n' ' ' < "$ERRFILE" | cut -c1-300)"
+fi
+
+for cidr in $CIDRS; do
+  if ip_in_cidr "$CURRENT_IP" "$cidr"; then
+    report ok "$CURRENT_IP" "$GROUP" -
+  fi
+done
+
+if [ "$MODE" = check ]; then
+  report absent "$CURRENT_IP" "$GROUP" - "current IP is not in the allowed SSH CIDRs (${CIDRS:-none})"
+fi
+
+# heal mode, and the current IP is missing: ADD ONLY. Never revoke or
+# replace an existing rule - see the header comment.
+PERM_JSON=$(printf '[{"IpProtocol":"tcp","FromPort":22,"ToPort":22,"IpRanges":[{"CidrIp":"%s/32","Description":"herdr-remote self-heal %s"}]}]' \
+  "$CURRENT_IP" "$(date -u +%Y-%m-%d)")
+if ! RULE_ID=$(aws ec2 authorize-security-group-ingress "${AWS_ARGS[@]}" --group-id "$GROUP" \
+  --ip-permissions "$PERM_JSON" \
+  --query 'SecurityGroupRules[0].SecurityGroupRuleId' --output text 2>"$ERRFILE") \
+  || [ -z "$RULE_ID" ] || [ "$RULE_ID" = "None" ]; then
+  report error "$CURRENT_IP" "$GROUP" - "authorize-security-group-ingress failed: $(tr '\n' ' ' < "$ERRFILE" | cut -c1-300)"
+fi
+report added "$CURRENT_IP" "$GROUP" "$RULE_ID"

--- a/relay/config-lib.sh
+++ b/relay/config-lib.sh
@@ -1,0 +1,37 @@
+# shellcheck shell=bash
+# herdr-remote shared config loading. Source this; do not execute it.
+#
+# load_config_file FILE
+#   Sources FILE with allexport on, so the values reach child processes - the
+#   relay only sees HERDR_RELAY_TOKEN if it is exported, and an unexported one
+#   means it starts with auth disabled.
+#   An explicitly exported non-empty value always beats the persisted one, so a
+#   stale or empty line in config.env/secrets.env can never silently override
+#   what the caller asked for on the command line.
+
+load_config_file() {
+  local file=$1
+  [ -f "$file" ] || return 0
+  local keys key i
+  local -a names=() values=()
+  keys=$(sed -nE 's/^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)=.*/\2/p' "$file")
+  for key in $keys; do
+    if [ -n "${!key:+set}" ]; then
+      names[${#names[@]}]="$key"
+      values[${#values[@]}]="${!key}"
+    fi
+  done
+  local had_allexport=no
+  case "$-" in *a*) had_allexport=yes ;; esac
+  set -a
+  # shellcheck disable=SC1090
+  source "$file"
+  [ "$had_allexport" = yes ] || set +a
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    printf -v "${names[$i]}" '%s' "${values[$i]}"
+    export "${names[$i]}"
+    i=$((i + 1))
+  done
+  return 0
+}

--- a/relay/herdr-remote
+++ b/relay/herdr-remote
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# herdr-remote - start/stop the herdr-remote relay and its tunnel (Cloudflare
+# quick tunnel or the AWS reverse tunnel), and print the URL and token to
+# paste into the phone web app.
+#
+#   herdr-remote start    start relay + tunnel, print URL and token
+#   herdr-remote stop     stop tunnel and relay
+#   herdr-remote status   report what is running, and the current URL
+#   herdr-remote url      print just the current tunnel URL
+#   herdr-remote token    print just the relay token
+#
+# Tunnel backend is chosen by HERDR_TUNNEL_MODE in
+# ~/.config/herdr-remote/config.env: "temp"/"named" (Cloudflare, default)
+# or "aws" (reverse SSH tunnel to infra/aws-tunnel/, see that directory).
+#
+# This is the canonical copy - keep it in the repo, not only in
+# ~/.local/bin, so it's versioned and reviewable like everything else
+# here. Symlink it into place:
+#   ln -sf "$(pwd)/relay/herdr-remote" ~/.local/bin/herdr-remote
+set -uo pipefail
+
+if [ -n "${HERDR_REMOTE_REPO:-}" ]; then
+  REPO="$HERDR_REMOTE_REPO"
+else
+  _src="${BASH_SOURCE[0]}"
+  while [ -L "$_src" ]; do
+    _target=$(readlink "$_src")
+    case "$_target" in
+      /*) _src="$_target" ;;
+      *)  _src="$(dirname "$_src")/$_target" ;;
+    esac
+  done
+  REPO="$(cd "$(dirname "$_src")/.." && pwd)"
+fi
+CONFIG="$HOME/.config/herdr-remote/config.env"
+SECRETS="$HOME/.config/herdr-remote/secrets.env"
+LOG="$REPO/relay/relay.log"
+WEB_APP="https://herdr-remote.pages.dev"
+CF_URL_RE='https://[a-z0-9-]*\.trycloudflare\.com'
+
+die() { printf 'herdr-remote: %s\n' "$1" >&2; exit 1; }
+
+# install-service.sh writes every known key into config.env even when it
+# has no value ("HERDR_AWS_HOST="), so "the key is present" says nothing.
+# Only a non-empty value counts as set; anything else fails, and callers
+# rely on that exit status to refuse to start.
+value_from() {
+  local key="$1"; shift
+  local file v
+  for file in "$@"; do
+    [ -f "$file" ] || continue
+    v=$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "$file" \
+      | tail -1 | sed -E "s/.*${key}=//; s/^\"//; s/\"\$//")
+    if [ -n "$v" ]; then printf '%s\n' "$v"; return 0; fi
+  done
+  return 1
+}
+
+config_value() { value_from "$1" "$CONFIG"; }
+
+# Every setting follows one rule, the same one start.sh/tunnel-aws.sh and
+# install-service.sh use: a non-empty exported value beats the persisted
+# file. A wrapper that disagreed with them about the port or the mode would
+# aim all of its checks at the wrong process.
+setting() {
+  local key="$1"
+  if [ -n "${!key:-}" ]; then printf '%s\n' "${!key}"; return 0; fi
+  config_value "$key"
+}
+
+# The token lives in secrets.env (mode 0600), which is where
+# install-service.sh has always written it; config.env is 0644 and never
+# carries it. Environment wins over both, for one-off overrides.
+token_value() {
+  if [ -n "${HERDR_RELAY_TOKEN:-}" ]; then printf '%s\n' "$HERDR_RELAY_TOKEN"; return 0; fi
+  value_from HERDR_RELAY_TOKEN "$SECRETS" "$CONFIG"
+}
+
+tunnel_mode() { setting HERDR_TUNNEL_MODE || echo "temp"; }
+aws_host() { setting HERDR_AWS_HOST; }
+
+PORT="$(setting HERDR_RELAY_PORT || echo 8375)"
+
+LABEL_RELAY="com.herdr-remote.relay"
+LABEL_TUNNEL="com.herdr-remote.tunnel"
+
+is_macos() { [ "$(uname -s)" = "Darwin" ]; }
+
+# install-service.sh installs these with KeepAlive/Restart=always, so a plain
+# kill is undone within seconds. Stopping means telling the supervisor.
+# "Loaded" means the supervisor is still in charge of the process right now,
+# which is what stop has to disprove. On systemd that is ActiveState, not
+# is-enabled: an explicitly stopped unit stays enabled so it returns at next
+# login, but it is genuinely down until then and Restart=always does not
+# revive it. activating covers the RestartSec auto-restart window.
+managed_job_loaded() {
+  local label=$1 unit=$2
+  if is_macos; then
+    launchctl print "gui/$(id -u)/$label" >/dev/null 2>&1
+  else
+    local state
+    state=$(systemctl --user show -p ActiveState "$unit" 2>/dev/null)
+    case "${state#ActiveState=}" in
+      active|activating|reloading|deactivating) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+}
+
+managed_jobs_loaded() {
+  managed_job_loaded "$LABEL_RELAY" herdr-relay.service \
+    || managed_job_loaded "$LABEL_TUNNEL" herdr-tunnel.service
+}
+
+stop_managed_jobs() {
+  if is_macos; then
+    launchctl bootout "gui/$(id -u)/$LABEL_TUNNEL" 2>/dev/null || true
+    launchctl bootout "gui/$(id -u)/$LABEL_RELAY" 2>/dev/null || true
+  else
+    systemctl --user stop herdr-tunnel.service 2>/dev/null || true
+    systemctl --user stop herdr-relay.service 2>/dev/null || true
+  fi
+}
+
+relay_pid()  { lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -1; }
+cf_tunnel_pids() { pgrep -f "cloudflared tunnel --url http://localhost:$PORT" 2>/dev/null; }
+# Three shapes to reap: the launcher script, autossh, and - when autossh
+# is not installed - the plain ssh the launcher's retry loop supervises.
+# Missing the last one leaves the remote forward bound, which makes the
+# next start fail against ExitOnForwardFailure.
+aws_tunnel_pids() {
+  { pgrep -f "$REPO/relay/tunnel-aws.sh" 2>/dev/null
+    pgrep -f "autossh.*127.0.0.1:.*:127.0.0.1:$PORT" 2>/dev/null
+    pgrep -f "ssh .*-R 127.0.0.1:[0-9]*:127.0.0.1:$PORT" 2>/dev/null
+  } | sort -u
+}
+tunnel_pids() { if [ "$(tunnel_mode)" = "aws" ]; then aws_tunnel_pids; else cf_tunnel_pids; fi; }
+launcher_pids() { pgrep -f "$REPO/relay/start.sh" 2>/dev/null; }
+
+current_url() {
+  if [ "$(tunnel_mode)" = "aws" ]; then
+    local h; h=$(aws_host)
+    [ -n "$h" ] && echo "https://$h"
+  else
+    [ -f "$LOG" ] || return 1
+    local u; u=$(grep -o "$CF_URL_RE" "$LOG" | tail -1)
+    [ -n "$u" ] || return 1
+    printf '%s\n' "$u"
+  fi
+}
+
+url_is_live() {
+  local u=$1
+  [ -n "$u" ] || return 1
+  curl -fsS -o /dev/null --max-time 15 -H "Authorization: Bearer $(token_value)" "$u" 2>/dev/null
+}
+
+cmd_start() {
+  [ -d "$REPO" ] || die "repo not found at $REPO (set HERDR_REMOTE_REPO)"
+  local tok; tok=$(token_value) || tok=""
+
+  if [ "$(tunnel_mode)" = "aws" ]; then
+    aws_host >/dev/null || die "HERDR_TUNNEL_MODE=aws but HERDR_AWS_HOST is not set in $CONFIG"
+    [ -n "$tok" ] || die "refusing to start the AWS reverse tunnel without HERDR_RELAY_TOKEN.
+  The AWS tunnel publishes this relay on the public internet over HTTPS, and
+  the relay grants whoever reaches it full control of your agents. A token is
+  mandatory for this path and there is no way to skip it.
+  Set HERDR_RELAY_TOKEN in $SECRETS, or re-run relay/install-service.sh."
+  fi
+
+  [ -n "$tok" ] || die "no HERDR_RELAY_TOKEN in $SECRETS (or $CONFIG, or the environment)"
+
+  if [ -n "$(relay_pid)" ]; then
+    echo "Already running. Current details:"
+    echo
+    cmd_status
+    return 0
+  fi
+
+  echo "Starting relay and tunnel (mode: $(tunnel_mode))..."
+  : > "$LOG"
+  nohup "$REPO/relay/start.sh" > "$LOG" 2>&1 &
+  disown 2>/dev/null || true
+
+  local url="" _i
+  for _i in $(seq 1 40); do
+    url=$(current_url)
+    [ -n "$url" ] && break
+    sleep 1
+  done
+
+  if [ -z "$url" ]; then
+    echo "Relay started, but no tunnel URL appeared within 40s." >&2
+    echo "Check: $LOG" >&2
+    return 1
+  fi
+
+  # A quick tunnel can print its URL (or the AWS host can be configured)
+  # before it is actually routable end-to-end.
+  local live=no _j
+  for _j in $(seq 1 20); do
+    if url_is_live "$url"; then live=yes; break; fi
+    sleep 2
+  done
+
+  echo
+  echo "  Web app:  $WEB_APP"
+  echo "  URL:      $url"
+  echo "  Token:    $tok"
+  echo
+  if [ "$live" = yes ]; then
+    echo "  Reachable: yes (verified through the tunnel with your token)"
+  else
+    echo "  Reachable: NOT YET - the URL is published but not answering."
+    echo "             Give it a moment, then: herdr-remote status"
+  fi
+  echo
+  echo "  Open the web app on your phone, tap the gear, paste the URL and token."
+  echo "  Stop it later with: herdr-remote stop"
+}
+
+cmd_stop() {
+  local found=no managed=no p
+  if managed_jobs_loaded; then managed=yes; found=yes; stop_managed_jobs; fi
+
+  for p in $(launcher_pids); do kill "$p" 2>/dev/null && found=yes; done
+  for p in $(tunnel_pids);   do kill "$p" 2>/dev/null && found=yes; done
+  p=$(relay_pid); [ -n "$p" ] && { kill "$p" 2>/dev/null && found=yes; }
+  sleep 2
+  p=$(relay_pid); [ -n "$p" ] && kill -9 "$p" 2>/dev/null
+  for p in $(tunnel_pids); do kill -9 "$p" 2>/dev/null; done
+
+  # Outlast the supervisors' restart throttle (5s relay, 10s tunnel) before
+  # believing anything: a process absent at t=2s proves nothing.
+  local _i
+  for _i in $(seq 1 14); do
+    if [ -z "$(relay_pid)" ] && [ -z "$(tunnel_pids)" ] && ! managed_jobs_loaded; then
+      break
+    fi
+    sleep 1
+  done
+
+  local rp tp
+  rp=$(relay_pid); tp=$(tunnel_pids | head -1)
+  if [ -n "$rp" ] || [ -n "$tp" ] || managed_jobs_loaded; then
+    echo "herdr-remote: could NOT confirm shutdown - do not assume this is closed." >&2
+    [ -n "$rp" ] && echo "  Relay:  still listening on port $PORT (pid $rp)" >&2
+    [ -n "$tp" ] && echo "  Tunnel: still running (pid $tp); the reverse forward may still be bound" >&2
+    if managed_jobs_loaded; then
+      echo "  A supervised service is still loaded and will keep restarting it." >&2
+      if is_macos; then
+        echo "  Stop it with: launchctl bootout gui/\$(id -u)/$LABEL_TUNNEL" >&2
+        echo "            and launchctl bootout gui/\$(id -u)/$LABEL_RELAY" >&2
+      else
+        echo "  Stop it with: systemctl --user stop herdr-tunnel.service herdr-relay.service" >&2
+      fi
+    fi
+    exit 1
+  fi
+
+  if [ "$found" = no ]; then
+    echo "Nothing was running."
+    return 0
+  fi
+  echo "Stopped. Verified: port $PORT is not listening, and no tunnel process is"
+  echo "running on this machine (re-checked past the supervisors' restart delay)."
+  if [ "$managed" = yes ]; then
+    if is_macos; then
+      echo "Supervised services were booted out; they come back at next login,"
+      echo "or immediately via relay/install-service.sh."
+    else
+      echo "Supervised services were stopped; they come back at next login,"
+      echo "or immediately via: systemctl --user start herdr-relay.service"
+    fi
+  fi
+}
+
+cmd_status() {
+  local r t u
+  r=$(relay_pid); t=$(tunnel_pids | head -1); u=$(current_url)
+  echo "  Mode:    $(tunnel_mode)"
+  if [ -n "$r" ]; then
+    echo "  Relay:   running (pid $r)"
+  elif managed_job_loaded "$LABEL_RELAY" herdr-relay.service; then
+    echo "  Relay:   no process now, but a supervised service is loaded and will restart it"
+  else
+    echo "  Relay:   not running (no process, no supervised service loaded)"
+  fi
+  if [ -n "$t" ]; then
+    echo "  Tunnel:  running (pid $t)"
+  elif managed_job_loaded "$LABEL_TUNNEL" herdr-tunnel.service; then
+    echo "  Tunnel:  no process now, but a supervised service is loaded and will restart it"
+  else
+    echo "  Tunnel:  not running (no process, no supervised service loaded)"
+  fi
+  if [ -n "$u" ]; then
+    if url_is_live "$u"; then
+      echo "  URL:     $u  (reachable)"
+    else
+      echo "  URL:     $u  (NOT reachable - stale, or the tunnel dropped)"
+      echo "           Fix with: herdr-remote stop && herdr-remote start"
+    fi
+  else
+    echo "  URL:     none recorded"
+  fi
+  echo "  Token:   $(token_value 2>/dev/null || echo 'not set')"
+  echo "  Web app: $WEB_APP"
+}
+
+case "${1:-}" in
+  start)  cmd_start ;;
+  stop)   cmd_stop ;;
+  status) cmd_status ;;
+  url)    current_url || die "no URL recorded" ;;
+  token)  token_value || die "no token in $SECRETS" ;;
+  ""|-h|--help|help)
+    awk 'NR > 1 && /^#/ { sub(/^# ?/, ""); print; next } NR > 1 { exit }' "$0"
+    ;;
+  *) die "unknown command '$1' (try: start, stop, status, url, token)" ;;
+esac

--- a/relay/herdr-remote
+++ b/relay/herdr-remote
@@ -12,6 +12,8 @@
 # Tunnel backend is chosen by HERDR_TUNNEL_MODE in
 # ~/.config/herdr-remote/config.env: "temp"/"named" (Cloudflare, default)
 # or "aws" (reverse SSH tunnel to infra/aws-tunnel/, see that directory).
+# In aws mode, start/status self-heal and diagnose a stale SSH
+# security-group rule - see relay/aws-fw-heal.sh.
 #
 # This is the canonical copy - keep it in the repo, not only in
 # ~/.local/bin, so it's versioned and reviewable like everything else
@@ -200,6 +202,35 @@ url_is_live() {
   curl -fsS -o /dev/null --max-time 15 -H "Authorization: Bearer $(token_value)" "$u" 2>/dev/null
 }
 
+# aws_fw_check/aws_fw_heal run relay/aws-fw-heal.sh and parse its one-line
+# RESULT=... report into the caller's IP/GROUP/RULE/REASON vars. Both set
+# FW_RESULT to one of ok/added/absent/error. See that script's header for
+# the full output contract - this is the one place that parses it, so
+# start and status cannot drift into reading it two different ways.
+aws_fw_run() {
+  local mode=$1 out
+  out=$("$REPO/relay/aws-fw-heal.sh" "$mode" 2>/dev/null)
+  FW_RESULT=$(printf '%s' "$out" | sed -nE 's/^RESULT=([a-z]+).*/\1/p')
+  FW_IP=$(printf '%s' "$out"     | sed -nE 's/.* IP=([^ ]*).*/\1/p')
+  FW_GROUP=$(printf '%s' "$out"  | sed -nE 's/.* GROUP=([^ ]*).*/\1/p')
+  FW_REASON=$(printf '%s' "$out" | sed -nE 's/.*REASON=(.*)$/\1/p')
+  [ -n "$FW_RESULT" ] || FW_RESULT="error"
+}
+
+# Verify the AWS tunnel's SSH security-group rule and add the current IP
+# when it's missing (never remove or replace an existing one). Runs on
+# every `start` in aws mode, including when already running, because a
+# stale rule is exactly what makes "already running" silently unreachable.
+aws_fw_selfheal() {
+  local out rc
+  out=$("$REPO/relay/aws-fw-heal.sh" heal)
+  rc=$?
+  [ -n "$out" ] && printf '%s\n' "$out"
+  if [ "$rc" -eq 20 ] && [ -z "$out" ]; then
+    echo "herdr-remote: could not verify the SSH firewall rule (see: $REPO/relay/aws-fw-heal.sh check)" >&2
+  fi
+}
+
 cmd_start() {
   [ -d "$REPO" ] || die "repo not found at $REPO (set HERDR_REMOTE_REPO)"
   local tok; tok=$(token_value) || tok=""
@@ -211,6 +242,7 @@ cmd_start() {
   the relay grants whoever reaches it full control of your agents. A token is
   mandatory for this path and there is no way to skip it.
   Set HERDR_RELAY_TOKEN in $SECRETS, or re-run relay/install-service.sh."
+    aws_fw_selfheal
   fi
 
   [ -n "$tok" ] || die "no HERDR_RELAY_TOKEN in $SECRETS (or $CONFIG, or the environment)"
@@ -346,7 +378,27 @@ cmd_status() {
       echo "  URL:     $u  (reachable)"
     else
       echo "  URL:     $u  (NOT reachable - stale, or the tunnel dropped)"
-      echo "           Fix with: herdr-remote stop && herdr-remote start"
+      if [ "$(tunnel_mode)" = "aws" ]; then
+        aws_fw_run check
+        case "$FW_RESULT" in
+          absent)
+            echo "           Cause: your current IP ($FW_IP) is not allowed to SSH into"
+            echo "           the tunnel host (security group $FW_GROUP) - the reverse tunnel"
+            echo "           cannot connect, which is why restarting alone will not fix this."
+            echo "           Fix with: herdr-remote start (adds your current IP automatically)"
+            ;;
+          ok)
+            echo "           SSH firewall rule looks fine ($FW_IP is allowed on $FW_GROUP);"
+            echo "           the cause is something else. Fix with: herdr-remote stop && herdr-remote start"
+            ;;
+          *)
+            echo "           Could not check the SSH firewall rule (${FW_REASON:-unknown reason})."
+            echo "           Fix with: herdr-remote stop && herdr-remote start, or check manually."
+            ;;
+        esac
+      else
+        echo "           Fix with: herdr-remote stop && herdr-remote start"
+      fi
     fi
   else
     echo "  URL:     none recorded"

--- a/relay/herdr-remote
+++ b/relay/herdr-remote
@@ -37,7 +37,10 @@ fi
 CONFIG="$HOME/.config/herdr-remote/config.env"
 SECRETS="$HOME/.config/herdr-remote/secrets.env"
 LOG="$REPO/relay/relay.log"
-WEB_APP="https://herdr-remote.pages.dev"
+# The hosted web app at herdr-remote.pages.dev is gated behind the upstream
+# author's Cloudflare Access org (302 -> graffold.cloudflareaccess.com), so no
+# operator can reach it and no local change unlocks it. We point at the one-tap
+# tunnel link (tap_url) instead, which needs no hosted page or setup.
 CF_URL_RE='https://[a-z0-9-]*\.trycloudflare\.com'
 
 die() { printf 'herdr-remote: %s\n' "$1" >&2; exit 1; }
@@ -246,7 +249,6 @@ cmd_start() {
   done
 
   echo
-  echo "  Web app:  $WEB_APP"
   echo "  URL:      $url"
   echo "  Token:    $tok"
   echo
@@ -350,7 +352,6 @@ cmd_status() {
     echo "  URL:     none recorded"
   fi
   echo "  Token:   $(token_value 2>/dev/null || echo 'not set')"
-  echo "  Web app: $WEB_APP"
   if [ -n "$u" ]; then
     echo "  Tap:     $(tap_url)"
     echo "           (embeds the token; it lands in your browser history)"

--- a/relay/herdr-remote
+++ b/relay/herdr-remote
@@ -6,7 +6,7 @@
 #   herdr-remote start    start relay + tunnel, print URL and token
 #   herdr-remote stop     stop tunnel and relay
 #   herdr-remote status   report what is running, and the current URL
-#   herdr-remote url      print just the current tunnel URL
+#   herdr-remote url      print the one-tap URL (tunnel URL + embedded token)
 #   herdr-remote token    print just the relay token
 #
 # Tunnel backend is chosen by HERDR_TUNNEL_MODE in
@@ -151,6 +151,46 @@ current_url() {
   fi
 }
 
+# Percent-encode a string for use as a URL query value. The installer
+# generates hex tokens, but HERDR_RELAY_TOKEN can be set by hand to anything,
+# and an unencoded '&' or '#' would silently truncate the token the phone
+# receives - producing a link that looks right and fails to authenticate.
+urlencode() {
+  local s=$1 out="" i c
+  for (( i = 0; i < ${#s}; i++ )); do
+    c=${s:i:1}
+    case "$c" in
+      [A-Za-z0-9._~-]) out+="$c" ;;
+      *) out+=$(printf '%%%02X' "'$c") ;;
+    esac
+  done
+  printf '%s\n' "$out"
+}
+
+# The one-tap URL: the tunnel URL with the token already embedded, so the
+# operator can tap it straight out of the terminal instead of assembling it by
+# hand. The web app configures itself from it - web/index.html derives the
+# relay URL from its own origin and reads ?token= into localStorage - so there
+# is nothing left to paste into the gear.
+#
+# The token has to be a QUERY parameter and cannot be a '#token=' fragment,
+# much as a fragment would keep it out of the request. The relay authenticates
+# the initial GET / server-side (relay/herdr_relay.py process_request), and
+# browsers never transmit the fragment, so a fragment link would be answered
+# 401 before the app ever loaded to read it.
+#
+# Every caller that shows a URL to a human goes through here, so start, status
+# and url cannot drift into three different spellings of the same link.
+tap_url() {
+  local u tok
+  u=$(current_url) || return 1
+  tok=$(token_value 2>/dev/null) || tok=""
+  if [ -z "$tok" ]; then printf '%s\n' "$u"; return 0; fi
+  # Emit an explicit "/" path: "https://host?token=" is legal and most clients
+  # normalise it, but the relay matches on the path it is handed, so spell it out.
+  printf '%s/?token=%s\n' "${u%/}" "$(urlencode "$tok")"
+}
+
 url_is_live() {
   local u=$1
   [ -n "$u" ] || return 1
@@ -209,6 +249,10 @@ cmd_start() {
   echo "  Web app:  $WEB_APP"
   echo "  URL:      $url"
   echo "  Token:    $tok"
+  echo
+  echo "  Tap this on your phone - it carries the token, so the app needs no setup:"
+  echo "    $(tap_url)"
+  echo "  (that link embeds the token, so it lands in your browser history)"
   echo
   if [ "$live" = yes ]; then
     echo "  Reachable: yes (verified through the tunnel with your token)"
@@ -307,13 +351,17 @@ cmd_status() {
   fi
   echo "  Token:   $(token_value 2>/dev/null || echo 'not set')"
   echo "  Web app: $WEB_APP"
+  if [ -n "$u" ]; then
+    echo "  Tap:     $(tap_url)"
+    echo "           (embeds the token; it lands in your browser history)"
+  fi
 }
 
 case "${1:-}" in
   start)  cmd_start ;;
   stop)   cmd_stop ;;
   status) cmd_status ;;
-  url)    current_url || die "no URL recorded" ;;
+  url)    tap_url || die "no URL recorded" ;;
   token)  token_value || die "no token in $SECRETS" ;;
   ""|-h|--help|help)
     awk 'NR > 1 && /^#/ { sub(/^# ?/, ""); print; next } NR > 1 { exit }' "$0"

--- a/relay/herdr-remote
+++ b/relay/herdr-remote
@@ -15,7 +15,9 @@
 #
 # This is the canonical copy - keep it in the repo, not only in
 # ~/.local/bin, so it's versioned and reviewable like everything else
-# here. Symlink it into place:
+# here. relay/install-service.sh symlinks it onto PATH for you (at
+# ~/.local/bin/herdr-remote) and warns if a different file is already
+# there. To place it by hand instead:
 #   ln -sf "$(pwd)/relay/herdr-remote" ~/.local/bin/herdr-remote
 set -uo pipefail
 

--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -298,6 +298,32 @@ send_telegram_test() {
         >/dev/null 2>&1
 }
 
+# Percent-encode a string for use as a URL query value. Kept in step with the
+# copy in relay/herdr-remote, which is the canonical definition.
+urlencode() {
+    local s=$1 out="" i c
+    for (( i = 0; i < ${#s}; i++ )); do
+        c=${s:i:1}
+        case "$c" in
+            [A-Za-z0-9._~-]) out+="$c" ;;
+            *) out+=$(printf '%%%02X' "'$c") ;;
+        esac
+    done
+    printf '%s\n' "$out"
+}
+
+# The one-tap URL the operator opens on their phone: the tunnel URL with the
+# token already embedded, so the web app configures itself and there is nothing
+# to paste into the gear. This is the same link `herdr-remote url` prints - see
+# tap_url() in relay/herdr-remote for why the token must be a query parameter
+# and cannot be a '#token=' fragment.
+aws_tap_url() {
+    local host=${HERDR_AWS_HOST:-} tok=${HERDR_RELAY_TOKEN:-}
+    [ -n "$host" ] || { printf '<HERDR_AWS_HOST not set>\n'; return 0; }
+    if [ -z "$tok" ]; then printf 'https://%s\n' "$host"; return 0; fi
+    printf 'https://%s/?token=%s\n' "${host%/}" "$(urlencode "$tok")"
+}
+
 generate_relay_token() {
     python3 -c 'import secrets; print(secrets.token_hex(32))'
 }
@@ -1312,6 +1338,7 @@ EOF
 
     echo "  Tunnel service installed."
     echo "  URL: https://${HERDR_AWS_HOST:-<HERDR_AWS_HOST not set>}"
+    echo "  Tap: $(aws_tap_url)"
 elif [ "$TUNNEL_MODE" != "none" ] && [ -n "$CLOUDFLARED_PATH" ]; then
     echo "Installing tunnel service (mode: $TUNNEL_MODE)..."
 
@@ -1658,13 +1685,17 @@ fi
 [ "$TUNNEL_MODE" != "none" ] && echo "  Tunnel:     $TUNNEL_MODE"
 [ "$TUNNEL_MODE" = "named" ] && echo "  URL:        wss://$TUNNEL_HOSTNAME"
 if [ "$TUNNEL_MODE" = "aws" ]; then
-    # The URL and token are the exact two values the operator types into the
-    # phone web app (https://herdr-remote.pages.dev - tap the gear). The AWS
-    # path always has a token (the tunnel install refuses to run without one),
-    # so print it here rather than making the operator dig it out of secrets.env.
+    # The URL and token are the exact two values the operator would otherwise
+    # type into the phone web app by hand. The AWS path always has a token (the
+    # tunnel install refuses to run without one), so print them here rather than
+    # making the operator dig them out of secrets.env - and print the combined
+    # one-tap link too, which is what most people actually want.
     echo "  URL:        https://${HERDR_AWS_HOST:-<HERDR_AWS_HOST not set>}"
     echo "  Token:      ${HERDR_RELAY_TOKEN}"
-    echo "  Open the web app, tap the gear, and paste the URL and token above."
+    echo "  Tap:        $(aws_tap_url)"
+    echo "  Tap that link on your phone - it carries the token, so the app needs"
+    echo "  no setup. (It embeds the token, so it lands in your browser history.)"
+    echo "  Or open the web app, tap the gear, and paste the URL and token above."
 fi
 echo "  Logs:       $LOG_DIR/"
 echo "  Config:     $CONFIG_FILE"

--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -1442,6 +1442,70 @@ echo ""
 echo "Services installed and started."
 echo ""
 
+# --- Install the operator-facing CLI wrapper ---
+#
+# relay/herdr-remote is the canonical start/stop/status wrapper. It is what the
+# operator actually types, and it is the only thing that knows how to boot the
+# launchd jobs out (a plain kill of the relay just gets restarted by KeepAlive).
+# If it is not installed onto PATH, the operator falls back to whatever stale
+# copy is already in ~/.local/bin - historically a pre-AWS, Cloudflare-only
+# wrapper whose `stop` greps for a cloudflared process, finds none under AWS,
+# kills only the relay, and reports "Stopped." while the public tunnel stays up.
+# We symlink (not copy) so the installed CLI can never fall behind the versioned
+# wrapper it points at, and warn loudly when a different file is already there.
+install_cli_wrapper() {
+    WRAPPER_SRC="$SCRIPT_DIR/herdr-remote"
+    BIN_DIR="$HOME/.local/bin"
+    WRAPPER_DEST="$BIN_DIR/herdr-remote"
+
+    if [ ! -f "$WRAPPER_SRC" ]; then
+        echo "  [warn] Canonical wrapper not found at $WRAPPER_SRC; skipping CLI install."
+        return 0
+    fi
+
+    chmod +x "$WRAPPER_SRC" 2>/dev/null || true
+    mkdir -p "$BIN_DIR"
+
+    if [ -L "$WRAPPER_DEST" ] && [ "$(readlink "$WRAPPER_DEST")" = "$WRAPPER_SRC" ]; then
+        echo "  [ok] CLI already linked: $WRAPPER_DEST -> $WRAPPER_SRC"
+    else
+        if [ -e "$WRAPPER_DEST" ] || [ -L "$WRAPPER_DEST" ]; then
+            # Something is already here that is not our symlink. Warn if it
+            # differs from the canonical wrapper (it almost always will - that
+            # stale copy is the whole reason this step exists), and preserve it.
+            if [ -L "$WRAPPER_DEST" ]; then
+                echo "  [warn] Replacing an existing herdr-remote at $WRAPPER_DEST"
+                echo "         (symlink -> $(readlink "$WRAPPER_DEST")) with a link to the canonical wrapper."
+            elif cmp -s "$WRAPPER_DEST" "$WRAPPER_SRC"; then
+                echo "  [note] $WRAPPER_DEST is an identical copy; converting it to a symlink so it stays in sync."
+            else
+                echo "  [warn] A DIFFERENT herdr-remote is already installed at $WRAPPER_DEST."
+                echo "         It does not match the canonical wrapper in this repo and is very likely a"
+                echo "         stale copy that mismanages the current tunnel backend (e.g. a Cloudflare-only"
+                echo "         'stop' that leaves an AWS tunnel serving publicly). Replacing it with a"
+                echo "         symlink to the versioned wrapper: $WRAPPER_SRC"
+                BACKUP="$WRAPPER_DEST.replaced-by-installer"
+                if cp -p "$WRAPPER_DEST" "$BACKUP" 2>/dev/null; then
+                    echo "         Previous file backed up to: $BACKUP"
+                fi
+            fi
+        fi
+        ln -sf "$WRAPPER_SRC" "$WRAPPER_DEST"
+        echo "  CLI installed: $WRAPPER_DEST -> $WRAPPER_SRC"
+    fi
+
+    case ":$PATH:" in
+        *":$BIN_DIR:"*) ;;
+        *)
+            echo "  [note] $BIN_DIR is not on your PATH. Add it so 'herdr-remote' resolves, e.g.:"
+            echo "         export PATH=\"$BIN_DIR:\$PATH\""
+            ;;
+    esac
+}
+install_cli_wrapper
+
+echo ""
+
 # --- Smoke test ---
 
 echo "Running smoke test..."
@@ -1580,6 +1644,7 @@ fi
 echo "  Logs:       $LOG_DIR/"
 echo "  Config:     $CONFIG_FILE"
 echo "  Secrets:    $SECRETS_FILE"
+[ -e "$HOME/.local/bin/herdr-remote" ] && echo "  CLI:        $HOME/.local/bin/herdr-remote (start | stop | status | url | token)"
 echo ""
 echo "Commands:"
 echo "  Relay log:    tail -f $LOG_DIR/relay.log"

--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_DIR="$HOME/.config/herdr-remote"
 CONFIG_FILE="$CONFIG_DIR/config.env"
 SECRETS_FILE="$CONFIG_DIR/secrets.env"
+# shellcheck source=config-lib.sh
+source "$SCRIPT_DIR/config-lib.sh"
 
 # --- Detect OS ---
 
@@ -97,7 +99,7 @@ if [ -f "$CONFIG_FILE" ]; then
         exit 1
     fi
     # shellcheck disable=SC1090
-    source "$CONFIG_FILE"
+    load_config_file "$CONFIG_FILE"
     EXISTING_INSTALL=true
 fi
 if [ -f "$SECRETS_FILE" ]; then
@@ -118,8 +120,7 @@ if [ -f "$SECRETS_FILE" ]; then
         echo "Repair it with: chmod 600 \"$SECRETS_FILE\""
         exit 1
     fi
-    # shellcheck disable=SC1090
-    source "$SECRETS_FILE"
+    load_config_file "$SECRETS_FILE"
 fi
 
 WS_PORT="${HERDR_RELAY_PORT:-8375}"
@@ -489,7 +490,35 @@ fi
 
 TUNNEL_MODE="none"
 
-if [ -z "$CLOUDFLARED_PATH" ]; then
+# HERDR_TUNNEL_MODE=aws (set by hand in config.env — see infra/aws-tunnel/)
+# replaces the whole interactive Cloudflare flow below with the reverse SSH
+# tunnel service. It was already sourced from $CONFIG_FILE at the top of
+# this script if present.
+if [ "${HERDR_TUNNEL_MODE:-}" = "aws" ]; then
+    TUNNEL_MODE="aws"
+    echo "AWS reverse tunnel"
+    echo "-------------------"
+    echo "  HERDR_TUNNEL_MODE=aws in $CONFIG_FILE — installing the reverse"
+    echo "  SSH tunnel service instead of Cloudflare Tunnel."
+
+    if [ -z "$HERDR_RELAY_TOKEN" ]; then
+        echo ""
+        echo "  Error: the AWS reverse tunnel requires HERDR_RELAY_TOKEN."
+        echo "  Unlike the Cloudflare path, this one publishes the relay on the"
+        echo "  public internet over HTTPS, and the relay grants whoever reaches"
+        echo "  it full control of your agents — read output, send keys, and"
+        echo "  trust all tools for a blocked agent. A token is mandatory here"
+        echo "  and there is no way to skip it."
+        echo ""
+        echo "  Re-run this installer and accept the token prompt, or set"
+        echo "  HERDR_RELAY_TOKEN in the environment before running it."
+        exit 1
+    fi
+
+    [ -n "${HERDR_AWS_HOST:-}" ] || echo "  WARNING: HERDR_AWS_HOST is not set — the tunnel will fail to start."
+    echo "  See infra/aws-tunnel/README.md for the EC2-side setup."
+    echo ""
+elif [ -z "$CLOUDFLARED_PATH" ]; then
     echo "Cloudflare tunnel"
     echo "-----------------"
     echo "  cloudflared not found."
@@ -544,7 +573,7 @@ fi
 
 # --- Tunnel configuration ---
 
-if [ -n "$CLOUDFLARED_PATH" ]; then
+if [ "$TUNNEL_MODE" != "aws" ] && [ -n "$CLOUDFLARED_PATH" ]; then
     echo ""
     echo "Cloudflare tunnel setup"
     echo "-----------------------"
@@ -892,6 +921,11 @@ HERDR_CLOUDFLARED_PATH=${CLOUDFLARED_PATH:-}
 HERDR_TG_ENABLED=$TELEGRAM_ENABLED
 HERDR_TG_USERNAME=${HERDR_TG_USERNAME:-}
 HERDR_TG_CHAT_TYPE=${HERDR_TG_CHAT_TYPE:-unknown}
+HERDR_AWS_HOST=${HERDR_AWS_HOST:-}
+HERDR_AWS_SSH_USER=${HERDR_AWS_SSH_USER:-}
+HERDR_AWS_SSH_PORT=${HERDR_AWS_SSH_PORT:-}
+HERDR_AWS_SSH_KEY=${HERDR_AWS_SSH_KEY:-}
+HERDR_AWS_TUNNEL_PORT=${HERDR_AWS_TUNNEL_PORT:-}
 EOF
 )
 chmod 644 "$CONFIG_TMP"
@@ -1202,6 +1236,82 @@ if [ "$TUNNEL_MODE" = "none" ] || [ "$TUNNEL_MODE" = "named-external" ]; then
         echo "  Tunnel: using existing cloudflared service (not managed by herdr-remote)."
         echo "  Hostname: ${TUNNEL_HOSTNAME:-unknown}"
     fi
+elif [ "$TUNNEL_MODE" = "aws" ]; then
+    if [ -z "$HERDR_RELAY_TOKEN" ]; then
+        echo "Error: refusing to install the AWS reverse tunnel service without"
+        echo "  HERDR_RELAY_TOKEN. This tunnel exposes the relay publicly over the"
+        echo "  internet, so a token is mandatory and cannot be skipped."
+        exit 1
+    fi
+
+    echo "Installing AWS reverse tunnel service..."
+    TUNNEL_SCRIPT="$SCRIPT_DIR/tunnel-aws.sh"
+
+    if [ "$OS" = "macos" ]; then
+        PLIST_TUNNEL="$HOME/Library/LaunchAgents/$LABEL_TUNNEL.plist"
+
+        launchctl bootout "gui/$(id -u)/$LABEL_TUNNEL" 2>/dev/null || true
+        sleep 1
+
+        cat > "$PLIST_TUNNEL" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LABEL_TUNNEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$TUNNEL_SCRIPT</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>$LOG_DIR/tunnel-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>$LOG_DIR/tunnel-stderr.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>$SERVICE_PATH</string>
+    </dict>
+</dict>
+</plist>
+EOF
+
+        wait_for_label_gone "$LABEL_TUNNEL" || true
+        bootstrap_with_retry "$PLIST_TUNNEL" "$LABEL_TUNNEL" || true
+    else
+        systemctl --user stop herdr-tunnel.service 2>/dev/null || true
+
+        cat > "$UNIT_DIR/herdr-tunnel.service" <<EOF
+[Unit]
+Description=herdr-remote AWS reverse tunnel
+After=herdr-relay.service network-online.target
+Wants=network-online.target
+Requires=herdr-relay.service
+
+[Service]
+ExecStart=$TUNNEL_SCRIPT
+Restart=always
+RestartSec=10
+Environment=PATH=$SERVICE_PATH
+
+[Install]
+WantedBy=default.target
+EOF
+
+        systemctl --user daemon-reload
+        systemctl --user enable herdr-tunnel.service
+        systemctl --user start herdr-tunnel.service
+    fi
+
+    echo "  Tunnel service installed."
+    echo "  URL: https://${HERDR_AWS_HOST:-<HERDR_AWS_HOST not set>}"
 elif [ "$TUNNEL_MODE" != "none" ] && [ -n "$CLOUDFLARED_PATH" ]; then
     echo "Installing tunnel service (mode: $TUNNEL_MODE)..."
 

--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -1509,13 +1509,29 @@ echo ""
 # --- Smoke test ---
 
 echo "Running smoke test..."
-sleep "${HERDR_INSTALL_SETTLE_SECONDS:-3}"
 
-# 1. Check port is listening
-if ! lsof -iTCP:"$WS_PORT" -sTCP:LISTEN >/dev/null 2>&1 && \
-   ! ss -tlnp 2>/dev/null | grep -q ":$WS_PORT "; then
+# 1. Wait for the port to come up, then check it is listening.
+#
+# The relay is launched by launchd/systemd and its first `uv run` does a cold
+# dependency resolve that regularly takes well over the old fixed 3s wait - so a
+# single check after `sleep 3` reported FAIL on installs that were perfectly
+# healthy a few seconds later. Poll instead: check once per second up to
+# HERDR_INSTALL_SETTLE_SECONDS (default 30) and succeed as soon as the port is
+# up. The env var stays an override - raise it on a slow first run, lower it to
+# fail fast in CI.
+SETTLE_SECONDS="${HERDR_INSTALL_SETTLE_SECONDS:-30}"
+PORT_UP=0
+for _ in $(seq 1 "$SETTLE_SECONDS"); do
+    if lsof -iTCP:"$WS_PORT" -sTCP:LISTEN >/dev/null 2>&1 || \
+       ss -tlnp 2>/dev/null | grep -q ":$WS_PORT "; then
+        PORT_UP=1
+        break
+    fi
+    sleep 1
+done
+if [ "$PORT_UP" -ne 1 ]; then
     echo ""
-    echo "  FAIL: Port $WS_PORT is not listening after 3 seconds."
+    echo "  FAIL: Port $WS_PORT is not listening after ${SETTLE_SECONDS} seconds."
     echo "  Check logs: tail -20 $LOG_DIR/relay.log"
     exit 1
 fi
@@ -1641,6 +1657,15 @@ else
 fi
 [ "$TUNNEL_MODE" != "none" ] && echo "  Tunnel:     $TUNNEL_MODE"
 [ "$TUNNEL_MODE" = "named" ] && echo "  URL:        wss://$TUNNEL_HOSTNAME"
+if [ "$TUNNEL_MODE" = "aws" ]; then
+    # The URL and token are the exact two values the operator types into the
+    # phone web app (https://herdr-remote.pages.dev - tap the gear). The AWS
+    # path always has a token (the tunnel install refuses to run without one),
+    # so print it here rather than making the operator dig it out of secrets.env.
+    echo "  URL:        https://${HERDR_AWS_HOST:-<HERDR_AWS_HOST not set>}"
+    echo "  Token:      ${HERDR_RELAY_TOKEN}"
+    echo "  Open the web app, tap the gear, and paste the URL and token above."
+fi
 echo "  Logs:       $LOG_DIR/"
 echo "  Config:     $CONFIG_FILE"
 echo "  Secrets:    $SECRETS_FILE"

--- a/relay/start.sh
+++ b/relay/start.sh
@@ -2,19 +2,23 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=config-lib.sh
+source "$SCRIPT_DIR/config-lib.sh"
 CONFIG_FILE="$HOME/.config/herdr-remote/config.env"
-WS_PORT="${HERDR_RELAY_PORT:-8375}"
 
 RELAY_PID=""
 TUNNEL_PID=""
 
 cleanup() {
+    local rc=$?
+    set +e
+    trap - INT TERM EXIT
     echo ""
     echo "Shutting down..."
     [ -n "$TUNNEL_PID" ] && kill "$TUNNEL_PID" 2>/dev/null && wait "$TUNNEL_PID" 2>/dev/null
     [ -n "$RELAY_PID" ] && kill "$RELAY_PID" 2>/dev/null && wait "$RELAY_PID" 2>/dev/null
     echo "Done."
-    exit 0
+    exit "$rc"
 }
 
 trap cleanup INT TERM EXIT
@@ -23,7 +27,24 @@ echo "herdr-remote relay"
 echo ""
 
 # Load config if available
-[ -f "$CONFIG_FILE" ] && source "$CONFIG_FILE"
+SECRETS_FILE="$HOME/.config/herdr-remote/secrets.env"
+load_config_file "$CONFIG_FILE"
+load_config_file "$SECRETS_FILE"
+
+WS_PORT="${HERDR_RELAY_PORT:-8375}"
+
+TUNNEL_MODE="${HERDR_TUNNEL_MODE:-temp}"
+
+# Refuse before anything is started, so the relay is not raised and then
+# torn down again on the way out.
+if [ "$TUNNEL_MODE" = "aws" ] && [ -z "${HERDR_RELAY_TOKEN:-}" ]; then
+    echo "Error: refusing to start the AWS reverse tunnel without HERDR_RELAY_TOKEN."
+    echo "  The AWS tunnel publishes this relay on the public internet over HTTPS,"
+    echo "  and the relay grants whoever reaches it full control of your agents."
+    echo "  A token is mandatory for this path and there is no way to skip it."
+    echo "  Set HERDR_RELAY_TOKEN in $SECRETS_FILE, or re-run install-service.sh."
+    exit 1
+fi
 
 # 1. Start relay
 echo "Starting relay on :$WS_PORT..."
@@ -39,9 +60,31 @@ if ! kill -0 "$RELAY_PID" 2>/dev/null; then
 fi
 echo "Relay running (pid $RELAY_PID)"
 
-# 2. Start tunnel (if cloudflared available)
-if command -v cloudflared >/dev/null 2>&1; then
-    TUNNEL_MODE="${HERDR_TUNNEL_MODE:-temp}"
+# 2. Start tunnel
+if [ "$TUNNEL_MODE" = "aws" ]; then
+    echo "Starting AWS reverse tunnel..."
+    "$SCRIPT_DIR/tunnel-aws.sh" &
+    TUNNEL_PID=$!
+    sleep 2
+
+    if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
+        echo "Error: AWS tunnel failed to start. Check HERDR_AWS_HOST/HERDR_AWS_SSH_KEY in $CONFIG_FILE."
+        TUNNEL_PID=""
+    elif [ -n "${HERDR_AWS_HOST:-}" ]; then
+        # The supervisor staying alive proves nothing: the plain-ssh fallback
+        # loop keeps retrying forever even if every connection attempt fails.
+        # Probe the endpoint before calling it reachable.
+        TUNNEL_URL="https://${HERDR_AWS_HOST}"
+        if curl -fsS -o /dev/null --max-time 10 \
+             -H "Authorization: Bearer $HERDR_RELAY_TOKEN" "$TUNNEL_URL" 2>/dev/null; then
+            echo "Tunnel URL: $TUNNEL_URL (reachable)"
+        else
+            echo "Tunnel supervisor started; URL will be $TUNNEL_URL once connected."
+            echo "  Not answering yet - it may still be connecting, or check the"
+            echo "  SSH key, HERDR_AWS_HOST, and the EC2 security group's SSH CIDR."
+        fi
+    fi
+elif command -v cloudflared >/dev/null 2>&1; then
 
     if [ "$TUNNEL_MODE" = "named" ] && [ -n "$HERDR_TUNNEL_NAME" ]; then
         echo "Starting named tunnel ($HERDR_TUNNEL_NAME)..."

--- a/relay/tunnel-aws.sh
+++ b/relay/tunnel-aws.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Reverse SSH tunnel from the Mac to the herdr-remote AWS rendezvous host
+# (see infra/aws-tunnel/). The Mac dials out; nothing inbound is ever
+# needed on the Mac or the home router.
+#
+# Config (from ~/.config/herdr-remote/config.env or the environment):
+#   HERDR_AWS_HOST          required - rendezvous host's stable hostname
+#   HERDR_AWS_SSH_USER      default: herdr-tunnel
+#   HERDR_AWS_SSH_PORT      default: 22
+#   HERDR_AWS_SSH_KEY       default: ~/.ssh/herdr-remote-tunnel
+#   HERDR_AWS_TUNNEL_PORT   default: 9375 (loopback port on the EC2 host)
+#   HERDR_RELAY_PORT        default: 8375 (local relay port to forward)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=config-lib.sh
+source "$SCRIPT_DIR/config-lib.sh"
+
+CONFIG_FILE="$HOME/.config/herdr-remote/config.env"
+SECRETS_FILE="$HOME/.config/herdr-remote/secrets.env"
+
+load_config_file "$CONFIG_FILE"
+load_config_file "$SECRETS_FILE"
+
+HOST="${HERDR_AWS_HOST:-}"
+SSH_USER="${HERDR_AWS_SSH_USER:-herdr-tunnel}"
+SSH_PORT="${HERDR_AWS_SSH_PORT:-22}"
+SSH_KEY="${HERDR_AWS_SSH_KEY:-$HOME/.ssh/herdr-remote-tunnel}"
+TUNNEL_PORT="${HERDR_AWS_TUNNEL_PORT:-9375}"
+RELAY_PORT="${HERDR_RELAY_PORT:-8375}"
+
+die() { printf 'tunnel-aws: %s\n' "$1" >&2; exit 1; }
+
+[ -n "$HOST" ] || die "HERDR_AWS_HOST is not set (add it to $CONFIG_FILE)"
+[ -r "$SSH_KEY" ] || die "SSH key not readable: $SSH_KEY"
+
+if [ -z "${HERDR_RELAY_TOKEN:-}" ]; then
+  die "refusing to open the reverse tunnel without HERDR_RELAY_TOKEN.
+  This tunnel publishes the relay on the public internet over HTTPS, and the
+  relay grants whoever reaches it full control of your agents - read output,
+  send keys, and trust all tools for a blocked agent. A token is mandatory
+  for this path and there is no way to skip it.
+  Set HERDR_RELAY_TOKEN in $SECRETS_FILE, or re-run relay/install-service.sh."
+fi
+
+SSH_OPTS=(
+  -N
+  -o ExitOnForwardFailure=yes
+  -o ServerAliveInterval=15
+  -o ServerAliveCountMax=3
+  -o StrictHostKeyChecking=accept-new
+  -o BatchMode=yes
+  -i "$SSH_KEY"
+  -p "$SSH_PORT"
+  -R "127.0.0.1:${TUNNEL_PORT}:127.0.0.1:${RELAY_PORT}"
+  "${SSH_USER}@${HOST}"
+)
+
+echo "tunnel-aws: forwarding ${HOST}:${TUNNEL_PORT} -> 127.0.0.1:${RELAY_PORT}"
+
+if command -v autossh >/dev/null 2>&1; then
+  # Foreground (no -f): this script is meant to run under a service
+  # supervisor (launchd/systemd), which needs to hold the PID to detect
+  # and restart a fully-dead autossh, not just a dropped SSH session.
+  export AUTOSSH_GATETIME=0
+  exec autossh -M 0 -N \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=15 \
+    -o ServerAliveCountMax=3 \
+    -o StrictHostKeyChecking=accept-new \
+    -o BatchMode=yes \
+    -i "$SSH_KEY" \
+    -p "$SSH_PORT" \
+    -R "127.0.0.1:${TUNNEL_PORT}:127.0.0.1:${RELAY_PORT}" \
+    "${SSH_USER}@${HOST}"
+fi
+
+echo "tunnel-aws: autossh not found, falling back to a supervised retry loop"
+echo "tunnel-aws: install autossh for faster reconnects (brew install autossh)"
+
+# ssh runs in the background so a signal can reach it. Left in the
+# foreground it would outlive this script when a supervisor (start.sh's
+# cleanup trap, or `herdr-remote stop`) kills us, and the orphan keeps
+# the remote forward bound - which makes the next connection fail
+# against ExitOnForwardFailure with no visible reason.
+SSH_PID=""
+cleanup() {
+  trap - INT TERM EXIT
+  if [ -n "$SSH_PID" ]; then
+    kill "$SSH_PID" 2>/dev/null
+    wait "$SSH_PID" 2>/dev/null
+  fi
+  exit 0
+}
+trap cleanup INT TERM EXIT
+
+BACKOFF=1
+while true; do
+  ssh "${SSH_OPTS[@]}" &
+  SSH_PID=$!
+  wait "$SSH_PID" 2>/dev/null
+  SSH_PID=""
+  echo "tunnel-aws: connection dropped, retrying in ${BACKOFF}s"
+  sleep "$BACKOFF"
+  BACKOFF=$(( BACKOFF < 30 ? BACKOFF * 2 : 30 ))
+done

--- a/tests/install-service.sh
+++ b/tests/install-service.sh
@@ -150,6 +150,35 @@ run_install() {
         bash "$ROOT/relay/install-service.sh"
 }
 
+run_install_env() {
+    local os="$1"; shift
+    local home="$1"; shift
+    local input="$1"; shift
+    mkdir -p "$home"
+    printf '%s' "$input" | env \
+        HOME="$home" \
+        PATH="$MOCK_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        HERDR_TEST_CALLS="$CALLS" \
+        HERDR_INSTALL_OS="$os" \
+        HERDR_INSTALL_SKIP_CLOUDFLARED=1 \
+        HERDR_INSTALL_SKIP_WEBSOCKET_SMOKE=1 \
+        HERDR_INSTALL_SETTLE_SECONDS=0 \
+        HERDR_INSTALL_SERVICE_DELAY=0 \
+        HERDR_LOG_DIR= \
+        HERDR_RELAY= \
+        HERDR_TG_CHAT_ID= \
+        HERDR_TG_CHAT_TYPE= \
+        HERDR_TG_ENABLED= \
+        HERDR_TG_TOKEN= \
+        HERDR_TG_USERNAME= \
+        HERDR_TEST_NONROOT_UID="${HERDR_TEST_NONROOT_UID:-501}" \
+        HERDR_TEST_PGREP="${HERDR_TEST_PGREP:-0}" \
+        HERDR_TEST_ROOT="${HERDR_TEST_ROOT:-0}" \
+        HERDR_TEST_OWNER_UID="${HERDR_TEST_OWNER_UID:-}" \
+        "$@" \
+        bash "$ROOT/relay/install-service.sh"
+}
+
 run_uninstall() {
     local os="$1"
     local home="$2"
@@ -344,5 +373,40 @@ assert_contains "$TMP/calls.log" 'launchctl bootout gui/501/com.herdr-remote.tun
 assert_contains "$TMP/calls.log" 'systemctl --user enable herdr-telegram.service'
 assert_contains "$TMP/calls.log" 'systemctl --user disable herdr-tunnel.service'
 assert_not_contains "$TMP/calls.log" '123456:ABC_def'
+
+# The AWS reverse tunnel publishes the relay on the public internet, so the
+# installer must refuse to install it without a token. This is the control the
+# whole AWS path's security rests on: the relay itself accepts an empty token
+# when bound to loopback, so nothing downstream would catch it.
+AWS_NOTOKEN_HOME="$TMP/aws-notoken-home"
+mkdir -p "$AWS_NOTOKEN_HOME/.config/herdr-remote"
+printf 'HERDR_TUNNEL_MODE=aws\nHERDR_AWS_HOST=relay.example.com\n' \
+    > "$AWS_NOTOKEN_HOME/.config/herdr-remote/config.env"
+chmod 600 "$AWS_NOTOKEN_HOME/.config/herdr-remote/config.env"
+if run_install_env macos "$AWS_NOTOKEN_HOME" $'n\nn\nn\nn\n' HERDR_RELAY_TOKEN= \
+        > "$TMP/aws-notoken.log" 2>&1; then
+    echo "aws mode without a relay token unexpectedly succeeded" >&2
+    exit 1
+fi
+assert_contains "$TMP/aws-notoken.log" 'requires HERDR_RELAY_TOKEN'
+[ ! -f "$AWS_NOTOKEN_HOME/Library/LaunchAgents/com.herdr-remote.tunnel.plist" ] || {
+    echo "aws tunnel service was installed despite the missing token" >&2
+    exit 1
+}
+
+# With a token the same invocation must actually reach the tunnel install and
+# persist the aws mode, so the refusal above is proven to be about the token
+# and not about the aws branch being unreachable in this harness.
+AWS_TOKEN_HOME="$TMP/aws-token-home"
+mkdir -p "$AWS_TOKEN_HOME/.config/herdr-remote"
+printf 'HERDR_TUNNEL_MODE=aws\nHERDR_AWS_HOST=relay.example.com\n' \
+    > "$AWS_TOKEN_HOME/.config/herdr-remote/config.env"
+chmod 600 "$AWS_TOKEN_HOME/.config/herdr-remote/config.env"
+run_install_env macos "$AWS_TOKEN_HOME" $'n\nn\nn\nn\n' \
+    HERDR_RELAY_TOKEN=abcdefghijklmnop1234 > "$TMP/aws-token.log" 2>&1 || true
+assert_not_contains "$TMP/aws-token.log" 'requires HERDR_RELAY_TOKEN'
+assert_file "$AWS_TOKEN_HOME/Library/LaunchAgents/com.herdr-remote.tunnel.plist"
+assert_contains "$AWS_TOKEN_HOME/Library/LaunchAgents/com.herdr-remote.tunnel.plist" 'tunnel-aws.sh'
+assert_contains "$AWS_TOKEN_HOME/.config/herdr-remote/config.env" 'HERDR_TUNNEL_MODE=aws'
 
 echo "installer service tests passed"

--- a/tests/install-service.sh
+++ b/tests/install-service.sh
@@ -287,6 +287,34 @@ assert_not_contains "$MAC_HOME/Library/LaunchAgents/com.herdr-remote.telegram.pl
 python3 -c 'import os, stat, sys; info = os.stat(sys.argv[1]); mode = stat.S_IMODE(info.st_mode); raise SystemExit(0 if mode == 0o600 and info.st_uid == os.getuid() else 1)' "$MAC_HOME/.config/herdr-remote/secrets.env"
 python3 -c 'import os, stat, sys; info = os.stat(sys.argv[1]); mode = stat.S_IMODE(info.st_mode); raise SystemExit(0 if mode == 0o644 and info.st_uid == os.getuid() else 1)' "$MAC_HOME/.config/herdr-remote/config.env"
 assert_contains "$TMP/mac-new.log" 'Telegram bot verified as @installer_test_bot'
+# The operator-facing CLI wrapper is symlinked onto PATH.
+[ -L "$MAC_HOME/.local/bin/herdr-remote" ] || {
+    echo "CLI wrapper was not symlinked into ~/.local/bin" >&2
+    exit 1
+}
+[ "$(readlink "$MAC_HOME/.local/bin/herdr-remote")" = "$ROOT/relay/herdr-remote" ] || {
+    echo "CLI wrapper symlink does not point at the canonical wrapper" >&2
+    exit 1
+}
+assert_contains "$TMP/mac-new.log" 'CLI installed:'
+
+# A pre-existing, DIFFERENT herdr-remote (e.g. a stale Cloudflare-only wrapper)
+# is warned about, backed up, and replaced by a symlink to the canonical copy.
+STALE_CLI_HOME="$TMP/stale-cli-home"
+mkdir -p "$STALE_CLI_HOME/.local/bin"
+printf '%s\n' '#!/bin/sh' '# stale cloudflare-only wrapper' 'echo old' \
+    > "$STALE_CLI_HOME/.local/bin/herdr-remote"
+run_install macos "$STALE_CLI_HOME" $'yy123456:ABC_def\n\nyn' > "$TMP/stale-cli.log" || {
+    cat "$TMP/stale-cli.log"
+    exit 1
+}
+assert_contains "$TMP/stale-cli.log" 'A DIFFERENT herdr-remote is already installed'
+assert_file "$STALE_CLI_HOME/.local/bin/herdr-remote.replaced-by-installer"
+assert_contains "$STALE_CLI_HOME/.local/bin/herdr-remote.replaced-by-installer" 'stale cloudflare-only wrapper'
+[ -L "$STALE_CLI_HOME/.local/bin/herdr-remote" ] || {
+    echo "stale CLI was not replaced by a symlink" >&2
+    exit 1
+}
 
 run_install macos "$MAC_HOME" 'yyyyn' > "$TMP/mac-retain.log" || {
     cat "$TMP/mac-retain.log"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -177,13 +177,42 @@ PATH="$HR_TMP/bin:$PATH" HOME="$HR_TMP/home" HERDR_REMOTE_REPO="$DIR" \
 assert_eq "$?" "0" "stop confirms shutdown instead of claiming a restart is pending"
 rm -rf "$HR_TMP"
 
+echo "22. herdr-remote url prints a one-tap URL with the token embedded"
+# The operator taps this straight out of the terminal, so the token has to be
+# a query parameter (the relay authenticates GET / server-side, and a fragment
+# is never sent to it) and has to be percent-encoded (parse_qs would otherwise
+# read a literal '+' as a space and a '&' would truncate the token).
+HR_TMP="$(mktemp -d)"
+mkdir -p "$HR_TMP/bin" "$HR_TMP/home/.config/herdr-remote"
+printf 'HERDR_TUNNEL_MODE=aws\nHERDR_AWS_HOST=example.sslip.io\n' \
+    > "$HR_TMP/home/.config/herdr-remote/config.env"
+printf 'HERDR_RELAY_TOKEN=a+b/c&d\n' > "$HR_TMP/home/.config/herdr-remote/secrets.env"
+printf '#!/bin/sh\nexit 1\n' > "$HR_TMP/bin/lsof"
+printf '#!/bin/sh\nexit 1\n' > "$HR_TMP/bin/pgrep"
+chmod +x "$HR_TMP/bin/lsof" "$HR_TMP/bin/pgrep"
+HR_URL=$(PATH="$HR_TMP/bin:$PATH" HOME="$HR_TMP/home" HERDR_REMOTE_REPO="$DIR" \
+    "$DIR/relay/herdr-remote" url 2>/dev/null)
+assert_eq "$HR_URL" "https://example.sslip.io/?token=a%2Bb%2Fc%26d" \
+    "url prints the tappable link with a percent-encoded token"
+
+echo "23. herdr-remote start, status and url agree on that URL"
+# Three surfaces printing three spellings of the same link is the drift this
+# guards against; they all have to come from tap_url().
+HR_STATUS=$(PATH="$HR_TMP/bin:$PATH" HOME="$HR_TMP/home" HERDR_REMOTE_REPO="$DIR" \
+    "$DIR/relay/herdr-remote" status 2>/dev/null | sed -n 's/^  Tap:  *//p')
+assert_eq "$HR_STATUS" "$HR_URL" "status prints the same link as url"
+HR_SRC_USERS=$(grep -c 'tap_url' "$DIR/relay/herdr-remote")
+[ "$HR_SRC_USERS" -ge 4 ]
+assert_eq "$?" "0" "start, status and url all route through tap_url"
+rm -rf "$HR_TMP"
+
 # --- Repository policy gates ---
 # These are POLICY gates, not behavior tests. They assert a property of the
 # repository's contents itself, which is the thing being guaranteed - not a
 # proxy for any code working.
 echo ""
 echo "=== Repository policy ==="
-echo "22. POLICY: no credential material committed anywhere in the repository"
+echo "24. POLICY: no credential material committed anywhere in the repository"
 # Scans every git-tracked file, not just the AWS tunnel directory and not
 # just the diff: the requirement is repo-wide, and a full scan gives the
 # same answer regardless of branch, rebase, or staging state.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -129,6 +129,79 @@ echo "18. LICENSE is AGPL"
 grep -q "GNU AFFERO GENERAL PUBLIC LICENSE" "$DIR/LICENSE"
 assert_eq "$?" "0" "AGPL license"
 
+# --- AWS reverse tunnel ---
+echo ""
+echo "=== AWS reverse tunnel ==="
+echo "19. tunnel-aws.sh and herdr-remote wrapper are executable"
+[ -x "$DIR/relay/tunnel-aws.sh" ] && [ -x "$DIR/relay/herdr-remote" ]
+assert_eq "$?" "0" "aws tunnel scripts +x"
+
+echo "20. CloudFormation template validates"
+if command -v aws >/dev/null 2>&1 && aws sts get-caller-identity >/dev/null 2>&1; then
+  aws cloudformation validate-template --region us-east-1 \
+    --template-body "file://$DIR/infra/aws-tunnel/cloudformation.yaml" >/dev/null 2>&1
+  assert_eq "$?" "0" "cloudformation.yaml is well-formed"
+else
+  PASS=$((PASS+1)); echo "  skip: aws CLI not available or not authenticated (no local mutation, read-only API call)"
+fi
+
+echo "21. herdr-remote stop confirms shutdown of a stopped-but-enabled unit"
+# install-service.sh enables the systemd units, and `stop` deliberately leaves
+# them enabled so they return at next login. A unit in that state is down, so
+# stop must confirm the shutdown rather than report that something will restart
+# it. Driven through the real wrapper with a mocked Linux service manager.
+HR_TMP="$(mktemp -d)"
+mkdir -p "$HR_TMP/bin" "$HR_TMP/home/.config/herdr-remote"
+printf 'HERDR_TUNNEL_MODE=temp\n' > "$HR_TMP/home/.config/herdr-remote/config.env"
+printf 'HERDR_RELAY_TOKEN=tok\n' > "$HR_TMP/home/.config/herdr-remote/secrets.env"
+printf '#!/bin/sh\necho Linux\n' > "$HR_TMP/bin/uname"
+printf '#!/bin/sh\nexit 1\n' > "$HR_TMP/bin/lsof"
+printf '#!/bin/sh\nexit 1\n' > "$HR_TMP/bin/pgrep"
+cat > "$HR_TMP/bin/systemctl" <<'HRSYSTEMCTL'
+#!/bin/sh
+# enabled, but not running: what a successful `stop` leaves behind
+for a in "$@"; do
+  case "$a" in
+    is-active)  exit 3 ;;
+    is-enabled) exit 0 ;;
+  esac
+done
+case " $* " in
+  *" show "*) echo "ActiveState=inactive" ;;
+esac
+exit 0
+HRSYSTEMCTL
+chmod +x "$HR_TMP/bin/uname" "$HR_TMP/bin/lsof" "$HR_TMP/bin/pgrep" "$HR_TMP/bin/systemctl"
+PATH="$HR_TMP/bin:$PATH" HOME="$HR_TMP/home" HERDR_REMOTE_REPO="$DIR" \
+    "$DIR/relay/herdr-remote" stop > "$HR_TMP/stop.log" 2>&1
+assert_eq "$?" "0" "stop confirms shutdown instead of claiming a restart is pending"
+rm -rf "$HR_TMP"
+
+# --- Repository policy gates ---
+# These are POLICY gates, not behavior tests. They assert a property of the
+# repository's contents itself, which is the thing being guaranteed - not a
+# proxy for any code working.
+echo ""
+echo "=== Repository policy ==="
+echo "22. POLICY: no credential material committed anywhere in the repository"
+# Scans every git-tracked file, not just the AWS tunnel directory and not
+# just the diff: the requirement is repo-wide, and a full scan gives the
+# same answer regardless of branch, rebase, or staging state.
+SECRET_RE='(AKIA|ASIA)[0-9A-Z]{16}'
+SECRET_RE="$SECRET_RE"'|aws_secret_access_key[[:space:]]*=[[:space:]]*[A-Za-z0-9/+=]{40}'
+SECRET_RE="$SECRET_RE"'|-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----'
+if command -v git >/dev/null 2>&1 && git -C "$DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  SECRET_HITS=$(git -C "$DIR" grep -lIE "$SECRET_RE" -- . 2>/dev/null)
+  if [ -n "$SECRET_HITS" ]; then
+    echo "  credential material found in:"
+    echo "$SECRET_HITS" | sed 's/^/    /'
+  fi
+  [ -z "$SECRET_HITS" ]
+  assert_eq "$?" "0" "no AWS keys or private keys are committed"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: cannot run the secret-hygiene gate outside a git checkout"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

The captain's home IP rotated today and broke the AWS reverse tunnel silently: `herdr-remote status` reported relay and tunnel both running, but the URL was "NOT reachable - stale, or the tunnel dropped", and its own advice (`herdr-remote stop && herdr-remote start`) could not fix it because the local side was never the problem. The real cause: the security group's port-22 ingress only allowed the old home IP, so the reverse ssh/autossh could never connect (443 answered 502 from Caddy with nothing behind it; 22 timed out).

- `relay/aws-fw-heal.sh` (new): discovers the tunnel's EC2 instance by its CloudFormation tags (`project=herdr-remote`, `Name=herdr-remote-tunnel`) - never a hard-coded instance/security-group id - compares the current public IP against the group's SSH ingress, and reports/adds accordingly. Two modes: `check` (read-only, prints a `RESULT=...` line for a caller to parse) and `heal` (same, and adds the current IP as a `/32` if missing). **Add-only**: never revokes or replaces an existing rule.
- `relay/herdr-remote start` (aws mode only) runs the heal on every invocation, including when already running - that's exactly the case a stale rule breaks, since the processes still look up. Silent on the no-op case; prints the address and rule id when it adds one; prints "could not verify" and continues starting on any degraded path (no aws CLI, no credentials, ambiguous tag match, etc.) rather than failing the whole command or claiming success it hasn't earned.
- `relay/herdr-remote status` runs the same check read-only when the URL isn't reachable, and names the firewall mismatch as the cause (with the actual fix) instead of recommending a restart that cannot help.
- Docs: `infra/aws-tunnel/README.md` and `relay/.env.example` document the new behavior and the optional `HERDR_AWS_PROFILE`/`HERDR_AWS_REGION` overrides; `AGENTS.md` notes the tag-based discovery convention for future AWS-tunnel work.

## Testing

Ran `bash -n` and `shellcheck` on both scripts. Validated `aws-fw-heal.sh` against the real, currently-live `herdr-remote-tunnel` stack (`sg-0de0c427fbfbb7fae`) without touching its live rules:
- `check`/`heal` no-op path (current IP already covered) - confirmed correct output and silence.
- Discovery by tag against the real instance - confirmed it resolves to the one instance/security group described in the ticket.
- Degraded paths - bad AWS profile, wrong region (no matching instance), `aws` not on `PATH` - each reported an honest "could not verify" reason and exited non-zero, never a false "fine".
- The actual `authorize-security-group-ingress` add path - tested against a scratch security group created and deleted for this purpose (not the live one), confirming the JSON syntax and rule-id extraction work.
- Ran the real `relay/herdr-remote start` and `status` (from this worktree, against the live config) - self-heal ran as a silent no-op ahead of "Already running", and status's new firewall diagnosis branches (ok / absent / could-not-verify) were exercised with the `absent`/error cases mocked, since the live tunnel is currently healthy and I did not want to disturb it to force a real absent case.

Not exercised: an actual "add" against the real security group (would have modified the captain's live, working infrastructure - out of scope and against the ticket's explicit instruction not to touch it), and the AWS-credential-based fallback with no `HERDR_AWS_PROFILE` set (the account's default AWS CLI profile has no credentials at all here, so that path degrades honestly by construction, but the "add with the *implicit* default profile" path specifically wasn't separately exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiQvLuUKpxEUpCYqZ5RCEM