### PR TITLE
fix: make web push and the installed PWA work on a phone

### DIFF
--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -2610,7 +2610,11 @@ async def main():
         except OSError:
             log.warning("UDP 8376 in use, plugin push disabled")
         tasks = [asyncio.create_task(poll_loop()), asyncio.create_task(event_push())]
-        server = await serve(handle_client, RELAY_HOST, WS_PORT, process_request=process_request)
+        # ping_timeout defaults to 20s, which a phone cannot meet: Android dozes the radio in a
+        # backgrounded tab and the pong lands late, so the server hangs up on a client that is
+        # fine. Keep pinging (it holds the proxy path open) but give the pong room.
+        server = await serve(handle_client, RELAY_HOST, WS_PORT, process_request=process_request,
+                             ping_interval=20, ping_timeout=90)
         hosts = ["local"] + REMOTES
         log.info("herdr-remote relay on %s:%d (WebSocket + HTTP POST)", RELAY_HOST, WS_PORT)
         log.info("Polling: %s", ", ".join(hosts))

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1947,6 +1947,17 @@ async def process_request(connection, request):
             _, qs = request.path.split("?", 1) if "?" in request.path else (request.path, "")
             params = urllib.parse.parse_qs(qs)
             token = params.get("token", [None])[0]
+        # And the cookie the index response plants below. A PWA's manifest start_url is a bare
+        # "/", so launching from the home screen arrives with no query token and 401s before a
+        # line of JS runs -- localStorage cannot help, the document fetch precedes it.
+        if not token:
+            for key, value in request.headers.raw_items():
+                if key.lower() != "cookie":
+                    continue
+                for part in value.split(";"):
+                    name, _, val = part.strip().partition("=")
+                    if name == "herdr_token":
+                        token = val
         if token != AUTH_TOKEN:
             headers = Headers([("Content-Type", "text/plain")])
             return Response(401, "Unauthorized", headers, b"Invalid token\n")
@@ -2003,11 +2014,17 @@ async def process_request(connection, request):
         if os.path.isfile(index_path):
             with open(index_path, "rb") as f:
                 body = f.read()
-            headers = Headers([
+            fields = [
                 ("Content-Type", "text/html; charset=utf-8"),
                 ("Cache-Control", "no-cache"),
-            ])
-            return Response(200, "OK", headers, body)
+            ]
+            if AUTH_TOKEN:
+                # Getting here means this request already authenticated, so plant the token for
+                # the tokenless loads that follow -- the PWA launch, and any bare bookmark.
+                fields.append(("Set-Cookie",
+                               f"herdr_token={AUTH_TOKEN}; Path=/; Max-Age=31536000;"
+                               " HttpOnly; SameSite=Lax"))
+            return Response(200, "OK", Headers(fields), body)
 
     # Serve service worker
     if path == "/sw.js":

--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -1014,8 +1014,10 @@ if [ -n "$EXISTING_PID" ]; then
         wait_for_label_gone "$LABEL_RELAY" || true
     fi
 
-    # Try graceful shutdown first (SIGTERM)
-    kill "$EXISTING_PID" 2>/dev/null
+    # Try graceful shutdown first (SIGTERM). `|| true` because the bootout above usually already
+    # took this PID down, and under `set -e` a kill that finds nothing aborts the whole install --
+    # after the relay has been stopped, which leaves the machine with no relay at all.
+    kill "$EXISTING_PID" 2>/dev/null || true
     for i in 1 2 3 4 5; do
         if ! kill -0 "$EXISTING_PID" 2>/dev/null; then
             break

--- a/relay/install-service.sh
+++ b/relay/install-service.sh
@@ -301,6 +301,22 @@ generate_relay_token() {
     python3 -c 'import secrets; print(secrets.token_hex(32))'
 }
 
+# Private key then public key, one per line, base64url as the relay and the browser want them.
+generate_vapid_keys() {
+    "$UV_PATH" run --quiet --with py-vapid python - <<'VAPID_PY'
+import base64
+from py_vapid import Vapid01
+from cryptography.hazmat.primitives import serialization
+
+v = Vapid01()
+v.generate_keys()
+b64 = lambda raw: base64.urlsafe_b64encode(raw).decode().rstrip("=")
+print(b64(v.private_key.private_numbers().private_value.to_bytes(32, "big")))
+print(b64(v.public_key.public_bytes(serialization.Encoding.X962,
+                                    serialization.PublicFormat.UncompressedPoint)))
+VAPID_PY
+}
+
 UV_PATH="$(find_binary uv)"
 HERDR_PATH="$(find_binary herdr)"
 HERDR_PUSH_PATH="$(find_binary herdr-push)"
@@ -373,6 +389,24 @@ fi
 HERDR_RELAY_TOKEN="$RELAY_TOKEN"
 HERDR_RELAY="ws://127.0.0.1:$WS_PORT"
 [ -n "$HERDR_RELAY_TOKEN" ] && HERDR_RELAY="$HERDR_RELAY?token=$HERDR_RELAY_TOKEN"
+
+# --- Web push signing keys ---
+
+# The relay only ever reads HERDR_VAPID_*; nothing generated them, so every install had web push
+# fail with "VAPID key not configured on relay". Generated once and then carried across re-runs:
+# a new keypair silently invalidates every subscription a browser has already handed out.
+if [ -z "${HERDR_VAPID_PRIVATE:-}" ] || [ -z "${HERDR_VAPID_PUBLIC:-}" ]; then
+    echo ""
+    echo "Web push keys"
+    echo "-------------"
+    if VAPID_KEYS="$(generate_vapid_keys 2>/dev/null)" && [ -n "$VAPID_KEYS" ]; then
+        HERDR_VAPID_PRIVATE="$(printf '%s\n' "$VAPID_KEYS" | sed -n 1p)"
+        HERDR_VAPID_PUBLIC="$(printf '%s\n' "$VAPID_KEYS" | sed -n 2p)"
+        echo "  [ok] Generated VAPID keypair"
+    else
+        echo "  Warning: could not generate a VAPID keypair. Web push stays off; the rest works."
+    fi
+fi
 
 # --- Telegram configuration ---
 
@@ -905,6 +939,8 @@ HERDR_RELAY_TOKEN=${HERDR_RELAY_TOKEN:-}
 HERDR_TG_TOKEN=${HERDR_TG_TOKEN:-}
 HERDR_TG_CHAT_ID=${HERDR_TG_CHAT_ID:-}
 HERDR_RELAY=$HERDR_RELAY
+HERDR_VAPID_PUBLIC=${HERDR_VAPID_PUBLIC:-}
+HERDR_VAPID_PRIVATE=${HERDR_VAPID_PRIVATE:-}
 EOF
 )
 chmod 600 "$SECRETS_TMP"

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -297,6 +297,13 @@ function scheduleReconnect() {
   reconnectTimer = setTimeout(() => { reconnectTimer = null; connect(); }, 3000);
 }
 
+// A backgrounded tab gets frozen on Android: the reconnect timer above never fires, so the page
+// comes back reading offline until something pokes it. Poke it on the way in, but only when the
+// socket is actually gone -- CONNECTING and OPEN are left alone so this cannot cut a live one.
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible' && (!ws || ws.readyState > WebSocket.OPEN)) connect();
+});
+
 function setStatus(s) {
   const dot = document.getElementById('statusDot');
   const label = document.getElementById('connLabel');


### PR DESCRIPTION
Five fixes found while setting `herdr-remote` up on a Mac mini and driving it from an Android phone. Each one blocked the phone path completely, and they're independent commits if you'd rather take a subset.

### Web push never worked on any install

The relay reads `HERDR_VAPID_PUBLIC` / `HERDR_VAPID_PRIVATE`, and nothing in the repo ever writes them. So **Enable Push** answers `VAPID key not configured on relay` on every fresh install — the feature is reachable only by someone who knows to hand-roll a P-256 keypair into `secrets.env`.

`install-service.sh` now generates one with `py-vapid` through the same `uv` the relay already runs under, so no new system dependency, and persists it next to the relay token. Deliberately kept across re-runs rather than regenerated: a new keypair silently invalidates every subscription browsers already hold.

### A PWA launch always 401s

Install the dashboard to a phone's home screen and every launch says `Invalid token`. The manifest's `start_url` is a bare `/`, so the launch carries no `?token=`, and `index.html` sits behind the token by design — the document fetch is refused before any JS runs, which is the only place the localStorage token could have been read from. The link works; the installed app never does.

An authenticated index load now sets the token as a cookie and the cookie is accepted as credentials. `HttpOnly` keeps it from page JS, `SameSite=Lax` keeps it off cross-site requests. No `Secure`, because the relay is also legitimately reached over http on loopback and there is no plaintext network path to sniff — a tunnel or `tailscale serve` terminates TLS and proxies over `127.0.0.1`.

Verified: `?token=` → 200 + cookie, cookie alone → 200, no credential → 401, wrong cookie → 401.

### The relay hangs up on phones that are fine

`serve()` takes the `websockets` default `ping_timeout=20`. Android dozes the radio of a backgrounded tab, the pong lands late, and the relay closes a healthy connection — on the phone this reads as the dashboard flipping to offline/connecting by itself. Ping interval stays at 20s since that's also what holds a proxied path open; only the deadline for answering moves.

### A frozen tab never reconnects

Android freezes a backgrounded tab, timers included, so the existing 3s reconnect never runs. Returning to the app leaves it sitting on offline until something else wakes it — the one moment someone is definitely watching is the one moment nothing retries. Now reconnects on `visibilitychange`, guarded on `readyState > OPEN` so a live or still-connecting socket is untouched.

### Re-running the installer can leave you with no relay

The port-conflict branch boots the launchd job out, then SIGTERMs a PID `bootout` already reaped. That `kill` returns non-zero, `set -e` is on, and the script exits right there — relay stopped, nothing installed, no error explaining why. The visible symptom is just the summary never printing, which is why it took two occurrences to spot.

---

Tested on macOS 26.3 with herdr 0.8.0, relay behind `tailscale serve`, dashboard installed as a PWA on Android with push confirmed delivered end to end (FCM `201`).

One thing I did **not** change, but is worth knowing: with the relay behind `tailscale serve`, a 10-minute probe measured the proxied WebSocket dropping about once per 5-10 minutes with `no close frame received or sent`, while a loopback control connection over the same window stayed up. It looks like the proxy rather than the relay, and the client reconnect covers it, so I left it alone.

https://claude.ai/code/session_01FwZYEYEMRatKesSZHzrrgZ
