### PR TITLE
fix(web): keep a sideways scroll across the 2s rebuild

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,19 @@ the tab would leave nowhere to go and start an agent in it. A pane whose tab `ta
 caught up with — the poll race right after a create — lands in a trailing `…` group rather than
 vanishing.
 
+**The Spaces and Tabs strips keep their sideways scroll across a snapshot.** They live inside
+`#agents`, which `render()` rewrites with `innerHTML` on every `agents` message — every two seconds
+— and that throws away the very elements holding the offset, so a space you had scrolled the strip
+to reach walked back off the screen under your thumb. `render()` now saves and restores it around
+the write (`chipStripScroll` / `restoreChipStripScroll`), keyed by **what the strip is**
+(`data-strip="spaces"|"tabs"`) rather than by its position in the list: the herd draws one strip and
+the space view draws two, and picking a space is exactly the moment you have just scrolled the
+Spaces row. The value is assigned rather than clamped by hand, so a strip that lost chips since the
+last snapshot lands at its own new end. It is the same bug the sibling row has, and
+`tests/test_web_spaces.py`'s `WebStripScrollTests` measures all three rows together — five of its
+six tests fail on the code this replaced, and the sixth is the guard that stops the fix from
+switching the sibling row's anchor off altogether.
+
 **What a row is called is two questions, so two functions and an explicit scope** (`paneParts` /
 `paneTitleInTab`), not one function guessing from whatever heading happens to be above it:
 
@@ -436,11 +449,23 @@ is at most three chips beside a row that is at most five. Sharing one row is **3
 takes the overflow, the padding, the border and `overscroll-behavior` (`.term-content`'s reason — at
 either end of a sideways drag the chain reaches the document and the browser reads it as the gesture
 that unloads the app), while the two groups inside it are plain flex boxes keeping their own ids and
-their own `aria-label`s. **A rebuilt strip loses its scroll position** — `replaceChildren` empties
-it, and an empty box has nothing to scroll — so `scrollSibsToOpenPane` puts the *pane* chip back on
-screen afterwards, never the tab chip, which is leftmost and never the one that went missing. It
-runs **after** the view is displayed: `renderSiblings` fires while the view is still `display:none`,
-where every rect is zero and no chip can be found to be off screen. The row sits in **normal flow**
+their own `aria-label`s. **A sideways scroll is the reader's, and it survives a rebuild they did not
+ask for.** The row is rebuilt from every `agents` snapshot — that is how a terminal appearing beside
+the open pane shows up without a reopen — and a rebuild costs it its position: `replaceChildren`
+empties both groups, the row's `scrollWidth` collapses with them, and the browser answers by clamping
+`scrollLeft` to 0. `scrollSibsToOpenPane` then pulled the open chip back into view from there, so a
+reader scrolling the row to read the name of a pane at the far end was snapped back to their own pane
+**every two seconds**. `renderSiblings` therefore carries the offset across the rebuild, and the
+auto-scroll is **anchored**: `sibsAnchoredTo` fires it once per pane, dropped only where "new" is
+meant — `openTerminal`'s real-switch branch (which covers entering a session from the list, where
+`activePane` is null) and the row disappearing. A **re-entry clears nothing**, so the `blocked` event
+that re-enters `openTerminal` for the pane already in front of you cannot drag the row back at the
+one moment you are most likely to be reading it. It is the *pane* chip that is anchored, never the
+tab chip, which is leftmost and never the one that went missing; and the placing call runs **after**
+the view is displayed, because `renderSiblings` fires while the view is still `display:none`, where
+every rect is zero, no chip can be found to be off screen and `scrollLeft` cannot be written either
+— which is why a row with no box is left unanchored rather than counted as placed. The row sits in
+**normal flow**
 under the header, which is why the absolutely-positioned history panel covers it exactly as it
 already covered the output and `positionHistoryPanel` is untouched. The search bar is in that same
 flow *after* it, so opening search pushes the output down rather than hiding it.

--- a/tests/test_web_spaces.py
+++ b/tests/test_web_spaces.py
@@ -952,5 +952,163 @@ class WebSessionNavTests(unittest.TestCase):
             self.assertTrue(covered, f"{sel} was reachable through the history panel")
 
 
+@unittest.skipIf(sync_playwright is None, "playwright is not installed")
+@unittest.skipIf(_chrome() is None, "no chromium build available")
+class WebStripScrollTests(unittest.TestCase):
+    """A sideways scroll is the reader's, and it survives a rebuild they did not ask for.
+
+    Three rows on this page scroll sideways and are rebuilt from every `agents` snapshot -- the
+    Spaces strip, the Tabs strip and the session's sibling row. `innerHTML` / `replaceChildren`
+    throw away the elements holding the offset (or collapse the scrollWidth under them, which the
+    browser answers by clamping scrollLeft to 0), so all three snapped back to the beginning every
+    two seconds: the space you had scrolled across the strip to reach walked back off the screen
+    under your thumb, and the sibling row then pulled the OPEN pane back into view on top of that.
+
+    Reached through `handleMessage`, not `render()`, because a snapshot is how it happens in the
+    field and the two are only the same until something between them changes.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.page = _shared["browser"].new_page(viewport=PHONE)
+        cls.page.goto(PAGE)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.page.close()
+
+    def setUp(self):
+        self.page.evaluate("""s => {
+          activeWorkspace = null; activeTab = null; activePane = null;
+          hideTerminal();
+          handleMessage(s);
+          window.__snap = s;
+        }""", SNAPSHOT)
+
+    # A strip has to OVERFLOW before it can prove anything, so every test says so first.
+    def scroll_to_end(self, sel):
+        moved = self.page.eval_on_selector(sel, """e => {
+          if (e.scrollWidth <= e.clientWidth + 1) return null;
+          e.scrollLeft = e.scrollWidth;          // the browser clamps it to this row's own end
+          return Math.round(e.scrollLeft);
+        }""")
+        self.assertTrue(moved, f"{sel} did not overflow, so nothing would be proved")
+        return moved
+
+    def scroll_left(self, sel):
+        return self.page.eval_on_selector(sel, "e => Math.round(e.scrollLeft)")
+
+    def snapshot(self):
+        """The 2s tick, as it arrives in the field."""
+        self.page.evaluate("() => handleMessage(window.__snap)")
+
+    def widen_spaces(self):
+        """Four more spaces, each with an agent in it: the strip is only up when the panes span more
+        than one space, and four chips fit across a phone."""
+        self.page.evaluate("""s => {
+          const snap = JSON.parse(JSON.stringify(s));
+          ['payments-gateway', 'search-indexer', 'notifications', 'infra-terraform']
+            .forEach((label, i) => {
+              const id = 'wX' + i;
+              snap.spaces.workspaces.push({workspace_id: id, label, number: 90 + i, focused: false,
+                                           tab_count: 1, pane_count: 1, host: 'local'});
+              snap.spaces.tabs.push({tab_id: id + ':t1', workspace_id: id, label: '1', number: 1,
+                                     focused: false, pane_count: 1, host: 'local'});
+              snap.agents.push({...s.agents[0], pane_id: id + ':pH',
+                                workspace_id: id, tab_id: id + ':t1'});
+            });
+          window.__snap = snap;
+          handleMessage(snap);
+        }""", SNAPSHOT)
+
+    # ------------------------------------------------------------- the herd list
+
+    def test_the_spaces_strip_keeps_its_place_across_a_snapshot(self):
+        self.widen_spaces()
+        moved = self.scroll_to_end('#agents [data-strip="spaces"]')
+        self.snapshot()
+        self.assertEqual(self.scroll_left('#agents [data-strip="spaces"]'), moved,
+                         "the Spaces strip walked back to the beginning on its own")
+
+    def test_the_spaces_strip_keeps_its_place_when_the_space_view_redraws_it(self):
+        """Picking a space is exactly when you have just scrolled the strip, and the space view
+        draws its own copy -- so the offset is kept by WHAT the strip is, not by where it sits."""
+        self.widen_spaces()
+        moved = self.scroll_to_end('#agents [data-strip="spaces"]')
+        self.page.evaluate("selectWorkspace('local|wX3')")
+        self.assertEqual(self.scroll_left('#agents [data-strip="spaces"]'), moved)
+
+    def test_the_tabs_strip_keeps_its_place_across_a_snapshot(self):
+        self.page.evaluate("""s => {
+          const snap = JSON.parse(JSON.stringify(s));
+          for (let i = 0; i < 8; i++) {
+            snap.spaces.tabs.push({tab_id: 'wA:tX' + i, workspace_id: 'wA', label: 'deploy-' + i,
+                                   number: 10 + i, focused: false, pane_count: 1, host: 'local'});
+          }
+          window.__snap = snap;
+          handleMessage(snap);
+          selectWorkspace('local|wA');
+        }""", SNAPSHOT)
+        moved = self.scroll_to_end('#agents [data-strip="tabs"]')
+        self.snapshot()
+        self.assertEqual(self.scroll_left('#agents [data-strip="tabs"]'), moved,
+                         "the Tabs strip walked back to the beginning on its own")
+
+    # --------------------------------------------------------- the session view
+
+    def crowd_the_tab(self, pane="wA:pH"):
+        """Enough panes beside the open one that the shared row overflows a phone -- and all of them
+        AFTER it, since the whole question is what happens to an offset that has the open chip off
+        screen. The strip sorts by pane_id, so `q*` puts every new chip past `pH`."""
+        self.page.evaluate("""p => {
+          const snap = JSON.parse(JSON.stringify(window.__snap));
+          snap.panes.push(...['q4', 'q5', 'q6', 'q7'].map(id => ({
+            ...snap.panes[0], pane_id: 'wA:' + id, label: 'a-longer-shell-name-' + id,
+            workspace_id: 'wA', tab_id: 'wA:t1'})));
+          window.__snap = snap;
+          handleMessage(snap);
+          openTerminal(p);
+        }""", pane)
+
+    def open_chip_is_on_screen(self):
+        return self.page.evaluate("""() => {
+          const row = document.getElementById('termSibs');
+          const chip = row.querySelector('#termSiblings [aria-current="true"]');
+          const c = chip.getBoundingClientRect(), b = row.getBoundingClientRect();
+          return c.left >= b.left - 1 && c.right <= b.right + 1;
+        }""")
+
+    def test_the_sibling_row_keeps_its_place_across_a_snapshot(self):
+        """The reported bug: the row is rebuilt from every snapshot, so a reader scrolling it to
+        read the name of a pane at the far end was snapped back to their own pane every two
+        seconds -- first by the clamp, then by scrollSibsToOpenPane on top of it."""
+        self.crowd_the_tab()
+        moved = self.scroll_to_end("#termSibs")
+        self.assertFalse(self.open_chip_is_on_screen(),
+                         "the open chip is still in view, so nothing would pull the row back")
+        self.snapshot()
+        self.assertEqual(self.scroll_left("#termSibs"), moved,
+                         "the sibling row was dragged back to the open pane")
+
+    def test_a_blocked_event_for_the_open_pane_does_not_drag_the_row_back(self):
+        """`blocked` re-enters openTerminal for the pane already in front of you. A question
+        arriving is the moment you are most likely to be reading the row, not the moment to move
+        it."""
+        self.crowd_the_tab()
+        moved = self.scroll_to_end("#termSibs")
+        self.page.evaluate("""() => handleMessage({type: 'blocked', pane_id: 'wA:pH',
+          agent: 'claude', project: 'api', prompt: 'ok?', options: ['Yes', 'No'], update: true})""")
+        self.assertEqual(self.scroll_left("#termSibs"), moved)
+
+    def test_a_real_switch_still_puts_the_pane_you_moved_to_on_the_screen(self):
+        """The guard must not become a way of switching the anchor off: entering a session, and
+        moving to a pane at the other end of the row, are the two moments it MAY move."""
+        self.crowd_the_tab()
+        self.scroll_to_end("#termSibs")
+        self.page.evaluate("openTerminal('wA:p2')")   # the first chip, off screen at that end
+        self.assertTrue(self.open_chip_is_on_screen(),
+                        "the pane you switched to was left off screen")
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/web/js/cards.js
+++ b/web/js/cards.js
@@ -140,19 +140,53 @@ function shellCard(p, scope) {
 // differ by one character and say nothing about what is inside them, with no mark for the pane you
 // were actually in and no way to reach a tab by name. Now it is herdr's own two levels: the tabs of
 // this space, then the panes of this tab, each named by what the pane can still say for itself.
+//
+// This row is rebuilt from EVERY `agents` snapshot -- that is how a terminal appearing beside the
+// open pane shows up without a reopen -- and a rebuild costs it its scroll position: `replaceChildren`
+// empties both groups, the row's scrollWidth collapses with them, and the browser clamps scrollLeft
+// to 0. Then `scrollSibsToOpenPane` pulled the open chip back into view from there. So a reader who
+// scrolled the row sideways to read the name of a pane at the far end was snapped back to their own
+// pane every two seconds, which reads as a row that refuses to be moved.
+//
+// The offset is the reader's, so it survives a rebuild they did not ask for, and the auto-scroll
+// fires only when the row is NEW to this pane. `sibsAnchoredTo` is what tells that apart from a
+// refresh, and it is dropped in the two places that mean "new": openTerminal's real-switch branch
+// (which covers entering a session from the list, since activePane is null there) and the row
+// disappearing entirely. A re-entry -- openTerminal on the pane already in front of you, which
+// every `blocked` event does -- clears nothing, so a question arriving cannot drag the row back.
+let sibsAnchoredTo = null;
+
 function renderSiblings() {
   const me = paneById(activePane);
   // No workspace id means this relay reports no hierarchy at all, and every pane would look like a
   // sibling of every other one. Nothing is better than a wrong neighbourhood.
   const wsKey = me && me.workspace_id ? agentWorkspaceKey(me) : null;
+  const row = document.getElementById('termSibs');
+  // Read BEFORE the rebuild: the two groups are about to be emptied, and the number is gone with
+  // them. 0 while the session view is still display:none, where the assignment below is a no-op
+  // and openTerminal's own call is what places the row.
+  const kept = row ? row.scrollLeft : 0;
   const tabs = renderTabStrip(me, wsKey);
   const panes = renderPaneStrip(me, wsKey);
   // The separator is the boundary between the two levels, so it exists only when both are there --
   // a rule that hangs off what the two strips actually rendered rather than off a second count.
   const sep = document.getElementById('termSibSep');
   if (sep) sep.style.display = tabs && panes ? 'block' : 'none';
-  const row = document.getElementById('termSibs');
   if (row) row.style.display = tabs || panes ? 'flex' : 'none';
+  if (!(tabs || panes)) { sibsAnchoredTo = null; return; }
+  if (!row) return;
+  row.scrollLeft = kept;
+  anchorSibsToOpenPane();
+}
+
+// Places the row on the open pane, ONCE per pane. `sibsAnchoredTo` is what tells entering a session
+// apart from the refresh that follows it every two seconds -- the first is allowed to move the row,
+// the second is the reader's own scroll and is not. A row with no box cannot be measured, so it is
+// left unanchored for the next caller that has one (openTerminal, after the view is displayed).
+function anchorSibsToOpenPane() {
+  const row = document.getElementById('termSibs');
+  if (!row || !row.clientWidth || sibsAnchoredTo === activePane) return;
+  sibsAnchoredTo = activePane;
   scrollSibsToOpenPane();
 }
 
@@ -339,6 +373,9 @@ function openTerminal(paneId) {
   if (activePane !== paneId) {
     hideHistory(); hideSearch(); clearPaneMirror();
     paneLines = PANE_LINES_BASE; paneFollowing = true; userScrolledUp = false;
+    // A real switch is one of the two moments the sibling row may place itself; dropping the anchor
+    // here is what asks for it, and what keeps a re-entry from asking again.
+    sibsAnchoredTo = null;
   }
   activePane = paneId;
   const a = agents.find(x => x.pane_id===paneId);
@@ -357,10 +394,11 @@ function openTerminal(paneId) {
   if (refreshInterval) clearInterval(refreshInterval);
   document.getElementById('terminalView').classList.add('active');
   // AFTER the view is displayed: renderSiblings ran while it was still display:none, where every
-  // rect is zero and no chip can be found to be off screen. A rebuilt strip loses its scroll
-  // position anyway (replaceChildren empties it, and an empty box has nothing to scroll), so this
-  // is a restore rather than a jump -- it does not fight a reader who scrolled the row by hand.
-  scrollSibsToOpenPane();
+  // rect is zero, no chip can be found to be off screen, and scrollLeft cannot be written either --
+  // so it deliberately left the row unanchored for this call to place. Guarded the same way, since
+  // openTerminal is re-entered on every `blocked` event for the pane already in front of you and a
+  // question arriving must not drag the row back under the reader's thumb.
+  anchorSibsToOpenPane();
   navPush('terminal', hideTerminal);
   const qa = document.getElementById('quickActions');
   const ak = document.getElementById('actionKeys');

--- a/web/js/spaces.js
+++ b/web/js/spaces.js
@@ -72,8 +72,38 @@ function render() {
   // Checked here rather than at the top of render(), so the name maps and the sibling strips still
   // track the truth while the list itself holds still.
   if (selectionInside(list)) return;
+  const strips = chipStripScroll(list);
   list.innerHTML = activeWorkspace ? renderSpaceView(rows) : renderHerd(rows, occupied);
+  restoreChipStripScroll(list, strips);
   bindLongPressHandlers();
+}
+
+// A rebuild is not a gesture, and this list rebuilds on every `agents` snapshot -- every two
+// seconds, forever. The chip strips scroll SIDEWAYS (ten spaces do not fit across a phone), and
+// `innerHTML` throws away the very elements that hold the offset, so a reader who had scrolled the
+// Spaces row to reach the space at the far end watched it snap back to the beginning mid-reach.
+// That is the reported bug, and it is the same one the sibling row has (see renderSiblings): the
+// offset is the reader's, so it survives a rebuild it did not ask for.
+//
+// Keyed by WHAT the strip is (`data-strip`), not by its position in the list: the herd draws one
+// strip and the space view draws two, and the Spaces row has to keep its place across that switch
+// as well -- picking a space is exactly when you have just scrolled it.
+function chipStripScroll(list) {
+  const kept = new Map();
+  for (const strip of list.querySelectorAll('.chip-strip')) {
+    if (strip.scrollLeft) kept.set(strip.dataset.strip, strip.scrollLeft);
+  }
+  return kept;
+}
+
+function restoreChipStripScroll(list, kept) {
+  if (!kept.size) return;
+  for (const strip of list.querySelectorAll('.chip-strip')) {
+    const x = kept.get(strip.dataset.strip);
+    // Assigned, not clamped by hand: a strip that lost chips since the last snapshot is put at its
+    // own new end by the browser rather than left pointing past it.
+    if (x) strip.scrollLeft = x;
+  }
 }
 
 // The herd, in the one order the app agrees on. AGENTS only: two thirds of the panes on a real host
@@ -168,7 +198,7 @@ function groupPanesByTab(workspaceKey) {
 }
 
 function spaceStrip(rows) {
-  let html = `<div class="chip-strip"><span class="chip-label">Spaces</span>`;
+  let html = `<div class="chip-strip" data-strip="spaces"><span class="chip-label">Spaces</span>`;
   html += `<button class="chip${activeWorkspace === null ? ' active' : ''}" onclick="backToWorkspaces()">All</button>`;
   for (const w of rows) {
     const held = [...agents, ...shellPanes].filter(p => agentWorkspaceKey(p) === w.key);
@@ -189,7 +219,7 @@ function spaceStrip(rows) {
 
 function tabStrip(rows) {
   const wsTabs = tabRows(activeWorkspace);
-  let html = `<div class="chip-strip"><span class="chip-label">Tabs</span>`;
+  let html = `<div class="chip-strip" data-strip="tabs"><span class="chip-label">Tabs</span>`;
   if (wsTabs.length > 1) {
     html += `<button class="chip${!activeTab ? ' active' : ''}" onclick="selectTab(null)">All</button>`;
   }


### PR DESCRIPTION
Closes #57.

## The bug

Three rows scroll sideways and are rebuilt from every `agents` snapshot: the Spaces strip, the Tabs
strip and the session's sibling row. The rebuild throws away the elements holding the offset —
`innerHTML` in `render()`, `replaceChildren` in `renderSiblings()`, which collapses the row's
`scrollWidth` so the browser clamps `scrollLeft` to 0 — so a space you had scrolled across the strip
to reach walked back off the screen under your thumb every two seconds.

The sibling row was worse: `scrollSibsToOpenPane` then pulled the **open** pane back into view from
0, so the row read as refusing to be moved.

## The fix

- `render()` saves and restores the chip strips around the write, keyed by `data-strip` rather than
  by position — the herd draws one strip and the space view draws two, and picking a space is exactly
  when you have just scrolled the Spaces row. The value is assigned rather than clamped by hand, so a
  strip that lost chips since the last snapshot lands at its own new end.
- `renderSiblings()` carries its offset across the rebuild, and the auto-scroll becomes **anchored**:
  `sibsAnchoredTo` fires it once per pane, dropped only in the two places that mean "new" — a real
  switch (which covers entering a session, where `activePane` is null) and the row disappearing. A
  re-entry clears nothing, so the `blocked` event that re-enters `openTerminal` cannot drag the row
  back at the one moment you are most likely to be reading it.

## Tests

`WebStripScrollTests` in `tests/test_web_spaces.py` measures all three rows in a browser. **Five of
its six tests fail on the code this replaces**, and the sixth is the guard that stops the anchor from
being switched off altogether (a real switch must still place the pane you moved to).

`sh tests/run.sh` at this branch's tip: **23 passed, 0 failed** (215 browser tests).
