### PR TITLE
fix(web): one row of every pane in the space, grouped by tab, in herdr's own order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,19 @@ the tab would leave nowhere to go and start an agent in it. A pane whose tab `ta
 caught up with — the poll race right after a create — lands in a trailing `…` group rather than
 vanishing.
 
+**The Spaces and Tabs strips keep their sideways scroll across a snapshot.** They live inside
+`#agents`, which `render()` rewrites with `innerHTML` on every `agents` message — every two seconds
+— and that throws away the very elements holding the offset, so a space you had scrolled the strip
+to reach walked back off the screen under your thumb. `render()` now saves and restores it around
+the write (`chipStripScroll` / `restoreChipStripScroll`), keyed by **what the strip is**
+(`data-strip="spaces"|"tabs"`) rather than by its position in the list: the herd draws one strip and
+the space view draws two, and picking a space is exactly the moment you have just scrolled the
+Spaces row. The value is assigned rather than clamped by hand, so a strip that lost chips since the
+last snapshot lands at its own new end. It is the same bug the sibling row has, and
+`tests/test_web_spaces.py`'s `WebStripScrollTests` measures all three rows together — five of its
+six tests fail on the code this replaced, and the sixth is the guard that stops the fix from
+switching the sibling row's anchor off altogether.
+
 **What a row is called is two questions, so two functions and an explicit scope** (`paneParts` /
 `paneTitleInTab`), not one function guessing from whatever heading happens to be above it:
 
@@ -436,11 +449,23 @@ is at most three chips beside a row that is at most five. Sharing one row is **3
 takes the overflow, the padding, the border and `overscroll-behavior` (`.term-content`'s reason — at
 either end of a sideways drag the chain reaches the document and the browser reads it as the gesture
 that unloads the app), while the two groups inside it are plain flex boxes keeping their own ids and
-their own `aria-label`s. **A rebuilt strip loses its scroll position** — `replaceChildren` empties
-it, and an empty box has nothing to scroll — so `scrollSibsToOpenPane` puts the *pane* chip back on
-screen afterwards, never the tab chip, which is leftmost and never the one that went missing. It
-runs **after** the view is displayed: `renderSiblings` fires while the view is still `display:none`,
-where every rect is zero and no chip can be found to be off screen. The row sits in **normal flow**
+their own `aria-label`s. **A sideways scroll is the reader's, and it survives a rebuild they did not
+ask for.** The row is rebuilt from every `agents` snapshot — that is how a terminal appearing beside
+the open pane shows up without a reopen — and a rebuild costs it its position: `replaceChildren`
+empties both groups, the row's `scrollWidth` collapses with them, and the browser answers by clamping
+`scrollLeft` to 0. `scrollSibsToOpenPane` then pulled the open chip back into view from there, so a
+reader scrolling the row to read the name of a pane at the far end was snapped back to their own pane
+**every two seconds**. `renderSiblings` therefore carries the offset across the rebuild, and the
+auto-scroll is **anchored**: `sibsAnchoredTo` fires it once per pane, dropped only where "new" is
+meant — `openTerminal`'s real-switch branch (which covers entering a session from the list, where
+`activePane` is null) and the row disappearing. A **re-entry clears nothing**, so the `blocked` event
+that re-enters `openTerminal` for the pane already in front of you cannot drag the row back at the
+one moment you are most likely to be reading it. It is the *pane* chip that is anchored, never the
+tab chip, which is leftmost and never the one that went missing; and the placing call runs **after**
+the view is displayed, because `renderSiblings` fires while the view is still `display:none`, where
+every rect is zero, no chip can be found to be off screen and `scrollLeft` cannot be written either
+— which is why a row with no box is left unanchored rather than counted as placed. The row sits in
+**normal flow**
 under the header, which is why the absolutely-positioned history panel covers it exactly as it
 already covered the output and `positionHistoryPanel` is untouched. The search bar is in that same
 flow *after* it, so opening search pushes the output down rather than hiding it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,8 +381,12 @@ about what a colour means.
   each section keeps the order the relay already sent and `Ready` is simply empty. No feature
   detection, no branch — which is what keeps an older relay, and `demo-worker`, working untouched.
 
-**Picking a space groups its panes by tab** (`groupPanesByTab`) — agents *and* bare shells, because
-that is the one view where "what is in this tab" is the question being asked. **Empty tabs render**
+**Picking a space groups its panes by tab** (`groupPanesByTab`) — agents *and* bare shells, in
+herdr's own order inside each tab, because that is the one view where "what is in this tab" is the
+question being asked and a tab is a thing with a shape. It goes through `panesInSpace` for that
+order (see the session view below); merging the relay's two arrays here, which is what it did, put
+every agent ahead of every terminal, so a terminal split *between* two agents was drawn last.
+**Empty tabs render**
 (`(empty tab)`): a freshly created tab holds a shell the relay may not have listed yet, and hiding
 the tab would leave nowhere to go and start an agent in it. A pane whose tab `tab list` has not
 caught up with — the poll race right after a create — lands in a trailing `…` group rather than
@@ -397,9 +401,8 @@ the write (`chipStripScroll` / `restoreChipStripScroll`), keyed by **what the st
 the space view draws two, and picking a space is exactly the moment you have just scrolled the
 Spaces row. The value is assigned rather than clamped by hand, so a strip that lost chips since the
 last snapshot lands at its own new end. It is the same bug the sibling row has, and
-`tests/test_web_spaces.py`'s `WebStripScrollTests` measures all three rows together — five of its
-six tests fail on the code this replaced, and the sixth is the guard that stops the fix from
-switching the sibling row's anchor off altogether.
+`tests/test_web_spaces.py`'s `WebStripScrollTests` measures all three rows together, with the guard
+that stops the fix from switching the sibling row's anchor off altogether beside them.
 
 **What a row is called is two questions, so two functions and an explicit scope** (`paneParts` /
 `paneTitleInTab`), not one function guessing from whatever heading happens to be above it:
@@ -432,43 +435,88 @@ switching the sibling row's anchor off altogether.
   the tab's **position** in its space while the number is a separate counter; comparing the two
   called that a rename and rendered a heading reading `2` beside one reading `Tab 1`.
 
-**The session view carries herdr's own two levels below the space, in one row** (`renderSiblings` →
-`renderTabStrip` / `renderPaneStrip`, ported from Collie's `TabStrip` + `PaneStrip`): the tabs of
-this space, then a 1px rule, then the panes of this tab. The space above them is the level left to
-the herd list, which is a tap on Back. Both groups are DOM nodes, both are rebuilt from every
-`agents` snapshot — so a terminal appearing beside the open pane shows up without a reopen — and
-each is **hidden on its own when it holds no choice**: the tabs unless the space has two *reachable*
-tabs (6 of the 10 agent panes measured sit in a single-tab space), the panes unless the tab holds a
-second pane (10 of 10 do, so that is the group which always shows). When neither has anything to say
-the row goes, border and all — nothing at all when `HERDR_SHELL_PANES` is off and each tab holds one
-agent, which is the same "renders exactly as before" guarantee the list has.
+**The session view says the two levels below the space in ONE list** (`renderSiblings` →
+`renderSibStrip` / `sibGroup`, where Collie's `TabStrip` + `PaneStrip` used to be ported side by
+side): every pane in this space, in herdr's order, grouped by tab, each group led by its tab's name
+and separated from the next by a 1px rule — read left to right the way a multiplexer's own status
+line is. The space above them is the level left to the herd list, which is a tap on Back. The row is
+DOM nodes, rebuilt from every `agents` snapshot — so a terminal appearing beside the open pane shows
+up without a reopen. The **names are absent in a single-tab space** (6 of the 10 agent panes measured
+sit in one, and each would have paid a chip to be told the name of the only tab there is), and the
+**row itself goes, border and all, when the space holds one pane** — there is nothing to switch to,
+and it would cost the output 33px to say so. A tab whose panes this client cannot name draws no
+group, which is also what keeps the row honest with `HERDR_SHELL_PANES` off, where it becomes the
+tabs that hold agents.
 
-They were **two rows of 33px**, and 4 of the 10 agent panes measured paid for both — for a row that
-is at most three chips beside a row that is at most five. Sharing one row is **33px back, 3.9% of a
-390×844 screen**, and it costs a horizontal scroll the two separate rows did not need: the outer row
-takes the overflow, the padding, the border and `overscroll-behavior` (`.term-content`'s reason — at
-either end of a sideways drag the chain reaches the document and the browser reads it as the gesture
-that unloads the app), while the two groups inside it are plain flex boxes keeping their own ids and
-their own `aria-label`s. **A sideways scroll is the reader's, and it survives a rebuild they did not
-ask for.** The row is rebuilt from every `agents` snapshot — that is how a terminal appearing beside
-the open pane shows up without a reopen — and a rebuild costs it its position: `replaceChildren`
-empties both groups, the row's `scrollWidth` collapses with them, and the browser answers by clamping
-`scrollLeft` to 0. `scrollSibsToOpenPane` then pulled the open chip back into view from there, so a
-reader scrolling the row to read the name of a pane at the far end was snapped back to their own pane
-**every two seconds**. `renderSiblings` therefore carries the offset across the rebuild, and the
-auto-scroll is **anchored**: `sibsAnchoredTo` fires it once per pane, dropped only where "new" is
-meant — `openTerminal`'s real-switch branch (which covers entering a session from the list, where
+**Every pane in the space is one tap, and no chip is rationed.** What this replaced went through
+three shapes. Two rows of 33px, and 4 of the 10 agent panes measured paid for both — for a row that
+is at most three chips beside a row that is at most five. Then one row of **two scrollers**, which
+bought back 33px (3.9% of a 390×844 screen) and turned it into a **width fight**: 2 tabs measure
+135px of a 370px row and 3 measure 253px, **68%**, against a pane chip that can be 178px on its own
+(a 32vw activity title plus the dot, the id tag and the padding), so a multi-tab space had to ration
+the tabs to 45% and still starved the level the reader came for. One list ends the fight — the widest
+chip can have the whole row — and it also ends the *two taps* it took to reach a pane in another tab
+(a tab chip, then whatever pane `tabLandingPane` decided to land you on). The tab's name is still
+tappable, and still lands on the neediest pane in it, because "take me to what needs me over there"
+is a different question from "take me to that pane".
+
+**The tab's name is `position: sticky` inside its own group, which is what makes one scroller safe.**
+In a shared scroller the pane chips come *after* the tab chips, so the scroll that reveals the open
+pane drove the tab level off the left edge: measured at 390px, opening a pane of `ble-dev` in a 3-tab
+space left `ble-verify` standing alone there — a *sibling* tab dressed as the breadcrumb of the one
+you were in — and in a 2-tab space it left the tail of a pane id and no tab level at all. A name that
+sticks **inside its own group** cannot be the wrong one: a sticky element is held by its containing
+block, so each name is pinned only while its own panes are on screen and the next group pushes it out
+rather than stacking on top of it. Swept across the whole scroll range in a browser, the name at the
+left edge always belongs to the group that owns that edge. Two consequences are load-bearing:
+- **The pinned name is painted over the chips scrolling beneath it,** so it needs an opaque
+  background — and the rule has to be `.term-sib.sib-tab`, because `.term-sib`'s own
+  `background: none` matches at the same specificity and comes later in the file. A see-through
+  pinned chip renders as two names on top of each other. `aria-current`'s fill still wins over both.
+- **The reveal must not place the open pane under it.** `scrollSibsToOpenPane` therefore measures
+  from the **group** box, which never sticks (a stuck name's rect is where it is *painted*, not where
+  it sits in the row), and either fits the name in the flow beside the pane — the common case, since
+  a name leads its own tab's panes rather than following every tab in the space — or places the pane
+  to the right of the name's own width. Measured over all 42 panes on this host: the open pane is
+  fully on screen and its own tab's name is visible in every one.
+
+**Colour is deliberately not the channel for "which tab".** The dot is the triage bucket (red →
+orange → green → grey) and a filled chip is the selection, everywhere on this page; a third scale
+keyed to the tab would collide with both. The name says it, the 1px rule says where a group ends, and
+the squarer corner says a name is not a pane chip — none of which costs a hue or a written heading (a
+`Tabs` / `Panes` heading measured 40px of the row, more than 4 of the 5 rows that scrolled on the
+real host overflowed by).
+
+**A sideways scroll is the reader's, and it survives a rebuild they did not ask for.** The row is
+rebuilt from every `agents` snapshot, and a rebuild costs it its position: `replaceChildren` empties
+it, its `scrollWidth` collapses, and the browser answers by clamping `scrollLeft` to 0. The
+auto-scroll then pulled the open chip back into view from there, so a reader scrolling to read the
+name of a pane at the far end was snapped back to their own pane **every two seconds**.
+`renderSiblings` therefore carries the offset across the rebuild, and the auto-scroll is
+**anchored**: `sibsAnchoredTo` fires it once per pane, dropped only where "new" is meant —
+`openTerminal`'s real-switch branch (which covers entering a session from the list, where
 `activePane` is null) and the row disappearing. A **re-entry clears nothing**, so the `blocked` event
 that re-enters `openTerminal` for the pane already in front of you cannot drag the row back at the
-one moment you are most likely to be reading it. It is the *pane* chip that is anchored, never the
-tab chip, which is leftmost and never the one that went missing; and the placing call runs **after**
-the view is displayed, because `renderSiblings` fires while the view is still `display:none`, where
-every rect is zero, no chip can be found to be off screen and `scrollLeft` cannot be written either
-— which is why a row with no box is left unanchored rather than counted as placed. The row sits in
-**normal flow**
+one moment you are most likely to be reading it. The reveal looks for **`[data-sib-id]`**, not for a
+bare `aria-current`: the tab's name carries that attribute too and is pinned to the left edge, so
+matching it would report every row as already placed. The placing call runs **after** the view is
+displayed, because `renderSiblings` fires while the view is still `display:none`, where every rect is
+zero, no chip can be found to be off screen and `scrollLeft` cannot be written either — which is why
+a row with no box is left unanchored rather than counted as placed. The row sits in **normal flow**
 under the header, which is why the absolutely-positioned history panel covers it exactly as it
 already covered the output and `positionHistoryPanel` is untouched. The search bar is in that same
 flow *after* it, so opening search pushes the output down rather than hiding it.
+
+**The row is in herdr's own order, which is `order` and nothing else** (`paneOrder` →
+`panesInSpace`, which `groupPanesByTab` goes through too, so the space view and the session row
+cannot disagree about two panes of one tab). The relay passes through each pane's index in
+`pane list`, which is the order the panes are laid out on the operator's screen — see the protocol
+section for why neither array position nor the pane id can stand in for it. Sorting the ids, which
+is what this did, put the live `w6:t1` in exactly the wrong order: pH, p15, p12 at the desk against
+p12, p15, pH on the phone. A missing `order` sorts **last, stably**, so an older relay and
+`demo-worker` keep the arrays as they arrived and the one pane that can lack it on a current relay —
+an agent a `blocked` push appended — is back in place on the next snapshot. `tabLandingPane` breaks
+its ties the same way, so a tap on a tab's name lands on the chip a reader would have picked.
 
 **The chrome above the output is measured, and it was 20% of the phone.** 69px of app header, of
 which the session view covered the bottom 20 — its `top` was a hardcoded `49px` against a header
@@ -478,11 +526,12 @@ text metrics for a button with no text in it. Then the two sibling rows. **170px
 single line of a pane had rendered.** It is **116px, 13.7%** now: the app header is a *height*
 (`--header-h`, the one place the number is written, and what `.terminal-view`'s `top` is computed
 from, so the two cannot drift again), the session header pins every child to 28px the way the
-history bar does, and the two levels share a row. `tests/test_web_spaces.py` measures all three
-against the screen rather than reading the CSS.
+history bar does, and the two levels share one row and one list. `tests/test_web_spaces.py` measures
+all three against the screen rather than reading the CSS.
 
-What that replaced was one flat row of the *other* panes in the workspace, tagged `Tab` and `Space`,
-each chip named `label || pane_id`. Three things were wrong with it, and each is now a rule:
+The row this all grew out of was also flat, and that is the shape it has come back to -- but it
+listed the *other* panes in the workspace tagged `Tab` and `Space`, each chip named
+`label || pane_id`. Three things were wrong with it, and each is now a rule:
 
 - **A pane is named by what it can still say for itself** (`paneChipName`, Collie's
   `paneDisplayName`): the operator's label, then — for an agent — the activity `title` it is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,9 +550,22 @@ live activity, not a session name: a working claude sets it to what it is doing,
 The durable title comes back from `get_history`), `status`, `cwd`, `project`, `host`, `remote`,
 `workspace_id`, `tab_id`, `focused` (the one pane per host herdr itself has in front),
 `scrollback` + `viewport_rows` (from herdr's `scroll`), `has_session` (this pane names an agent
-transcript), and `last_active_at` / `last_seen_at` (epoch **milliseconds**, because every client
-that will compare them is JavaScript). The session ref itself stays server-side in
-`pane_session_map`.
+transcript), `order` (see below), and `last_active_at` / `last_seen_at` (epoch **milliseconds**,
+because every client that will compare them is JavaScript). The session ref itself stays
+server-side in `pane_session_map`.
+
+**`order` is the pane's index in its host's own `pane list`, and it is the only thing that says
+where a pane sits on the operator's screen.** herdr answers `pane list` in the order the panes are
+laid out — verified against `pane layout` on every tab of this host, the same split-tree walk, top
+left first — and nothing else in the record implies it. The ids will not do: `pane swap` and
+`pane move` rearrange panes, and the suffix is a creation counter in a base wider than ten, so
+`w6:t1` reads pH, p15, p12 at the desk and sorts to p12, p15, pH. Splitting one `pane list` into
+`agents` + `panes` also throws away the interleaving, which is how a terminal split between two
+agents ends up drawn last. Per host, since a client only ever orders panes within one tab of one
+machine. A relay older than this sends none, and a client must then keep the arrays as they
+arrived rather than invent an order — the web app sorts missing last, stably, which is the same
+thing. An `agent_update` carries no `order` (it is a merge, and the snapshot beside it has one),
+and an agent a `blocked` push appends before its first snapshot has none for one poll.
 
 The same `agents` message carries `spaces` — `{workspaces: [...], tabs: [...]}` from
 `herdr workspace list` and `herdr tab list`. `pane list` gives every pane a `workspace_id` and a
@@ -568,9 +581,11 @@ The same message carries **`panes`** — the panes with no agent in them, which 
 entries because six clients render that array and every one of them assumes its entries are
 agents; a shell pane would show up in all of them as a card with an empty harness name. Each entry
 is `pane_id`, `label`, `cwd`, `project`, `host`, `remote`, `workspace_id`, `tab_id`, `focused`,
-`scrollback`, `viewport_rows` — no `status` (herdr reports `agent_status: "unknown"` for all of
-them), no `title` (there is no such field on a non-agent pane) and no `has_session`. They come out
-of the **same `pane list`** the poll already runs, so listing them costs nothing.
+`scrollback`, `viewport_rows`, `order` — no `status` (herdr reports `agent_status: "unknown"` for
+all of them), no `title` (there is no such field on a non-agent pane) and no `has_session`. They
+come out of the **same `pane list`** the poll already runs, so listing them costs nothing — which
+is also why their `order` is comparable with an agent entry's: the two arrays are one list, indexed
+before it was split.
 
 Two things are true of a shell pane and not of an agent pane:
 

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -839,7 +839,7 @@ def pane_session_ref(pane):
     return session
 
 
-def shell_pane_record(pane, host_label, remote):
+def shell_pane_record(pane, host_label, remote, order=0):
     """The payload for a pane with no agent in it.
 
     Deliberately NOT an `agents` entry. Six clients render that array and every one of them
@@ -868,6 +868,7 @@ def shell_pane_record(pane, host_label, remote):
         # there is a real ring to read instead of a TUI to walk.
         "scrollback": scroll.get("max_offset_from_bottom", 0),
         "viewport_rows": scroll.get("viewport_rows", 0),
+        "order": order,
     }
 
 
@@ -876,6 +877,15 @@ def list_panes_from_host(remote=None):
 
     Split here rather than in two functions because the CLI call is the expensive part -- 12ms
     locally, a full SSH round trip remotely -- and the poll runs it every POLL_INTERVAL.
+
+    The split is also what makes `order` necessary. herdr answers `pane list` in the order the
+    operator sees the panes at the desk -- verified against `pane layout` on every tab of this
+    host, it is the same split-tree walk, top-left first -- and that order is not derivable from
+    anything else in the record: `pane swap` and `pane move` exist, and the pane id's suffix is a
+    creation counter (`w6:pH` was opened before `w6:p12`), so neither the layout nor even the
+    creation order survives sorting the ids as strings. Splitting one list in two throws the
+    interleaving away, so each record keeps its index in the list it came from. Per host, since a
+    client only ever compares panes within one tab of one machine.
     """
     raw = run_herdr("pane", "list", remote=remote)
     host_label = remote or "local"
@@ -887,10 +897,10 @@ def list_panes_from_host(remote=None):
         return [], []
 
     agents, shells = [], []
-    for p in panes:
+    for order, p in enumerate(panes):
         if not p.get("agent"):
             if SHELL_PANES and p.get("pane_id"):
-                shells.append(shell_pane_record(p, host_label, remote))
+                shells.append(shell_pane_record(p, host_label, remote, order))
             continue
         session = pane_session_ref(p)
         if session:
@@ -927,6 +937,9 @@ def list_panes_from_host(remote=None):
             "focused": bool(p.get("focused")),
             "scrollback": scroll.get("max_offset_from_bottom", 0),
             "viewport_rows": scroll.get("viewport_rows", 0),
+            # Where this pane sits in herdr's own `pane list` -- see the docstring. A client that
+            # groups panes by tab has no other way back to the order on screen.
+            "order": order,
             # Whether this pane names a transcript at all -- the client's cue for offering a
             # history view. The ref itself stays in pane_session_map.
             "has_session": session is not None,

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -2706,6 +2706,33 @@ class RelayShellPaneTests(unittest.TestCase):
             for absent in ("agent", "status", "has_session", "title"):
                 self.assertNotIn(absent, first)
 
+    def test_a_pane_keeps_its_place_in_herdrs_own_list(self):
+        """Splitting one `pane list` in two throws away which pane sits where, and nothing else in
+        the record brings it back.
+
+        `pane list` answers in the order the operator sees the panes -- verified against
+        `pane layout` on every tab of this host, the same split-tree walk, top-left first -- and
+        that is not derivable from the ids: `pane swap` and `pane move` rearrange panes, and the id
+        suffix is a creation counter in a base wider than ten, so `w6:t1` reads pH, p15, p12 on
+        screen and sorts to p12, p15, pH. The shell pane in the middle of it is the case the split
+        loses outright, since a client merging the two arrays draws it last.
+        """
+        listing = json.dumps({"result": {"panes": [
+            {"pane_id": "w6:pH", "agent": "claude", "agent_status": "idle", "cwd": "/work/db",
+             "workspace_id": "w6", "tab_id": "w6:t1"},
+            {"pane_id": "w6:p12", "agent_status": "unknown", "cwd": "/work/db",
+             "workspace_id": "w6", "tab_id": "w6:t1"},
+            {"pane_id": "w6:p15", "agent": "claude", "agent_status": "idle", "cwd": "/work/db",
+             "workspace_id": "w6", "tab_id": "w6:t1"},
+        ]}})
+        with loaded_relay(shell_panes="1") as relay:
+            with mock.patch.object(relay, "run_herdr",
+                                   side_effect=lambda *a, remote=None: listing if a[:2] == ("pane", "list") else ""):
+                agents, shells = relay.list_panes_from_host()
+            self.assertEqual([(p["pane_id"], p["order"]) for p in agents],
+                             [("w6:pH", 0), ("w6:p15", 2)])
+            self.assertEqual([(p["pane_id"], p["order"]) for p in shells], [("w6:p12", 1)])
+
     def test_only_one_pane_list_serves_both_kinds(self):
         """The CLI call is the cost -- 12ms locally, an SSH round trip remotely, every poll."""
         with loaded_relay(shell_panes="1") as relay:

--- a/tests/test_web_spaces.py
+++ b/tests/test_web_spaces.py
@@ -86,16 +86,23 @@ def _shell(pane_id, workspace, tab, **extra):
 # tabmate terminal AND one a tab away, a space holding nothing but terminals, an agent in a space
 # `workspace list` never reported, and a space carrying the two halves of `done` -- one finished while
 # you were away and one you have already looked at.
+#
+# `order` is each pane's index in the host's own `pane list`, which the relay passes through because
+# it is the order the panes sit in on the operator's screen and nothing else in the record implies it.
+# Numbered here as one walk of the hierarchy, the way herdr answers: wA's two tabs, then wB, wC, wD,
+# wE. The terminal is to the left of the agent in the two tabs that hold both.
 SNAPSHOT = {
     "type": "agents",
     "agents": [
         # No operator label: its herd title is the SPACE label, not this per-pane `project`.
-        _agent("wA:pH", "wA", "wA:t1", status="working", active=300, seen=300),
+        _agent("wA:pH", "wA", "wA:t1", status="working", active=300, seen=300, order=1),
         _agent("wB:pH", "wB", "wB:t1", status="blocked", project="billing",
-               active=500, seen=0, options=["Yes", "No"]),
-        _agent("wD:pH", "wD", "wD:t1", project="orphan", active=200, seen=900),
-        _agent("wE:pR", "wE", "wE:t1", status="done", project="extras", active=400, seen=100),
-        _agent("wE:pD", "wE", "wE:t1", status="done", project="extras", active=100, seen=800),
+               active=500, seen=0, options=["Yes", "No"], order=4),
+        _agent("wD:pH", "wD", "wD:t1", project="orphan", active=200, seen=900, order=7),
+        _agent("wE:pR", "wE", "wE:t1", status="done", project="extras", active=400, seen=100,
+               order=8),
+        _agent("wE:pD", "wE", "wE:t1", status="done", project="extras", active=100, seen=800,
+               order=9),
     ],
     "spaces": {
         "workspaces": [
@@ -122,13 +129,19 @@ SNAPSHOT = {
         ],
     },
     "panes": [
-        _shell("wA:p2", "wA", "wA:t1"),
-        _shell("wA:p3", "wA", "wA:t2"),
-        _shell("wB:p2", "wB", "wB:t1", project="billing"),
-        _shell("wC:p1", "wC", "wC:t1", project="logs"),
-        _shell("wC:p2", "wC", "wC:t1", project="logs"),
+        _shell("wA:p2", "wA", "wA:t1", order=0),
+        _shell("wA:p3", "wA", "wA:t2", order=2),
+        _shell("wB:p2", "wB", "wB:t1", project="billing", order=3),
+        _shell("wC:p1", "wC", "wC:t1", project="logs", order=5),
+        _shell("wC:p2", "wC", "wC:t1", project="logs", order=6),
     ],
 }
+
+
+# What the order test clones its panes from: one agent record and one shell record with every field
+# the renderers read, so a test can lay out a tab of its own without restating the shapes.
+SEEDS = {"agent": _agent("seed", "wA", "wA:t1", status="working"),
+         "shell": _shell("seed", "wA", "wA:t1")}
 
 
 class _Page:
@@ -336,9 +349,13 @@ class WebSpaceViewTests(unittest.TestCase, _Page):
         return out
 
     def test_a_space_is_grouped_by_tab_with_both_kinds_together(self):
+        """And in herdr's order inside each tab, which is the same order the session strip draws --
+        both go through panesInSpace. Merging the two arrays here, which is what this did, put every
+        agent ahead of every terminal, so wA:p2 was drawn last in a view whose whole claim is that it
+        shows what is in a tab. It is to the LEFT of wA:pH on the operator's screen."""
         self.page.evaluate("selectWorkspace('local|wA')")
         self.assertEqual(self.groups(), [
-            ("Tab 1", ["wA:pH", "wA:p2"]),
+            ("Tab 1", ["wA:p2", "wA:pH"]),
             ("deploy", ["wA:p3"]),
         ])
 
@@ -524,39 +541,88 @@ class WebSessionNavTests(unittest.TestCase):
           ws = {readyState: 1, send: p => window.__sent.push(JSON.parse(p))};
         }""", SNAPSHOT)
 
-    def strip(self, sel):
-        """A strip in order: ('chip', id, name, tag, is-where-you-are)."""
-        return self.page.eval_on_selector_all(f"{sel} .term-sib", """els => els.map(e =>
+    def strip(self, kind=""):
+        """The row in order: ('chip', id, name, tag, is-where-you-are).
+
+        One row and one list, so which chips you mean is a test on the chip rather than on a
+        container of its own: `[data-sib-tab]` is a tab's name, `[data-sib-id]` is a pane.
+        """
+        return self.page.eval_on_selector_all(f"#termSiblings .term-sib{kind}", """els => els.map(e =>
           ['chip', e.dataset.sibId || e.dataset.sibTab, e.children[1].textContent,
            (e.querySelector('.sib-tag') || {textContent: ''}).textContent,
            e.getAttribute('aria-current') === 'true'])""")
 
     def tabs(self):
-        return self.strip("#termTabs")
+        return self.strip("[data-sib-tab]")
 
     def panes(self):
-        return self.strip("#termSiblings")
+        return self.strip("[data-sib-id]")
+
+    def groups(self):
+        """The row as the reader reads it: each tab's name, then the panes behind it."""
+        return self.page.eval_on_selector_all("#termSiblings .sib-group", """els => els.map(g => [
+          g.querySelector('.sib-tab').children[1].textContent,
+          [...g.querySelectorAll('[data-sib-id]')].map(e => e.dataset.sibId)])""")
 
     def visible(self, sel):
         return self.page.eval_on_selector(sel, "e => e.offsetHeight") > 0
 
-    def names(self, sel="#termSiblings"):
-        return [c[2] for c in self.strip(sel) if c[0] == "chip"]
+    def names(self, kind="[data-sib-id]"):
+        return [c[2] for c in self.strip(kind) if c[0] == "chip"]
 
     # -------------------------------------------------------------- the levels
 
-    def test_the_session_view_carries_herdrs_own_two_levels_below_the_space(self):
+    def test_the_row_is_every_pane_in_the_space_grouped_by_tab(self):
         """space > tab > pane, of which the space is the one left to the herd list -- a tap on Back.
-        wA:pH sits in wA:t1 beside a terminal, with a second tab holding one more."""
+        The other two are ONE list, read left to right the way a multiplexer's status line is: the
+        panes of tab 1, then the panes of tab 2, each group led by its tab's name. wA:pH sits in
+        wA:t1 beside a terminal, with a second tab holding one more -- and that one is now a single
+        tap rather than a tab chip followed by whatever pane it decided to land you on."""
         self.page.evaluate("openTerminal('wA:pH')")
-        self.assertEqual(self.tabs(), [
-            ["chip", "wA:t1", "Tab 1", "", True],
-            ["chip", "wA:t2", "deploy", "", False],
+        self.assertEqual(self.groups(), [
+            ["Tab 1", ["wA:p2", "wA:pH"]],
+            ["deploy", ["wA:p3"]],
         ])
+        # And in that order in the DOM, so a screen reader and a thumb travel the same row.
+        self.assertEqual(
+            [c[1] for c in self.strip()],
+            ["wA:t1", "wA:p2", "wA:pH", "wA:t2", "wA:p3"])
         self.assertEqual(self.panes(), [
             ["chip", "wA:p2", "api", "p2", False],
             ["chip", "wA:pH", "claude", "pH", True],
+            ["chip", "wA:p3", "api", "p3", False],
         ])
+
+    def test_the_strip_is_in_herdrs_own_order_not_the_ids(self):
+        """The shape this was measured on, live: `w6:t1` holds pH and p15 with a terminal p12 between
+        them, and reads pH, p15, p12 at the desk -- `pane list` and `pane layout` agree, top-left
+        first. Sorting the ids put it in exactly the wrong order, because the suffix is a creation
+        counter in a base wider than ten (pH was opened before p12), and merging the relay's two
+        arrays would have drawn the terminal last."""
+        self.page.evaluate("""seeds => {
+          agents = agents.filter(a => a.pane_id !== 'wA:pH');
+          shellPanes = shellPanes.filter(p => p.pane_id !== 'wA:p2');
+          agents.push({...seeds.agent, pane_id: 'wA:pH', order: 0},
+                      {...seeds.agent, pane_id: 'wA:p15', order: 1});
+          shellPanes.push({...seeds.shell, pane_id: 'wA:p12', order: 2});
+          activePane = null;
+          openTerminal('wA:pH');
+        }""", SEEDS)
+        # wA:p3 rides along at the end: the row is the whole space, and it is in wA:t2.
+        self.assertEqual([c[1] for c in self.panes() if c[0] == "chip"],
+                         ["wA:pH", "wA:p15", "wA:p12", "wA:p3"])
+
+    def test_a_relay_that_reports_no_order_keeps_the_order_it_sent(self):
+        """One rule, no feature detection: a missing `order` sorts last and the sort is stable, so
+        every pane ties and both strips keep the arrays as they arrived. Which is what an older relay
+        and the demo worker send, and also what a `blocked` push leaves behind for one snapshot."""
+        self.page.evaluate("""() => {
+          [...agents, ...shellPanes].forEach(p => { delete p.order; });
+          activePane = null;
+          openTerminal('wA:pH');
+        }""")
+        self.assertEqual([c[1] for c in self.panes() if c[0] == "chip"],
+                         ["wA:pH", "wA:p2", "wA:p3"])
 
     def test_the_pane_you_are_in_is_in_the_strip_and_marked(self):
         """The old row listed the OTHER panes, so a row of chips had no `you are here` in it. Blue
@@ -566,19 +632,21 @@ class WebSessionNavTests(unittest.TestCase):
           const bg = sel => getComputedStyle(document.querySelector(sel)).backgroundColor;
           return [bg('#termSiblings [data-sib-id="wA:pH"]'),
                   bg('#termSiblings [data-sib-id="wA:p2"]'),
-                  bg('#termTabs [data-sib-tab="wA:t1"]'),
-                  bg('#termTabs [data-sib-tab="wA:t2"]')];
+                  bg('#termSiblings [data-sib-tab="wA:t1"]'),
+                  bg('#termSiblings [data-sib-tab="wA:t2"]')];
         }""")
         self.assertEqual(fills[0], fills[2], "the open pane and its tab are marked differently")
         self.assertNotEqual(fills[0], fills[1], "the open pane's chip looks like its neighbour's")
-        self.assertEqual(fills[1], fills[3])
+        # A tab's name carries an opaque background of its own -- it is pinned, and the panes scroll
+        # under it -- so what has to differ is the marked one from the unmarked one.
+        self.assertNotEqual(fills[2], fills[3], "the tab you are in looks like the one you are not")
 
     def test_one_tab_is_not_a_choice(self):
         """6 of the 10 agent panes measured sit in a single-tab space, and would each have paid a
-        row to be told the name of the only tab there is."""
+        chip, and a rule, to be told the name of the only tab there is."""
         self.page.evaluate("openTerminal('wB:pH')")
         self.assertEqual(self.tabs(), [])
-        self.assertFalse(self.visible("#termTabs"))
+        self.assertEqual(self.groups(), [])
         # wB:p2's `project` is `billing` and its cwd is /work/api. The chip says `api`, which is
         # the directory -- the field that belongs to the pane rather than to the whole worktree.
         self.assertEqual(self.names(), ["api", "claude"])
@@ -593,14 +661,15 @@ class WebSessionNavTests(unittest.TestCase):
           openTerminal('wA:pH');
         }""")
         self.assertEqual(self.tabs(), [])
-        self.assertFalse(self.visible("#termTabs"))
+        self.assertEqual(self.groups(), [])
 
     def test_a_pane_with_nothing_beside_it_costs_no_pixels(self):
-        """Three of the ten agent panes on the measured host have no pane beside them."""
+        """Three of the ten agent panes on the measured host have no pane beside them. The threshold
+        is the SPACE rather than the tab: one pane in it is nothing to switch to, and the row would
+        cost the output 33px to say so."""
         self.page.evaluate("openTerminal('wD:pH')")
         self.assertEqual(self.panes(), [])
-        self.assertFalse(self.visible("#termSiblings"))
-        self.assertFalse(self.visible("#termTabs"))
+        self.assertFalse(self.visible("#termSibs"))
 
     def test_with_no_shell_panes_the_session_view_is_exactly_what_it_was(self):
         """HERDR_SHELL_PANES off: the relay ships no `panes` key, and wA:pH's only neighbours were
@@ -610,7 +679,7 @@ class WebSessionNavTests(unittest.TestCase):
                            without)
         self.assertEqual(self.panes(), [])
         self.assertEqual(self.tabs(), [])
-        self.assertFalse(self.visible("#termSiblings"))
+        self.assertFalse(self.visible("#termSibs"))
 
     # --------------------------------------------------------------- the names
 
@@ -623,7 +692,8 @@ class WebSessionNavTests(unittest.TestCase):
           shellPanes.find(p => p.pane_id === 'wA:p2').cwd = '/work/api/build';
           openTerminal('wA:pH');
         }""")
-        self.assertEqual(self.names(), ["build", "claude"])
+        # `api` at the end is wA:t2's own terminal, whose cwd this test did not move.
+        self.assertEqual(self.names(), ["build", "claude", "api"])
         self.assertEqual(self.page.evaluate("agents.find(a => a.pane_id === 'wA:pH').project"),
                          "api")
 
@@ -634,7 +704,7 @@ class WebSessionNavTests(unittest.TestCase):
           agents.find(a => a.pane_id === 'wA:pH').title = 'fixing the poll';
           openTerminal('wA:pH');
         }""")
-        self.assertEqual(self.names(), ["api", "fixing the poll"])
+        self.assertEqual(self.names(), ["api", "fixing the poll", "api"])
 
     def test_an_operators_own_label_still_wins(self):
         self.page.evaluate("""() => {
@@ -643,7 +713,7 @@ class WebSessionNavTests(unittest.TestCase):
           agents.find(a => a.pane_id === 'wA:pH').title = 'fixing the poll';
           openTerminal('wA:pH');
         }""")
-        self.assertEqual(self.names(), ["build", "poller"])
+        self.assertEqual(self.names(), ["build", "poller", "api"])
 
     def test_the_pane_ids_own_suffix_is_the_handle_when_the_name_repeats(self):
         """Three shells sitting in `herdr`, three claudes in one tab: the name is routinely shared
@@ -654,8 +724,9 @@ class WebSessionNavTests(unittest.TestCase):
           openTerminal('wA:pH');
         }""")
         chips = [c for c in self.panes() if c[0] == "chip"]
-        self.assertEqual([c[2] for c in chips], ["api", "api", "claude"])
-        self.assertEqual([c[3] for c in chips], ["p2", "p9", "pH"])
+        # Three in wA:t1, then wA:t2's own terminal -- four chips, three of them called `api`.
+        self.assertEqual([c[2] for c in chips], ["api", "api", "claude", "api"])
+        self.assertEqual([c[3] for c in chips], ["p2", "p9", "pH", "p3"])
 
     def test_a_tab_is_named_by_its_label_and_a_bare_number_says_it_is_positional(self):
         """herdr labels an unlabelled tab by its POSITION, so a chip reading `2` beside one reading
@@ -663,20 +734,20 @@ class WebSessionNavTests(unittest.TestCase):
         self.page.evaluate("openTerminal('wA:pH')")
         self.assertEqual([c[2] for c in self.tabs() if c[0] == "chip"], ["Tab 1", "deploy"])
 
-    def test_the_two_rows_are_told_apart_without_spending_a_word_on_it(self):
-        """A written `Tabs` / `Panes` label cost 40px of the row including its gap, and 4 of the 5
-        rows that scrolled on the real host overflowed by less than that. So the tab is squarer than
-        the pane, the pane carries the id tag the tab has not got, and the name of each row lives on
-        its aria-label, where it is still announced and costs nothing."""
+    def test_a_tabs_name_is_told_from_a_pane_without_spending_a_word_on_it(self):
+        """A written `Tabs` / `Panes` heading cost 40px of the row including its gap, and 4 of the 5
+        rows that scrolled on the real host overflowed by less than that. So the tab's name is
+        squarer than a pane chip, the pane carries the id tag the tab has not got, and what the shape
+        says is announced through the chip's own aria-label, where it costs nothing."""
         self.page.evaluate("openTerminal('wA:pH')")
         shape = self.page.evaluate("""() => [
-          getComputedStyle(document.querySelector('#termTabs .term-sib')).borderTopLeftRadius,
-          getComputedStyle(document.querySelector('#termSiblings .term-sib')).borderTopLeftRadius,
-          document.getElementById('termTabs').getAttribute('aria-label'),
+          getComputedStyle(document.querySelector('#termSiblings [data-sib-tab]')).borderTopLeftRadius,
+          getComputedStyle(document.querySelector('#termSiblings [data-sib-id]')).borderTopLeftRadius,
+          document.querySelector('#termSiblings [data-sib-tab]').getAttribute('aria-label'),
           document.getElementById('termSiblings').getAttribute('aria-label')]""")
-        self.assertNotEqual(shape[0], shape[1], "a tab chip and a pane chip are the same shape")
+        self.assertNotEqual(shape[0], shape[1], "a tab's name and a pane chip are the same shape")
         self.assertIn("Tab", shape[2])
-        self.assertIn("Pane", shape[3])
+        self.assertIn("Panes", shape[3])
         self.assertEqual([c[3] for c in self.tabs()], ["", ""])   # no id tag on a tab
 
     # -------------------------------------------------------------- the marks
@@ -709,8 +780,8 @@ class WebSessionNavTests(unittest.TestCase):
         blocked, terminals = self.page.evaluate("""() => {
           const g = sel => { const c = getComputedStyle(document.querySelector(sel));
                              return [c.backgroundColor, c.borderStyle]; };
-          return [g('#termTabs [data-sib-tab="wA:t2"] .dot'),
-                  g('#termTabs [data-sib-tab="wA:t1"] .dot')];
+          return [g('#termSiblings [data-sib-tab="wA:t2"] .dot'),
+                  g('#termSiblings [data-sib-tab="wA:t1"] .dot')];
         }""")
         red = self.page.eval_on_selector(
             '#agents [data-bucket="needs"] .dot', "e => getComputedStyle(e).backgroundColor")
@@ -720,7 +791,7 @@ class WebSessionNavTests(unittest.TestCase):
           render();
           openTerminal('wA:p2');
         }""")
-        hollow = self.page.eval_on_selector('#termTabs [data-sib-tab="wA:t2"] .dot',
+        hollow = self.page.eval_on_selector('#termSiblings [data-sib-tab="wA:t2"] .dot',
                                             "e => getComputedStyle(e).borderStyle")
         self.assertNotEqual(hollow, "none", "a tab of terminals was given a status it does not have")
 
@@ -730,8 +801,8 @@ class WebSessionNavTests(unittest.TestCase):
         self.page.evaluate("openTerminal('wA:pH')")
         self.page.eval_on_selector('#termSiblings [data-sib-id="wA:p2"]', "e => e.click()")
         self.assertEqual(self.page.evaluate("activePane"), "wA:p2")
-        # And the strips are redrawn around the pane that is now open.
-        self.assertEqual([c[4] for c in self.panes() if c[0] == "chip"], [True, False])
+        # And the row is redrawn around the pane that is now open.
+        self.assertEqual([c[4] for c in self.panes() if c[0] == "chip"], [True, False, False])
 
     def test_tapping_a_tab_lands_on_the_pane_in_it_that_needed_you(self):
         """Ranked through `bucketOf` like everything else on this page, so the tap goes to whatever
@@ -743,34 +814,37 @@ class WebSessionNavTests(unittest.TestCase):
           render();
           openTerminal('wA:pH');
         }""")
-        self.page.eval_on_selector('#termTabs [data-sib-tab="wA:t2"]', "e => e.click()")
+        self.page.eval_on_selector('#termSiblings [data-sib-tab="wA:t2"]', "e => e.click()")
         self.assertEqual(self.page.evaluate("activePane"), "wA:pX")
-        # The tabs row follows you across; the panes row is now that tab's.
+        # The mark follows you across; the row itself is the same row.
         self.assertEqual([c[1] for c in self.tabs() if c[0] == "chip" and c[4]], ["wA:t2"])
-        self.assertEqual([c[1] for c in self.panes() if c[0] == "chip"], ["wA:p3", "wA:pX"])
+        self.assertEqual(self.groups(),
+                         [["Tab 1", ["wA:p2", "wA:pH"]], ["deploy", ["wA:p3", "wA:pX"]]])
 
     def test_a_tab_with_only_terminals_in_it_is_still_reachable(self):
-        """The landing rule falls through to the first terminal -- a build log is a place to go."""
+        """The landing rule falls through to the first terminal -- a build log is a place to go. And
+        it is reachable twice over now: by its own chip in the row, or by its tab's name."""
         self.page.evaluate("openTerminal('wA:pH')")
-        self.page.eval_on_selector('#termTabs [data-sib-tab="wA:t2"]', "e => e.click()")
+        self.page.eval_on_selector('#termSiblings [data-sib-tab="wA:t2"]', "e => e.click()")
         self.assertEqual(self.page.evaluate("activePane"), "wA:p3")
-        # wA:p3 is alone in wA:t2, so there is nothing to switch to and the panes row goes away --
-        # while the tabs row stays, because that is the level that still has a choice on it.
-        self.assertFalse(self.visible("#termSiblings"))
-        self.assertTrue(self.visible("#termTabs"))
+        # wA:p3 is alone in wA:t2, but the row is the whole space -- so standing in a one-pane tab
+        # still leaves the other tab's panes a tap away, which the two-level row could not say.
+        self.assertTrue(self.visible("#termSibs"))
+        self.assertEqual(self.groups(), [["Tab 1", ["wA:p2", "wA:pH"]], ["deploy", ["wA:p3"]]])
 
     def test_the_tab_you_are_already_in_is_inert(self):
         """Re-entering openTerminal would close the history panel you have open for no reason."""
         self.page.evaluate("openTerminal('wA:pH'); toggleHistory()")
-        self.page.eval_on_selector('#termTabs [data-sib-tab="wA:t1"]', "e => e.click()")
+        self.page.eval_on_selector('#termSiblings [data-sib-tab="wA:t1"]', "e => e.click()")
         self.assertEqual(self.page.evaluate("activePane"), "wA:pH")
         self.assertNotEqual(
             self.page.eval_on_selector("#termHistory", "e => e.style.display"), "none")
 
     def test_from_a_terminal_the_agent_is_one_tap_back(self):
-        """Same rule read the other way -- the row is every pane in the tab, whichever kind."""
+        """Same rule read the other way -- the row is every pane in the space, whichever kind."""
         self.page.evaluate("openTerminal('wA:p2')")
-        self.assertEqual([c[1] for c in self.panes() if c[0] == "chip"], ["wA:p2", "wA:pH"])
+        self.assertEqual([c[1] for c in self.panes() if c[0] == "chip"],
+                         ["wA:p2", "wA:pH", "wA:p3"])
 
     def test_switching_pane_from_the_strip_does_not_carry_the_search_over(self):
         """`originalContent` is one global holding the open pane's output. Switching with the search
@@ -817,9 +891,10 @@ class WebSessionNavTests(unittest.TestCase):
                        agent: 'claude', status: 'blocked'});
           openTerminal('wA:pH');
         }""")
-        self.assertEqual([c[1] for c in self.panes() if c[0] == "chip"], ["wA:p2", "wA:pH"])
+        self.assertEqual([c[1] for c in self.panes() if c[0] == "chip"],
+                         ["wA:p2", "wA:pH", "wA:p3"])
 
-    def test_no_tab_hierarchy_means_no_tab_row_and_the_space_as_the_pane_row(self):
+    def test_no_tab_hierarchy_means_no_names_and_the_space_as_one_flat_row(self):
         """With no tab ids to go by there is no level below the space to draw, and the panes row
         falls back to the set it used to show."""
         self.page.evaluate("""() => {
@@ -828,8 +903,9 @@ class WebSessionNavTests(unittest.TestCase):
           openTerminal('wA:pH');
         }""")
         self.assertEqual(self.tabs(), [])
+        # Still herdr's order, now across the whole space: wA:p2, wA:pH, then wA:p3 in the next tab.
         self.assertEqual([c[1] for c in self.panes() if c[0] == "chip"],
-                         ["wA:p2", "wA:p3", "wA:pH"])
+                         ["wA:p2", "wA:pH", "wA:p3"])
 
     # ------------------------------------------------- one row, and what is above it
 
@@ -876,74 +952,168 @@ class WebSessionNavTests(unittest.TestCase):
         self.assertGreater(len(heights), 3, "the header lost its controls")
         self.assertEqual(set(heights), {28}, f"the header's children measure {heights}")
 
-    def test_both_levels_share_one_row(self):
+    def test_one_row_holds_both_levels_and_one_scroller_holds_the_row(self):
         """They were two rows of 33px, and 4 of the 10 agent panes on the measured host paid for
-        both -- for a row that is at most three chips and a row that is at most five."""
+        both. Then they were one row of two scrollers, which turned the saving into a width fight --
+        so it is one list in one scroller, and the outer row must not scroll or a drag would move the
+        levels against each other again."""
         self.page.evaluate("openTerminal('wA:pH')")
         row = self.page.evaluate("""() => {
-          const t = document.getElementById('termTabs').getBoundingClientRect();
-          const p = document.getElementById('termSiblings').getBoundingClientRect();
+          const strip = document.getElementById('termSiblings');
           const r = document.getElementById('termSibs').getBoundingClientRect();
-          return {tabsTop: Math.round(t.top), panesTop: Math.round(p.top),
-                  tabsLeft: Math.round(t.left), panesLeft: Math.round(p.left),
-                  row: Math.round(r.height)};
+          const tab = document.querySelector('#termSiblings [data-sib-tab]').getBoundingClientRect();
+          const pane = document.querySelector('#termSiblings [data-sib-id]').getBoundingClientRect();
+          return {row: Math.round(r.height), tabTop: Math.round(tab.top),
+                  paneTop: Math.round(pane.top), tabLeft: Math.round(tab.left),
+                  paneLeft: Math.round(pane.left),
+                  scrollers: [getComputedStyle(document.getElementById('termSibs')).overflowX,
+                              getComputedStyle(strip).overflowX],
+                  boxes: document.querySelectorAll('#termSiblings, #termTabs').length};
         }""")
-        self.assertEqual(row["tabsTop"], row["panesTop"], "the two levels are still stacked")
-        self.assertLess(row["tabsLeft"], row["panesLeft"], "the tabs are not to the left of the panes")
-        self.assertLess(row["row"], 40, f"the shared row is {row['row']}px")
+        self.assertLess(row["row"], 40, f"the row is {row['row']}px")
+        self.assertEqual(row["tabTop"], row["paneTop"], "the two levels are still stacked")
+        self.assertLess(row["tabLeft"], row["paneLeft"], "a tab's name is not ahead of its panes")
+        self.assertEqual(row["scrollers"], ["hidden", "auto"])
+        self.assertEqual(row["boxes"], 1, "the levels are back in boxes of their own")
 
-    def test_the_separator_stands_between_the_levels_only_when_both_are_there(self):
-        """1px is what tells the two levels apart now that they share a row, and a separator with
-        one side missing is a mark against nothing. wB has a single tab, so it draws panes only."""
+    def test_a_pane_chip_is_not_rationed_by_the_tab_names(self):
+        """What the two-scroller row cost: 3 tabs measured 253px of a 370px row, 68%, so the pane
+        level was capped to 45% and a 178px chip -- a 32vw activity title plus its dot, id tag and
+        padding -- could not be shown whole. In one list the widest chip has the whole row."""
+        self.page.evaluate("""() => {
+          for (let i = 0; i < 6; i++) {
+            spaces.tabs.push({tab_id: 'wA:tL' + i, workspace_id: 'wA', label: 'a-long-tab-name-' + i,
+                              number: 20 + i, focused: false, pane_count: 1, host: 'local'});
+            shellPanes.push({...shellPanes[0], pane_id: 'wA:pL' + i, tab_id: 'wA:tL' + i,
+                             order: 30 + i});
+          }
+          activePane = null;
+          openTerminal('wA:pH');
+        }""")
+        room = self.page.evaluate("""() => {
+          const strip = document.getElementById('termSiblings');
+          return {view: strip.clientWidth, row: document.getElementById('termSibs').clientWidth,
+                  widest: Math.max(...[...strip.querySelectorAll('.term-sib')]
+                    .map(e => e.getBoundingClientRect().width))};
+        }""")
+        self.assertGreater(room["view"], room["row"] * 0.9,
+                           f"the scroller was rationed to {room['view']}px of {room['row']}px")
+        self.assertGreater(room["view"], room["widest"])
+
+    def test_the_rule_stands_between_groups_and_nowhere_else(self):
+        """1px is what says where one tab's panes end, and a rule on the first group would be a mark
+        against nothing. wB has a single tab, so it draws no groups at all."""
         self.page.evaluate("openTerminal('wA:pH')")
-        self.assertTrue(self.visible("#termSibSep"))
+        borders = self.page.eval_on_selector_all(
+            "#termSiblings .sib-group", "els => els.map(e => getComputedStyle(e).borderLeftWidth)")
+        self.assertEqual(borders, ["0px", "1px"])
         self.page.evaluate("openTerminal('wB:pH')")
-        self.assertFalse(self.visible("#termTabs"))
-        self.assertTrue(self.visible("#termSiblings"))
-        self.assertFalse(self.visible("#termSibSep"), "a separator with nothing on one side of it")
+        self.assertEqual(self.page.eval_on_selector_all("#termSiblings .sib-group", "e => e.length"), 0)
+        self.assertTrue(self.visible("#termSibs"), "wB has two panes; the row still has a job")
 
-    def test_the_row_itself_goes_when_neither_level_has_a_choice_to_offer(self):
-        """Border and all: wD holds one pane in one tab, so both groups are empty and the row would
-        otherwise cost the output 33px to say nothing at all."""
+    def test_the_row_itself_goes_when_there_is_nothing_to_switch_to(self):
+        """Border and all: wD holds one pane in one tab, so the row would otherwise cost the output
+        33px to say that the pane you are in is the only one there is."""
         self.page.evaluate("openTerminal('wD:pH')")
         self.assertFalse(self.visible("#termSibs"))
         self.assertEqual(self.page.evaluate("() => document.getElementById('termSibs').offsetHeight"), 0)
 
-    def test_the_open_pane_is_scrolled_onto_the_screen_in_a_row_that_overflows(self):
-        """One row holds both levels, so it overflows sooner -- and the chip that must not be off
-        screen is the one saying where you are. It sits after every tab chip and after every earlier
-        pane, which is exactly where a row scrolled to 0 cannot show it."""
+    def crowd_wa_t1(self):
+        """Four more terminals in wA:t1, all of them AFTER the open pane in herdr's order, so the row
+        overflows a phone with the open chip off the right edge of it."""
         self.page.evaluate("""() => {
-          shellPanes.push(...['p4', 'p5', 'p6', 'p7'].map(id => ({
+          shellPanes.push(...['p4', 'p5', 'p6', 'p7'].map((id, i) => ({
             pane_id: 'wA:' + id, label: 'a-longer-shell-name-' + id, cwd: '/x', project: 'api',
-            host: 'local', workspace_id: 'wA', tab_id: 'wA:t1'})));
+            host: 'local', workspace_id: 'wA', tab_id: 'wA:t1', order: 20 + i})));
           activePane = null;
           openTerminal('wA:pH');
         }""")
+
+    def test_the_open_pane_is_scrolled_onto_the_screen_in_a_row_that_overflows(self):
+        """The chip that must not be off screen is the one saying where you are. It sits after every
+        earlier pane, which is exactly where a row scrolled to 0 cannot show it."""
+        self.crowd_wa_t1()
         seen = self.page.evaluate("""() => {
-          const row = document.getElementById('termSibs');
-          const chip = row.querySelector('#termSiblings [aria-current="true"]');
-          const c = chip.getBoundingClientRect(), b = row.getBoundingClientRect();
-          return {overflows: row.scrollWidth > row.clientWidth + 1,
+          const box = document.getElementById('termSiblings');
+          const chip = box.querySelector('[data-sib-id][aria-current="true"]');
+          const c = chip.getBoundingClientRect(), b = box.getBoundingClientRect();
+          return {overflows: box.scrollWidth > box.clientWidth + 1,
                   inside: c.left >= b.left - 1 && c.right <= b.right + 1};
         }""")
         self.assertTrue(seen["overflows"], "the row did not overflow, so nothing was proved")
         self.assertTrue(seen["inside"], "the chip you are standing in is off screen")
 
-    def test_the_shared_row_contains_its_overscroll(self):
+    def test_the_open_pane_is_never_placed_under_the_pinned_name(self):
+        """A name pinned at the left edge is painted OVER the chips scrolling beneath it, so a reveal
+        that put the open pane hard against that edge would hide it behind its own tab's name. Either
+        the name fits in the flow beside it, or the pane is placed to the right of the name's width --
+        both are `elementFromPoint` on the chip's own left edge coming back as the chip."""
+        self.crowd_wa_t1()
+        for pane in ("wA:pH", "wA:p7", "wA:p2"):
+            self.page.evaluate("p => { activePane = null; openTerminal(p); }", pane)
+            own = self.page.evaluate("""() => {
+              const chip = document.querySelector('#termSiblings [data-sib-id][aria-current="true"]');
+              const r = chip.getBoundingClientRect();
+              const hit = document.elementFromPoint(r.left + 3, r.top + r.height / 2);
+              return !!(hit && hit.closest('.term-sib') === chip);
+            }""")
+            self.assertTrue(own, f"{pane}'s chip is under something else")
+
+    def test_the_pinned_name_is_the_group_at_the_left_edge_all_the_way_along(self):
+        """The whole reason one scroller is safe. In a shared scroller the scroll that reveals the
+        open pane drove the tab level off the left edge -- measured at 390px in a 3-tab space, what
+        was left standing there was a SIBLING tab, reading as the breadcrumb of the tab you were in.
+        A name that sticks inside its own group cannot be the wrong one: it belongs to the panes
+        beside it. Swept across the whole scroll range, 25px at a time."""
+        self.crowd_wa_t1()
+        sweep = self.page.evaluate("""() => {
+          const strip = document.getElementById('termSiblings');
+          const b = strip.getBoundingClientRect();
+          const out = [];
+          for (let x = 0; x <= strip.scrollWidth - strip.clientWidth; x += 25) {
+            strip.scrollLeft = x;
+            const hit = document.elementFromPoint(b.left + 3, b.top + b.height / 2);
+            const chip = hit && hit.closest && hit.closest('.term-sib[data-sib-tab]');
+            // Which group actually owns that edge: the last one whose box starts left of it.
+            const owner = [...strip.querySelectorAll('.sib-group')]
+              .filter(g => g.getBoundingClientRect().left <= b.left + 4).pop();
+            if (chip) out.push([chip.closest('.sib-group') === owner, Math.round(x)]);
+          }
+          return out;
+        }""")
+        self.assertGreater(len(sweep), 4, "the row did not overflow far enough to prove anything")
+        self.assertEqual([s for s in sweep if not s[0]], [],
+                         "a name was pinned over another group's panes")
+
+    def test_a_pinned_name_is_opaque(self):
+        """`.term-sib` sets `background: none` at the same specificity and later in the file, so
+        `.sib-tab` alone lost -- and a transparent pinned chip lets the panes scroll through it,
+        which renders as two names on top of each other."""
+        self.page.evaluate("openTerminal('wA:pH')")
+        fills = self.page.evaluate("""() => [
+          getComputedStyle(document.querySelector('#termSiblings [data-sib-tab="wA:t2"]')).backgroundColor,
+          getComputedStyle(document.querySelector('#termSiblings [data-sib-tab="wA:t1"]')).backgroundColor,
+          getComputedStyle(document.querySelector('#termSiblings [data-sib-tab="wA:t2"]')).position]""")
+        self.assertNotIn(fills[0], ("rgba(0, 0, 0, 0)", "transparent"),
+                         "an unpinned tab name is see-through")
+        self.assertNotEqual(fills[1], fills[0], "aria-current's fill lost to the sticky background")
+        self.assertEqual(fills[2], "sticky")
+
+    def test_the_row_contains_its_overscroll(self):
         """The same rule .term-content carries: at either end of a horizontal drag the chain reaches
-        the document, and the browser reads it as the gesture that unloads the app."""
+        the document, and the browser reads it as the gesture that unloads the app. It travels with
+        the scroll, so it is on the box that does the scrolling."""
         self.page.evaluate("openTerminal('wA:pH')")
         self.assertEqual(
-            self.page.evaluate(
-                "() => getComputedStyle(document.getElementById('termSibs')).overscrollBehaviorX"),
+            self.page.evaluate("() => getComputedStyle(document.getElementById('termSiblings'))"
+                               ".overscrollBehaviorX"),
             "contain")
 
     def test_the_history_panel_still_covers_everything_under_the_header(self):
         """Both rows are in normal flow, so a panel opened over the output covers them too -- the
         same geometry the panel already had, which is why positionHistoryPanel is untouched."""
         self.page.evaluate("openTerminal('wA:pH'); toggleHistory()")
-        for sel in ("#termTabs", "#termSiblings"):
+        for sel in ("#termSiblings", "#termSibs"):
             covered = self.page.evaluate("""sel => {
               const s = document.querySelector(sel).getBoundingClientRect();
               const el = document.elementFromPoint(s.left + s.width / 2, s.top + s.height / 2);
@@ -1057,37 +1227,39 @@ class WebStripScrollTests(unittest.TestCase):
     # --------------------------------------------------------- the session view
 
     def crowd_the_tab(self, pane="wA:pH"):
-        """Enough panes beside the open one that the shared row overflows a phone -- and all of them
-        AFTER it, since the whole question is what happens to an offset that has the open chip off
-        screen. The strip sorts by pane_id, so `q*` puts every new chip past `pH`."""
+        """Enough panes beside the open one that the pane level overflows a phone -- and all of them
+        AFTER it in herdr's order, since the whole question is what happens to an offset that has the
+        open chip off screen."""
         self.page.evaluate("""p => {
           const snap = JSON.parse(JSON.stringify(window.__snap));
-          snap.panes.push(...['q4', 'q5', 'q6', 'q7'].map(id => ({
+          snap.panes.push(...['q4', 'q5', 'q6', 'q7'].map((id, i) => ({
             ...snap.panes[0], pane_id: 'wA:' + id, label: 'a-longer-shell-name-' + id,
-            workspace_id: 'wA', tab_id: 'wA:t1'})));
+            workspace_id: 'wA', tab_id: 'wA:t1', order: 20 + i})));
           window.__snap = snap;
           handleMessage(snap);
           openTerminal(p);
         }""", pane)
 
     def open_chip_is_on_screen(self):
+        # `[data-sib-id]`, because a bare `[aria-current]` finds the TAB's name first -- and that one
+        # is pinned to the left edge, so it would report every row as placed.
         return self.page.evaluate("""() => {
-          const row = document.getElementById('termSibs');
-          const chip = row.querySelector('#termSiblings [aria-current="true"]');
-          const c = chip.getBoundingClientRect(), b = row.getBoundingClientRect();
+          const box = document.getElementById('termSiblings');
+          const chip = box.querySelector('[data-sib-id][aria-current="true"]');
+          const c = chip.getBoundingClientRect(), b = box.getBoundingClientRect();
           return c.left >= b.left - 1 && c.right <= b.right + 1;
         }""")
 
     def test_the_sibling_row_keeps_its_place_across_a_snapshot(self):
         """The reported bug: the row is rebuilt from every snapshot, so a reader scrolling it to
         read the name of a pane at the far end was snapped back to their own pane every two
-        seconds -- first by the clamp, then by scrollSibsToOpenPane on top of it."""
+        seconds -- first by the clamp, then by the auto-scroll on top of it."""
         self.crowd_the_tab()
-        moved = self.scroll_to_end("#termSibs")
+        moved = self.scroll_to_end("#termSiblings")
         self.assertFalse(self.open_chip_is_on_screen(),
                          "the open chip is still in view, so nothing would pull the row back")
         self.snapshot()
-        self.assertEqual(self.scroll_left("#termSibs"), moved,
+        self.assertEqual(self.scroll_left("#termSiblings"), moved,
                          "the sibling row was dragged back to the open pane")
 
     def test_a_blocked_event_for_the_open_pane_does_not_drag_the_row_back(self):
@@ -1095,16 +1267,16 @@ class WebStripScrollTests(unittest.TestCase):
         arriving is the moment you are most likely to be reading the row, not the moment to move
         it."""
         self.crowd_the_tab()
-        moved = self.scroll_to_end("#termSibs")
+        moved = self.scroll_to_end("#termSiblings")
         self.page.evaluate("""() => handleMessage({type: 'blocked', pane_id: 'wA:pH',
           agent: 'claude', project: 'api', prompt: 'ok?', options: ['Yes', 'No'], update: true})""")
-        self.assertEqual(self.scroll_left("#termSibs"), moved)
+        self.assertEqual(self.scroll_left("#termSiblings"), moved)
 
     def test_a_real_switch_still_puts_the_pane_you_moved_to_on_the_screen(self):
         """The guard must not become a way of switching the anchor off: entering a session, and
         moving to a pane at the other end of the row, are the two moments it MAY move."""
         self.crowd_the_tab()
-        self.scroll_to_end("#termSibs")
+        self.scroll_to_end("#termSiblings")
         self.page.evaluate("openTerminal('wA:p2')")   # the first chip, off screen at that end
         self.assertTrue(self.open_chip_is_on_screen(),
                         "the pane you switched to was left off screen")

--- a/tests/test_web_spaces.py
+++ b/tests/test_web_spaces.py
@@ -952,5 +952,163 @@ class WebSessionNavTests(unittest.TestCase):
             self.assertTrue(covered, f"{sel} was reachable through the history panel")
 
 
+@unittest.skipIf(sync_playwright is None, "playwright is not installed")
+@unittest.skipIf(_chrome() is None, "no chromium build available")
+class WebStripScrollTests(unittest.TestCase):
+    """A sideways scroll is the reader's, and it survives a rebuild they did not ask for.
+
+    Three rows on this page scroll sideways and are rebuilt from every `agents` snapshot -- the
+    Spaces strip, the Tabs strip and the session's sibling row. `innerHTML` / `replaceChildren`
+    throw away the elements holding the offset (or collapse the scrollWidth under them, which the
+    browser answers by clamping scrollLeft to 0), so all three snapped back to the beginning every
+    two seconds: the space you had scrolled across the strip to reach walked back off the screen
+    under your thumb, and the sibling row then pulled the OPEN pane back into view on top of that.
+
+    Reached through `handleMessage`, not `render()`, because a snapshot is how it happens in the
+    field and the two are only the same until something between them changes.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.page = _shared["browser"].new_page(viewport=PHONE)
+        cls.page.goto(PAGE)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.page.close()
+
+    def setUp(self):
+        self.page.evaluate("""s => {
+          activeWorkspace = null; activeTab = null; activePane = null;
+          hideTerminal();
+          handleMessage(s);
+          window.__snap = s;
+        }""", SNAPSHOT)
+
+    # A strip has to OVERFLOW before it can prove anything, so every test says so first.
+    def scroll_to_end(self, sel):
+        moved = self.page.eval_on_selector(sel, """e => {
+          if (e.scrollWidth <= e.clientWidth + 1) return null;
+          e.scrollLeft = e.scrollWidth;          // the browser clamps it to this row's own end
+          return Math.round(e.scrollLeft);
+        }""")
+        self.assertTrue(moved, f"{sel} did not overflow, so nothing would be proved")
+        return moved
+
+    def scroll_left(self, sel):
+        return self.page.eval_on_selector(sel, "e => Math.round(e.scrollLeft)")
+
+    def snapshot(self):
+        """The 2s tick, as it arrives in the field."""
+        self.page.evaluate("() => handleMessage(window.__snap)")
+
+    def widen_spaces(self):
+        """Four more spaces, each with an agent in it: the strip is only up when the panes span more
+        than one space, and four chips fit across a phone."""
+        self.page.evaluate("""s => {
+          const snap = JSON.parse(JSON.stringify(s));
+          ['payments-gateway', 'search-indexer', 'notifications', 'infra-terraform']
+            .forEach((label, i) => {
+              const id = 'wX' + i;
+              snap.spaces.workspaces.push({workspace_id: id, label, number: 90 + i, focused: false,
+                                           tab_count: 1, pane_count: 1, host: 'local'});
+              snap.spaces.tabs.push({tab_id: id + ':t1', workspace_id: id, label: '1', number: 1,
+                                     focused: false, pane_count: 1, host: 'local'});
+              snap.agents.push({...s.agents[0], pane_id: id + ':pH',
+                                workspace_id: id, tab_id: id + ':t1'});
+            });
+          window.__snap = snap;
+          handleMessage(snap);
+        }""", SNAPSHOT)
+
+    # ------------------------------------------------------------- the herd list
+
+    def test_the_spaces_strip_keeps_its_place_across_a_snapshot(self):
+        self.widen_spaces()
+        moved = self.scroll_to_end('#agents [data-strip="spaces"]')
+        self.snapshot()
+        self.assertEqual(self.scroll_left('#agents [data-strip="spaces"]'), moved,
+                         "the Spaces strip walked back to the beginning on its own")
+
+    def test_the_spaces_strip_keeps_its_place_when_the_space_view_redraws_it(self):
+        """Picking a space is exactly when you have just scrolled the strip, and the space view
+        draws its own copy -- so the offset is kept by WHAT the strip is, not by where it sits."""
+        self.widen_spaces()
+        moved = self.scroll_to_end('#agents [data-strip="spaces"]')
+        self.page.evaluate("selectWorkspace('local|wX3')")
+        self.assertEqual(self.scroll_left('#agents [data-strip="spaces"]'), moved)
+
+    def test_the_tabs_strip_keeps_its_place_across_a_snapshot(self):
+        self.page.evaluate("""s => {
+          const snap = JSON.parse(JSON.stringify(s));
+          for (let i = 0; i < 8; i++) {
+            snap.spaces.tabs.push({tab_id: 'wA:tX' + i, workspace_id: 'wA', label: 'deploy-' + i,
+                                   number: 10 + i, focused: false, pane_count: 1, host: 'local'});
+          }
+          window.__snap = snap;
+          handleMessage(snap);
+          selectWorkspace('local|wA');
+        }""", SNAPSHOT)
+        moved = self.scroll_to_end('#agents [data-strip="tabs"]')
+        self.snapshot()
+        self.assertEqual(self.scroll_left('#agents [data-strip="tabs"]'), moved,
+                         "the Tabs strip walked back to the beginning on its own")
+
+    # --------------------------------------------------------- the session view
+
+    def crowd_the_tab(self, pane="wA:pH"):
+        """Enough panes beside the open one that the shared row overflows a phone -- and all of them
+        AFTER it, since the whole question is what happens to an offset that has the open chip off
+        screen. The strip sorts by pane_id, so `q*` puts every new chip past `pH`."""
+        self.page.evaluate("""p => {
+          const snap = JSON.parse(JSON.stringify(window.__snap));
+          snap.panes.push(...['q4', 'q5', 'q6', 'q7'].map(id => ({
+            ...snap.panes[0], pane_id: 'wA:' + id, label: 'a-longer-shell-name-' + id,
+            workspace_id: 'wA', tab_id: 'wA:t1'})));
+          window.__snap = snap;
+          handleMessage(snap);
+          openTerminal(p);
+        }""", pane)
+
+    def open_chip_is_on_screen(self):
+        return self.page.evaluate("""() => {
+          const row = document.getElementById('termSibs');
+          const chip = row.querySelector('#termSiblings [aria-current="true"]');
+          const c = chip.getBoundingClientRect(), b = row.getBoundingClientRect();
+          return c.left >= b.left - 1 && c.right <= b.right + 1;
+        }""")
+
+    def test_the_sibling_row_keeps_its_place_across_a_snapshot(self):
+        """The reported bug: the row is rebuilt from every snapshot, so a reader scrolling it to
+        read the name of a pane at the far end was snapped back to their own pane every two
+        seconds -- first by the clamp, then by scrollSibsToOpenPane on top of it."""
+        self.crowd_the_tab()
+        moved = self.scroll_to_end("#termSibs")
+        self.assertFalse(self.open_chip_is_on_screen(),
+                         "the open chip is still in view, so nothing would pull the row back")
+        self.snapshot()
+        self.assertEqual(self.scroll_left("#termSibs"), moved,
+                         "the sibling row was dragged back to the open pane")
+
+    def test_a_blocked_event_for_the_open_pane_does_not_drag_the_row_back(self):
+        """`blocked` re-enters openTerminal for the pane already in front of you. A question
+        arriving is the moment you are most likely to be reading the row, not the moment to move
+        it."""
+        self.crowd_the_tab()
+        moved = self.scroll_to_end("#termSibs")
+        self.page.evaluate("""() => handleMessage({type: 'blocked', pane_id: 'wA:pH',
+          agent: 'claude', project: 'api', prompt: 'ok?', options: ['Yes', 'No'], update: true})""")
+        self.assertEqual(self.scroll_left("#termSibs"), moved)
+
+    def test_a_real_switch_still_puts_the_pane_you_moved_to_on_the_screen(self):
+        """The guard must not become a way of switching the anchor off: entering a session, and
+        moving to a pane at the other end of the row, are the two moments it MAY move."""
+        self.crowd_the_tab()
+        self.scroll_to_end("#termSibs")
+        self.page.evaluate("openTerminal('wA:p2')")   # the first chip, off screen at that end
+        self.assertTrue(self.open_chip_is_on_screen(),
+                        "the pane you switched to was left off screen")
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/web/app.css
+++ b/web/app.css
@@ -193,29 +193,40 @@ body { font-family: var(--font-mono); background: var(--bg); color: var(--text);
    the output. Measured on a real host: at most three tabmates and at most five panes in a
    workspace, so chips are the whole control -- no menu -- and the row is absent for three of ten
    agent panes and for every pane when HERDR_SHELL_PANES is off. */
-/* ONE row for both levels. They were two rows of 33px, 66px of a 390x844 screen, and 4 of the 10
-   agent panes on the measured host paid for both -- for a row that is at most three chips and a row
-   that is at most five. The scroll, the padding and the border live on the outer row now; the two
-   groups inside it are plain flex boxes that keep their own ids, their own aria-labels and their
-   own "hidden when it holds no choice" rule. overscroll-behavior for the reason .term-content has
-   it: at either end of a horizontal drag the chain reaches the document and hands the browser its
-   back gesture, which unloads the app. */
-.term-sibs { display: flex; align-items: center; gap: 8px; overflow-x: auto; overscroll-behavior: contain; padding: 5px 10px; border-bottom: 1px solid var(--border); flex-shrink: 0; scrollbar-width: none; -webkit-overflow-scrolling: touch; }
-.term-sibs::-webkit-scrollbar { display: none; }
-.term-siblings { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
-/* The only thing separating the two levels now that they share a row -- 1px against the 40px a
-   written label cost, and shape still says the rest: a tab chip is squarer and carries no id tag. */
-.sib-sep { width: 1px; height: 15px; background: var(--border); flex-shrink: 0; }
-/* A tab is squarer than a pane, which -- with the 1px rule between the groups and the id tag a tab
-   has not got -- is what tells the two levels apart now that they share a row and neither carries a
-   written label. Measured at 390x844: a `Tabs` / `Panes` label cost 40px of the row including its
-   gap, and 4 of the 5 rows that scrolled on the real host overflowed by LESS than that -- 3px, 13px,
-   17px, 41px. The name is on each group's aria-label, where it costs nothing and is still announced. */
-.term-sib.sib-tab { border-radius: 6px; }
+/* ONE row, ONE scroller, and the tab's name sticks. They were two rows of 33px, 66px of a 390x844
+   screen, and 4 of the 10 agent panes on the measured host paid for both; then they were one row
+   split into two scrollers, which turned the saving into a width fight -- 2 tabs measure 135px of a
+   370px row and 3 measure 253px, 68%, against a pane chip that can be 178px on its own. One list
+   ends the fight: the panes of tab 1, then the panes of tab 2, each group behind its tab's name,
+   with the whole row's width available to whichever chip needs it.
+   The name is `position: sticky` INSIDE its own group, which is what makes a single scroller safe:
+   held by its containing block, each name is pinned to the left edge only while its own panes are on
+   screen, and the next group pushes it out rather than stacking on top of it. It needs an opaque
+   background for the chips scrolling underneath, and `aria-current`'s fill still wins on specificity.
+   overscroll-behavior for the reason .term-content has it: at either end of a horizontal drag the
+   chain reaches the document and hands the browser its back gesture, which unloads the app. */
+.term-sibs { display: flex; align-items: center; overflow: hidden; padding: 5px 10px; border-bottom: 1px solid var(--border); flex-shrink: 0; }
+.term-siblings { display: flex; align-items: center; gap: 6px; flex: 1 1 0; min-width: 0; overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; -webkit-overflow-scrolling: touch; }
+.term-siblings::-webkit-scrollbar { display: none; }
+.sib-group { display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
+/* Where one tab's panes end and the next tab's begin -- 1px, drawn only between groups, so it is
+   never a mark against nothing. It scrolls with the row: it belongs to the boundary, not the edge. */
+.sib-group + .sib-group { margin-left: 8px; padding-left: 8px; border-left: 1px solid var(--border); }
+
+/* A tab is squarer than a pane. With the 1px rule between groups and the id tag a tab has not got,
+   that is what tells a group's name from the panes behind it -- no `Tabs` / `Panes` heading, which
+   measured 40px of the row including its gap at 390x844, more than 4 of the 5 rows that scrolled on
+   the real host overflowed by (3px, 13px, 17px, 41px). What the shape says is announced through the
+   chip's own aria-label, where it costs nothing. */
+/* Squarer, and PINNED: `.term-sib.sib-tab` rather than `.sib-tab` because `.term-sib`'s own
+   `background: none` matches at the same specificity and comes later in the file -- a transparent
+   sticky chip lets the pane chips scroll through it, which renders as two names on top of each
+   other. `aria-current`'s fill still wins over this: same specificity, later rule. */
+.term-sib.sib-tab { border-radius: 6px; position: sticky; left: 0; z-index: 1; background: var(--bg); }
 /* An explicit height rather than padding: a chip naming a pane by its activity title carries CJK,
    whose glyphs are taller than latin at the same font-size, and the row grew 2px whenever one
    showed up. The row's height is set by its tallest chip, so it has to be the chip that is fixed. */
-.term-sib { display: flex; align-items: center; gap: 5px; height: 22px; padding: 0 9px; border-radius: 9999px; border: 1px solid var(--border); background: none; color: var(--text); font-size: 0.7rem; font-family: inherit; white-space: nowrap; cursor: pointer; }
+.term-sib { display: flex; align-items: center; gap: 5px; flex-shrink: 0; height: 22px; padding: 0 9px; border-radius: 9999px; border: 1px solid var(--border); background: none; color: var(--text); font-size: 0.7rem; font-family: inherit; white-space: nowrap; cursor: pointer; }
 /* A title can be a sentence -- `分析主目录文件状态并规划迁移` is one of the two on the measured host, and
    its chip came to 205px of a 390px row -- so one chip is not allowed to become the whole strip.
    32vw bites on those and on nothing else: the longest directory name here, `herdr-remote-dev`,

--- a/web/index.html
+++ b/web/index.html
@@ -102,17 +102,16 @@ document.addEventListener('DOMContentLoaded', () => bind());
     <button class="history-btn icon-toggle" id="historyBtn" aria-pressed="false" onclick="toggleHistory()" aria-label="Conversation history"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M12 7v5l4 2"/></svg></button>
     <button class="refresh-btn" onclick="followPane()" aria-label="Refresh pane"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 16h5v5"/></svg></button>
   </div>
-  <!-- space > tab > pane, the same three levels herdr itself has, in ONE row that can say two of
-       them from inside a session. Both groups are built by renderSiblings as DOM nodes, and each is
-       hidden on its own when it holds no choice: the tabs unless the space has two REACHABLE tabs
-       (6 of 10 agent panes on the measured host sit in a single-tab space), the panes unless the
-       tab holds a second pane (10 of 10 do there, so that group is the one that always shows).
-       When neither has anything to say the row itself goes, border and all.
+  <!-- space > tab > pane, the same three levels herdr itself has. ONE row says the lower two, read
+       left to right the way a multiplexer's status line is: every pane in this space, in herdr's
+       order, grouped by tab, each group led by its tab's name -- and the name STICKS to the left
+       edge while its own panes scroll past, so the tab you are standing in can never be scrolled
+       away or stood in for by a sibling. Built by renderSiblings as DOM nodes. The names are absent
+       in a single-tab space (6 of 10 agent panes on the measured host sit in one), and the row
+       itself goes, border and all, when the space holds one pane and there is nothing to switch to.
        The space above them is the one level left to the herd list, which is a tap on Back. -->
   <div class="term-sibs" id="termSibs" style="display:none">
-    <div class="term-siblings" id="termTabs" aria-label="Tabs in this space" style="display:none"></div>
-    <span class="sib-sep" id="termSibSep" style="display:none"></span>
-    <div class="term-siblings" id="termSiblings" aria-label="Panes in this tab" style="display:none"></div>
+    <div class="term-siblings" id="termSiblings" aria-label="Panes in this space, by tab"></div>
   </div>
   <div class="term-history" id="termHistory" style="display:none">
     <div class="hist-bar">

--- a/web/js/cards.js
+++ b/web/js/cards.js
@@ -132,21 +132,43 @@ function shellCard(p, scope) {
   </div>`;
 }
 
-// The two rows under the session header, both drawn from the snapshot already in hand.
+// The row under the session header: every pane in this space, in herdr's order, grouped by tab.
 //
-// What replaced what: this was one flat row of the OTHER panes in the workspace, tagged `Tab` and
-// `Space`, each chip named `label || pane_id`. On the host this was measured against, 28 of the 30
-// panes carry no operator label -- so that row read `w6:pH  w6:pQ  w6:pR`, three chips whose names
-// differ by one character and say nothing about what is inside them, with no mark for the pane you
-// were actually in and no way to reach a tab by name. Now it is herdr's own two levels: the tabs of
-// this space, then the panes of this tab, each named by what the pane can still say for itself.
+// What replaced what, twice. It was one flat row of the OTHER panes in the workspace, tagged `Tab`
+// and `Space`, each chip named `label || pane_id` -- and on the host this was measured against, 28
+// of the 30 panes carry no operator label, so that row read `w6:pH  w6:pQ  w6:pR`: three chips whose
+// names differ by one character, no mark for the pane you were standing in, and no way to reach a
+// tab by name. That became herdr's own two levels, the tabs of the space beside the panes of the
+// current tab -- which put a WIDTH FIGHT in a 370px row. Two tabs cost 135px of it and three cost
+// 253px, 68%, against a pane chip that can be 178px on its own, so a multi-tab space starved the
+// level the reader actually came for. Splitting the row into two scrollers to keep the tab level
+// from scrolling away only moved the fight; capping the tabs at 45% only rationed it.
 //
-// This row is rebuilt from EVERY `agents` snapshot -- that is how a terminal appearing beside the
-// open pane shows up without a reopen -- and a rebuild costs it its scroll position: `replaceChildren`
-// empties both groups, the row's scrollWidth collapses with them, and the browser clamps scrollLeft
-// to 0. Then `scrollSibsToOpenPane` pulled the open chip back into view from there. So a reader who
-// scrolled the row sideways to read the name of a pane at the far end was snapped back to their own
-// pane every two seconds, which reads as a row that refuses to be moved.
+// So there is ONE list and one scroller, read left to right the way a multiplexer's own status line
+// is: the panes of tab 1, then the panes of tab 2, in tab order, each group led by its tab's name.
+// Every pane in the space is one tap away instead of two (a tab chip, then whatever pane it decided
+// to land you on), and a pane chip gets the whole row's width when it needs it.
+//
+// THE TAB'S NAME IS STICKY, which is what makes one row safe. The names sit inside the flow, so at
+// rest the row simply reads `Tab 1  p1 p2 | ble-dev  p3 p4`; once a group's panes scroll under the
+// left edge its name stays pinned there, and the next group's name replaces it on the way past. That
+// is the bug the two-scroller version existed to fix -- in one shared scroller the scroll that
+// reveals the open pane drove the tab level off the left edge, and at 390px in a 3-tab space what
+// was left standing there was a SIBLING tab, `ble-verify` while you were in `ble-dev`, reading as
+// the breadcrumb of the tab you were in. A pinned name cannot be the wrong one: it belongs to the
+// panes beside it.
+//
+// Colour is deliberately NOT the channel. The dot is the triage bucket (red -> orange -> green ->
+// grey) and a filled chip is the selection, everywhere on this page; a third scale keyed to "which
+// tab" would collide with both. The name says it, the 1px rule between groups says where one ends,
+// and both cost less than a hue.
+//
+// The row is rebuilt from EVERY `agents` snapshot -- that is how a terminal appearing beside the
+// open pane shows up without a reopen -- and a rebuild costs it its scroll position:
+// `replaceChildren` empties it, its scrollWidth collapses, and the browser answers by clamping
+// scrollLeft to 0. Then the auto-scroll pulled the open chip back into view from there. So a reader
+// who scrolled sideways to read the name of a pane at the far end was snapped back to their own pane
+// every two seconds, which reads as a row that refuses to be moved.
 //
 // The offset is the reader's, so it survives a rebuild they did not ask for, and the auto-scroll
 // fires only when the row is NEW to this pane. `sibsAnchoredTo` is what tells that apart from a
@@ -162,27 +184,61 @@ function renderSiblings() {
   // sibling of every other one. Nothing is better than a wrong neighbourhood.
   const wsKey = me && me.workspace_id ? agentWorkspaceKey(me) : null;
   const row = document.getElementById('termSibs');
-  // Read BEFORE the rebuild: the two groups are about to be emptied, and the number is gone with
-  // them. 0 while the session view is still display:none, where the assignment below is a no-op
-  // and openTerminal's own call is what places the row.
-  const kept = row ? row.scrollLeft : 0;
-  const tabs = renderTabStrip(me, wsKey);
-  const panes = renderPaneStrip(me, wsKey);
-  // The separator is the boundary between the two levels, so it exists only when both are there --
-  // a rule that hangs off what the two strips actually rendered rather than off a second count.
-  const sep = document.getElementById('termSibSep');
-  if (sep) sep.style.display = tabs && panes ? 'block' : 'none';
-  if (row) row.style.display = tabs || panes ? 'flex' : 'none';
-  if (!(tabs || panes)) { sibsAnchoredTo = null; return; }
-  if (!row) return;
-  row.scrollLeft = kept;
+  const strip = document.getElementById('termSiblings');
+  // Read BEFORE the rebuild: the strip is about to be emptied and the number goes with it. 0 while
+  // the session view is still display:none, where the assignment below is a no-op and openTerminal's
+  // own call is what places the row.
+  const kept = strip ? strip.scrollLeft : 0;
+  const drew = renderSibStrip(me, wsKey);
+  if (row) row.style.display = drew ? 'flex' : 'none';
+  if (!drew) { sibsAnchoredTo = null; return; }
+  if (!strip) return;
+  strip.scrollLeft = kept;
   anchorSibsToOpenPane();
 }
 
-// Places the row on the open pane, ONCE per pane. `sibsAnchoredTo` is what tells entering a session
-// apart from the refresh that follows it every two seconds -- the first is allowed to move the row,
-// the second is the reader's own scroll and is not. A row with no box cannot be measured, so it is
-// left unanchored for the next caller that has one (openTerminal, after the view is displayed).
+/** Every pane in the space, grouped by tab. Returns whether it drew anything, which is what tells
+ *  the row whether it has to exist at all.
+ *
+ *  Two panes is the threshold, and it is about the SPACE rather than the tab: with one pane in the
+ *  space there is nothing to switch to, and the row would cost the output 33px to say so. A tab with
+ *  no pane this client can name draws no group -- there is no CLI for pointing the web client at an
+ *  empty tab -- which is also what keeps the row honest with HERDR_SHELL_PANES off, where it becomes
+ *  the tabs that hold agents. */
+function renderSibStrip(me, wsKey) {
+  const strip = document.getElementById('termSiblings');
+  if (!strip) return false;
+  strip.replaceChildren();
+  const all = panesInSpace(wsKey);
+  if (all.length < 2) return false;
+  const groups = groupPanesByTab(wsKey).filter(g => g.panes.length);
+  // One tab is not a choice, and 6 of the 10 agent panes measured sit in a single-tab space -- they
+  // would each have paid a chip, and a rule, to be told the name of the only tab there is.
+  if (groups.length < 2) {
+    strip.append(...all.map(p => siblingChip(p, p.pane_id === activePane)));
+    return true;
+  }
+  const mine = me && me.tab_id ? agentTabKey(me) : null;
+  for (const g of groups) strip.append(sibGroup(g, g.key === mine));
+  return true;
+}
+
+// One tab's panes, behind its name. A group is a box of its own so the name can stick INSIDE it: a
+// sticky element is held by its containing block, so each name is pinned only while its own panes
+// are on screen and is pushed out by the next group rather than stacking up at the edge.
+function sibGroup(g, current) {
+  const box = document.createElement('div');
+  box.className = 'sib-group';
+  box.dataset.sibGroup = g.key;
+  box.append(tabChip(g, g.panes, current),
+             ...g.panes.map(p => siblingChip(p, p.pane_id === activePane)));
+  return box;
+}
+
+// Places the row on the pane you are in, ONCE per pane. `sibsAnchoredTo` is what tells entering a
+// session apart from the refresh that follows it every two seconds -- the first is allowed to move
+// the row, the second is the reader's own scroll and is not. A row with no box cannot be measured,
+// so it is left unanchored for the next caller that has one (openTerminal, after the view is shown).
 function anchorSibsToOpenPane() {
   const row = document.getElementById('termSibs');
   if (!row || !row.clientWidth || sibsAnchoredTo === activePane) return;
@@ -190,25 +246,57 @@ function anchorSibsToOpenPane() {
   scrollSibsToOpenPane();
 }
 
-// One row holds both levels now, so it overflows sooner -- and the chip that must not be off screen
-// is the one saying where you are. Computed rather than scrollIntoView(), which on a fixed-position
-// ancestor also scrolls the document and takes the header with it.
+/** Puts the pane you are in on the screen, with its tab's name if the two fit.
+ *
+ *  Computed rather than scrollIntoView(), which on a fixed-position ancestor also scrolls the
+ *  document and takes the header with it. Two things make it more than a reveal:
+ *
+ *  - A stuck name is PAINTED at the left edge rather than where it sits in the row, so its rect is
+ *    no use as a flow position. The group box never sticks, and that is what the arithmetic uses.
+ *  - A pane placed hard against the left edge would sit UNDER the stuck name. So either the group's
+ *    name fits in the flow beside it -- the common case, since a name leads its own tab's panes
+ *    rather than following every tab in the space -- or the pane is placed to the right of the name's
+ *    own width. */
 function scrollSibsToOpenPane() {
-  const row = document.getElementById('termSibs');
-  // The PANE chip, not whichever marked chip comes first: the tab you are in is the leftmost thing
-  // in the row and is never the one off screen, so matching it would report the job already done.
-  const cur = row && (row.querySelector('#termSiblings [aria-current="true"]')
-                      || row.querySelector('[aria-current="true"]'));
-  if (!cur || row.style.display === 'none') return;
-  const chip = cur.getBoundingClientRect(), box = row.getBoundingClientRect();
-  if (chip.left < box.left) row.scrollLeft -= box.left - chip.left + 8;
-  else if (chip.right > box.right) row.scrollLeft += chip.right - box.right + 8;
+  const strip = document.getElementById('termSiblings');
+  if (!strip || !strip.clientWidth) return;
+  const pane = strip.querySelector('[data-sib-id][aria-current="true"]');
+  if (!pane) return;
+  const group = pane.closest('.sib-group');
+  const label = group && group.querySelector('.sib-tab');
+  const box = strip.getBoundingClientRect(), view = strip.clientWidth;
+  const at = el => el.getBoundingClientRect().left - box.left + strip.scrollLeft;
+  const start = at(pane), end = start + pane.getBoundingClientRect().width;
+  const lead = label ? label.getBoundingClientRect().width + 6 : 0;
+  const together = group && end - at(group) <= view;
+  // The window of offsets that satisfies both, and the reader's own offset is left alone inside it.
+  const lo = end - view + 8;
+  const hi = together ? at(group) - 8 : start - lead - 8;
+  strip.scrollLeft = Math.max(0, Math.min(Math.max(strip.scrollLeft, lo), Math.max(lo, hi)));
 }
 
-// Every pane in one space. By pane_id, not by array: the two lists are disjoint in a snapshot, but
-// a `blocked` push can add an agent record for a pane still sitting in shellPanes, and that pane
-// would draw two chips. One order for both strips, and creation order in practice: herdr numbers a
-// pane's suffix p1, p2, ... p9, pA, pB, which sorts lexicographically into the order they opened.
+/** Where a pane sits in herdr's own `pane list`, which is the order it sits in on the screen the
+ *  operator is looking at -- the same split-tree walk `pane layout` returns, top-left first.
+ *
+ * Neither of the two things this page could compute for itself is that order. The relay splits ONE
+ * `pane list` into `agents` and `panes`, so the array a pane arrives in says nothing about where it
+ * is: merging them puts every agent ahead of every terminal, which misplaces the terminal sitting
+ * between two agents. And sorting the ids -- what this did -- is worse, because the suffix is a
+ * creation counter in a base wider than ten: measured live, `w6:t1` reads pH, p15, p12 at the desk
+ * and sorted to p12, p15, pH, while `w6:tC` reads p16, p18, p17 and sorted to p16, p17, p18. Even a
+ * correct creation order would not be it, since `pane swap` and `pane move` exist.
+ *
+ * Missing means last, and the sort is stable: a relay older than `order` sends none at all, so
+ * every pane ties and both strips keep the order the relay sent. The one pane that can lack it on a
+ * relay that does send it is an agent a `blocked` push appended, and the next snapshot -- two
+ * seconds -- puts it back where it belongs. */
+function paneOrder(p) {
+  return typeof p.order === 'number' ? p.order : Number.MAX_SAFE_INTEGER;
+}
+
+// Every pane in one space, in herdr's order. By pane_id, not by array: the two lists are disjoint in
+// a snapshot, but a `blocked` push can add an agent record for a pane still sitting in shellPanes,
+// and that pane would draw two chips.
 function panesInSpace(wsKey) {
   if (!wsKey) return [];
   const seen = new Set(), list = [];
@@ -217,20 +305,7 @@ function panesInSpace(wsKey) {
     seen.add(p.pane_id);
     list.push(p);
   }
-  return list.sort((a, b) => a.pane_id.localeCompare(b.pane_id));
-}
-
-// The same panes, keyed by tab. Panes with no tab id are absent rather than pooled: a relay that
-// reports no tabs has no level here to draw, and the pane row falls back to the whole space.
-function panesByTab(wsKey) {
-  const byTab = new Map();
-  for (const p of panesInSpace(wsKey)) {
-    if (!p.tab_id) continue;
-    const key = agentTabKey(p);
-    if (!byTab.has(key)) byTab.set(key, []);
-    byTab.get(key).push(p);
-  }
-  return byTab;
+  return list.sort((a, b) => paneOrder(a) - paneOrder(b));
 }
 
 // Where a tab chip lands you: the neediest agent in it, and failing that its first terminal. Ranked
@@ -238,32 +313,17 @@ function panesByTab(wsKey) {
 // been highest in the herd list -- if something in there is blocked, that is what you meant.
 function tabLandingPane(list) {
   const rank = p => (p.agent ? TRIAGE_ORDER.indexOf(bucketOf(p)) : TRIAGE_ORDER.length);
-  return [...list].sort((a, b) => rank(a) - rank(b) || a.pane_id.localeCompare(b.pane_id))[0];
-}
-
-// Returns whether it drew anything, which is what tells the shared row whether it has to exist.
-function renderTabStrip(me, wsKey) {
-  const strip = document.getElementById('termTabs');
-  if (!strip) return false;
-  strip.replaceChildren();
-  const byTab = panesByTab(wsKey);
-  // A tab with no pane we can name is not a place we can go -- there is no CLI for switching the
-  // web client to an empty tab, and a chip that does nothing is worse than no chip. This is also
-  // what keeps the row honest with HERDR_SHELL_PANES off: it becomes the tabs holding agents.
-  const rows = tabRows(wsKey).filter(t => (byTab.get(t.key) || []).length);
-  // One tab is not a choice, and 6 of the 10 agent panes measured live in a single-tab space --
-  // they would each have paid a chip to be told the name of the only tab there is.
-  if (rows.length < 2) { strip.style.display = 'none'; return false; }
-  const mine = me && me.tab_id ? agentTabKey(me) : null;
-  strip.append(...rows.map(t => tabChip(t, byTab.get(t.key), t.key === mine)));
-  strip.style.display = 'flex';
-  return true;
+  // Ties go to whichever comes first at the desk, not to whichever id sorts first -- the same
+  // question the strip's own order asks, so the tap lands on the chip a reader would have picked.
+  return [...list].sort((a, b) => rank(a) - rank(b) || paneOrder(a) - paneOrder(b))[0];
 }
 
 function tabChip(row, list, current) {
   const chip = document.createElement('button');
   chip.className = 'term-sib sib-tab';
-  chip.dataset.sibTab = row.id;
+  // Absent rather than the string "undefined" for the trailing `…` group, whose panes name a tab
+  // `tab list` has not caught up with -- the poll race right after a create.
+  if (row.id) chip.dataset.sibTab = row.id;
   if (current) chip.setAttribute('aria-current', 'true');
   // The same dot the space and tab chips in the herd carry, from the same classifier -- so a tab
   // says what is going on inside it before you open it. Null for a tab holding only terminals,
@@ -281,22 +341,6 @@ function tabChip(row, list, current) {
   // re-entering openTerminal and closing the panels you have open.
   if (!current) chip.onclick = () => openTerminal(tabLandingPane(list).pane_id);
   return chip;
-}
-
-function renderPaneStrip(me, wsKey) {
-  const strip = document.getElementById('termSiblings');
-  if (!strip) return false;
-  strip.replaceChildren();
-  // No tab id on the open pane means this relay reports no tabs at all; fall back to the whole
-  // space, which is the set this row used to show and still the only one available.
-  const list = me && me.tab_id ? (panesByTab(wsKey).get(agentTabKey(me)) || [])
-                               : panesInSpace(wsKey);
-  // Nothing to switch to means nothing to anchor either, so the row costs nothing -- 3 of the 10
-  // agent panes measured have no pane beside them.
-  if (list.length < 2) { strip.style.display = 'none'; return false; }
-  strip.append(...list.map(p => siblingChip(p, p.pane_id === activePane)));
-  strip.style.display = 'flex';
-  return true;
 }
 
 /** What a chip is called.

--- a/web/js/cards.js
+++ b/web/js/cards.js
@@ -140,19 +140,53 @@ function shellCard(p, scope) {
 // differ by one character and say nothing about what is inside them, with no mark for the pane you
 // were actually in and no way to reach a tab by name. Now it is herdr's own two levels: the tabs of
 // this space, then the panes of this tab, each named by what the pane can still say for itself.
+//
+// This row is rebuilt from EVERY `agents` snapshot -- that is how a terminal appearing beside the
+// open pane shows up without a reopen -- and a rebuild costs it its scroll position: `replaceChildren`
+// empties both groups, the row's scrollWidth collapses with them, and the browser clamps scrollLeft
+// to 0. Then `scrollSibsToOpenPane` pulled the open chip back into view from there. So a reader who
+// scrolled the row sideways to read the name of a pane at the far end was snapped back to their own
+// pane every two seconds, which reads as a row that refuses to be moved.
+//
+// The offset is the reader's, so it survives a rebuild they did not ask for, and the auto-scroll
+// fires only when the row is NEW to this pane. `sibsAnchoredTo` is what tells that apart from a
+// refresh, and it is dropped in the two places that mean "new": openTerminal's real-switch branch
+// (which covers entering a session from the list, since activePane is null there) and the row
+// disappearing entirely. A re-entry -- openTerminal on the pane already in front of you, which
+// every `blocked` event does -- clears nothing, so a question arriving cannot drag the row back.
+let sibsAnchoredTo = null;
+
 function renderSiblings() {
   const me = paneById(activePane);
   // No workspace id means this relay reports no hierarchy at all, and every pane would look like a
   // sibling of every other one. Nothing is better than a wrong neighbourhood.
   const wsKey = me && me.workspace_id ? agentWorkspaceKey(me) : null;
+  const row = document.getElementById('termSibs');
+  // Read BEFORE the rebuild: the two groups are about to be emptied, and the number is gone with
+  // them. 0 while the session view is still display:none, where the assignment below is a no-op
+  // and openTerminal's own call is what places the row.
+  const kept = row ? row.scrollLeft : 0;
   const tabs = renderTabStrip(me, wsKey);
   const panes = renderPaneStrip(me, wsKey);
   // The separator is the boundary between the two levels, so it exists only when both are there --
   // a rule that hangs off what the two strips actually rendered rather than off a second count.
   const sep = document.getElementById('termSibSep');
   if (sep) sep.style.display = tabs && panes ? 'block' : 'none';
-  const row = document.getElementById('termSibs');
   if (row) row.style.display = tabs || panes ? 'flex' : 'none';
+  if (!(tabs || panes)) { sibsAnchoredTo = null; return; }
+  if (!row) return;
+  row.scrollLeft = kept;
+  anchorSibsToOpenPane();
+}
+
+// Places the row on the open pane, ONCE per pane. `sibsAnchoredTo` is what tells entering a session
+// apart from the refresh that follows it every two seconds -- the first is allowed to move the row,
+// the second is the reader's own scroll and is not. A row with no box cannot be measured, so it is
+// left unanchored for the next caller that has one (openTerminal, after the view is displayed).
+function anchorSibsToOpenPane() {
+  const row = document.getElementById('termSibs');
+  if (!row || !row.clientWidth || sibsAnchoredTo === activePane) return;
+  sibsAnchoredTo = activePane;
   scrollSibsToOpenPane();
 }
 
@@ -339,6 +373,9 @@ function openTerminal(paneId) {
   if (activePane !== paneId) {
     hideHistory(); hideSearch(); clearPaneMirror();
     paneLines = PANE_LINES_BASE; paneFollowing = true; userScrolledUp = false;
+    // A real switch is one of the two moments the sibling row may place itself; dropping the anchor
+    // here is what asks for it, and what keeps a re-entry from asking again.
+    sibsAnchoredTo = null;
   }
   activePane = paneId;
   const a = agents.find(x => x.pane_id===paneId);
@@ -357,10 +394,11 @@ function openTerminal(paneId) {
   if (refreshInterval) clearInterval(refreshInterval);
   document.getElementById('terminalView').classList.add('active');
   // AFTER the view is displayed: renderSiblings ran while it was still display:none, where every
-  // rect is zero and no chip can be found to be off screen. A rebuilt strip loses its scroll
-  // position anyway (replaceChildren empties it, and an empty box has nothing to scroll), so this
-  // is a restore rather than a jump -- it does not fight a reader who scrolled the row by hand.
-  scrollSibsToOpenPane();
+  // rect is zero, no chip can be found to be off screen, and scrollLeft cannot be written either --
+  // so it deliberately left the row unanchored for this call to place. Guarded the same way, since
+  // openTerminal is re-entered on every `blocked` event for the pane already in front of you and a
+  // question arriving must not drag the row back under the reader's thumb.
+  anchorSibsToOpenPane();
   navPush('terminal', hideTerminal);
   const qa = document.getElementById('quickActions');
   const ak = document.getElementById('actionKeys');

--- a/web/js/spaces.js
+++ b/web/js/spaces.js
@@ -176,24 +176,27 @@ function tabHeading(g) {
 
 /** A workspace's panes by tab, in tab order, including empty tabs. Panes whose tab is not in the
  *  tab list yet -- a brief poll race after a create -- fall into a trailing group so they are never
- *  lost -- the list is the panes, and the hierarchy only names and orders them. */
+ *  lost -- the list is the panes, and the hierarchy only names and orders them.
+ *
+ *  Through panesInSpace, so this view and the session strip put two panes of one tab in the same
+ *  order: herdr's own. Merging the two arrays here, which is what this did, put every agent ahead of
+ *  every terminal -- so a terminal split between two agents was drawn last, in a view whose whole
+ *  claim is that it shows what is in a tab. */
 function groupPanesByTab(workspaceKey) {
-  const panes = [], seen = new Set();
-  for (const p of [...agents, ...shellPanes]) {
-    // By pane_id: the two arrays are disjoint in a snapshot, but a `blocked` push can add an agent
-    // record for a pane still sitting in shellPanes.
-    if (seen.has(p.pane_id) || agentWorkspaceKey(p) !== workspaceKey) continue;
-    seen.add(p.pane_id);
-    panes.push(p);
-  }
+  const panes = panesInSpace(workspaceKey);
   const tabs = tabRows(workspaceKey);
   const groups = tabs.map(t => ({
-    key: t.key, name: t.name, focused: t.focused,
+    // `id` is the bare tab id the relay wants, `key` the host-qualified one this page compares on.
+    // The session strip needs both: it marks the group holding the open pane by key and puts the id
+    // on the chip.
+    key: t.key, id: t.id, name: t.name, focused: t.focused,
     panes: panes.filter(p => agentTabKey(p) === t.key),
   }));
   const known = new Set(tabs.map(t => t.key));
   const orphans = panes.filter(p => !known.has(agentTabKey(p)));
-  if (orphans.length) groups.push({key: `${workspaceKey}|other`, name: '…', panes: orphans});
+  if (orphans.length) {
+    groups.push({key: `${workspaceKey}|other`, id: '', name: '…', panes: orphans});
+  }
   return groups;
 }
 

--- a/web/js/spaces.js
+++ b/web/js/spaces.js
@@ -72,8 +72,38 @@ function render() {
   // Checked here rather than at the top of render(), so the name maps and the sibling strips still
   // track the truth while the list itself holds still.
   if (selectionInside(list)) return;
+  const strips = chipStripScroll(list);
   list.innerHTML = activeWorkspace ? renderSpaceView(rows) : renderHerd(rows, occupied);
+  restoreChipStripScroll(list, strips);
   bindLongPressHandlers();
+}
+
+// A rebuild is not a gesture, and this list rebuilds on every `agents` snapshot -- every two
+// seconds, forever. The chip strips scroll SIDEWAYS (ten spaces do not fit across a phone), and
+// `innerHTML` throws away the very elements that hold the offset, so a reader who had scrolled the
+// Spaces row to reach the space at the far end watched it snap back to the beginning mid-reach.
+// That is the reported bug, and it is the same one the sibling row has (see renderSiblings): the
+// offset is the reader's, so it survives a rebuild it did not ask for.
+//
+// Keyed by WHAT the strip is (`data-strip`), not by its position in the list: the herd draws one
+// strip and the space view draws two, and the Spaces row has to keep its place across that switch
+// as well -- picking a space is exactly when you have just scrolled it.
+function chipStripScroll(list) {
+  const kept = new Map();
+  for (const strip of list.querySelectorAll('.chip-strip')) {
+    if (strip.scrollLeft) kept.set(strip.dataset.strip, strip.scrollLeft);
+  }
+  return kept;
+}
+
+function restoreChipStripScroll(list, kept) {
+  if (!kept.size) return;
+  for (const strip of list.querySelectorAll('.chip-strip')) {
+    const x = kept.get(strip.dataset.strip);
+    // Assigned, not clamped by hand: a strip that lost chips since the last snapshot is put at its
+    // own new end by the browser rather than left pointing past it.
+    if (x) strip.scrollLeft = x;
+  }
 }
 
 // The herd, in the one order the app agrees on. AGENTS only: two thirds of the panes on a real host
@@ -168,7 +198,7 @@ function groupPanesByTab(workspaceKey) {
 }
 
 function spaceStrip(rows) {
-  let html = `<div class="chip-strip"><span class="chip-label">Spaces</span>`;
+  let html = `<div class="chip-strip" data-strip="spaces"><span class="chip-label">Spaces</span>`;
   html += `<button class="chip${activeWorkspace === null ? ' active' : ''}" onclick="backToWorkspaces()">All</button>`;
   for (const w of rows) {
     const held = [...agents, ...shellPanes].filter(p => agentWorkspaceKey(p) === w.key);
@@ -189,7 +219,7 @@ function spaceStrip(rows) {
 
 function tabStrip(rows) {
   const wsTabs = tabRows(activeWorkspace);
-  let html = `<div class="chip-strip"><span class="chip-label">Tabs</span>`;
+  let html = `<div class="chip-strip" data-strip="tabs"><span class="chip-label">Tabs</span>`;
   if (wsTabs.length > 1) {
     html += `<button class="chip${!activeTab ? ' active' : ''}" onclick="selectTab(null)">All</button>`;
   }


### PR DESCRIPTION
Closes #58. Closes #59.

**Depends on #60** — its single commit is the first of the three here and disappears from this PR
when #60 merges. Nothing else in the stack: #55 touches `web/js/state.js` and is independent of both.

## What is wrong

Two separate faults, both visible the moment you open an agent in a space with more than one tab.

**The hierarchy.** The tabs of the space and the panes of the current tab shared one horizontal
scroller, and the pane chips come *after* the tab chips — so the scroll that reveals the open pane
drove the whole tab level off the left edge. At 390px in a 3-tab space what was left standing there
was a **sibling** tab (`ble-verify` while you were in `ble-dev`), reading as the breadcrumb of the tab
you were in; in a 2-tab space, the tail of a pane's id tag and no tab level at all. Rationing the
width could not fix it either: 2 tabs measure 135px of a 370px row and 3 measure **253px, 68%**,
against a pane chip that can be 178px on its own.

**The order.** Both the strip and the space view sorted a tab's panes by the pane id as a string,
which is not the order they are in at the desk: `w6:t1` reads `pH, p15, p12` there and sorted to
`p12, p15, pH`; `w6:tC` reads `p16, p18, p17` and sorted to `p16, p17, p18`. The id cannot stand in
for it — the suffix is a creation counter in a base wider than ten, and `pane swap` / `pane move`
rearrange panes without touching ids.

## The fix

**relay** — `feat(relay): report where each pane sits in herdr's own pane list`

`pane list` answers in the order the panes are laid out (verified against `pane layout` on every tab
of this host: the same split-tree walk, top-left first), and splitting that one listing into `agents`
+ `panes` threw the interleaving away — so a terminal split between two agents could not be placed at
all. Each record now carries **`order`**, its index in the listing it came from, one numbering across
both arrays, per host. Purely additive: six clients read these arrays and none of them has to know.

**web** — `fix(web): one row of every pane in the space, grouped by tab`

One list in one scroller, read left to right the way a multiplexer's own status line is: the panes of
tab 1, then the panes of tab 2, in tab order, each group led by its tab's name and cut from the next
by a 1px rule.

- **The widest chip can have the whole row**, and every pane in the space is **one tap** instead of
  two (a tab chip, then whatever pane `tabLandingPane` decided to land you on). The tab's name is
  still tappable and still lands on the neediest pane in it.
- **The name is `position: sticky` inside its own group**, which is what makes one scroller safe: a
  sticky element is held by its containing block, so each name is pinned to the left edge only while
  its own panes are on screen and the next group pushes it out instead of stacking on it. A pinned
  name therefore cannot be the wrong one — it belongs to the panes beside it.
- Two consequences are load-bearing. The pinned chip is painted **over** the panes scrolling beneath
  it, so it needs an opaque background — and the rule has to be `.term-sib.sib-tab`, because
  `.term-sib`'s own `background: none` matches at the same specificity and comes later in the file (a
  see-through pinned chip renders as two names on top of each other). And the reveal must not place
  the open pane **under** it, so it measures from the group box, which never sticks, and either fits
  the name in the flow beside the pane or places the pane to the right of the name's width.
- **Colour is deliberately not the channel for "which tab".** The dot is the triage bucket and a
  filled chip is the selection, everywhere on this page; a third scale keyed to the tab would collide
  with both. The name says it, the rule says where a group ends, and the squarer corner says a name is
  not a pane chip.
- Order comes from `paneOrder` / `panesInSpace`, which `groupPanesByTab` goes through too, so the
  space view and the session row cannot disagree about two panes of one tab. A missing `order` sorts
  **last, stably**, so an older relay and `demo-worker` keep the arrays as they arrived.

The row is the same **33px** and the chrome above the output the same **116px** of a 390×844 screen —
no height was added to fix either fault.

## Tests

- `tests/test_web_spaces.py`: the pinned name is the group at the left edge across the **whole**
  scroll range (swept 25px at a time), the open pane is never placed under it, the name is opaque, the
  rule stands only between groups, one row / one scroller, herdr's order, and the no-`order` fallback.
- `tests/test_herdr_relay.py`: `order` is the index in `pane list`, spanning both arrays, with a shell
  pane in the middle of it.
- Measured against the live host (45 panes, 17 spaces) at 320, 390 and 1280: for **all 42** reachable
  panes the open chip is fully on screen and its own tab's name is visible.
- `sh tests/run.sh` at this branch's tip: **23 passed, 0 failed** (215 browser tests).
