### PR TITLE
fix(relay): stop re-notifying for a blocked pane whose TUI is animating

### DIFF
--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1782,14 +1782,25 @@ async def _poll_once():
                 )
                 previous = last_blocked_prompts.get(pid)
                 if previous != fingerprint:
-                    message["update"] = previous is not None and previous[0] == message["prompt_id"]
+                    # A blocked pane whose TUI animates (spinners, elapsed timers) repaints
+                    # its captured content every poll, so question_prompt_id -- and this
+                    # fingerprint -- churn even though the pane is sitting on one prompt. The
+                    # old `previous[0] == prompt_id` test then read every churn as a brand-new
+                    # prompt (update=False) and re-fired the notification. Any re-broadcast for
+                    # a pane still in the same blocked streak is an update: `previous` is
+                    # cleared the moment the pane leaves `blocked` (see the else branch), so
+                    # `previous is not None` means "already announced this block".
+                    message["update"] = previous is not None
                     last_blocked_prompts[pid] = fingerprint
                     await broadcast(message)
-                    await send_web_push(
-                        title=f"\U0001f411 {a['project']} blocked",
-                        body=content[:120],
-                        url=f"/?pane={pid}",
-                    )
+                    # Clients still need every re-broadcast (the prompt_id they must echo back
+                    # to approve moves with the content), but the notification is one-shot.
+                    if not message["update"]:
+                        await send_web_push(
+                            title=f"\U0001f411 {a['project']} blocked",
+                            body=content[:120],
+                            url=f"/?pane={pid}",
+                        )
                     if gen != POLL_GENERATION:
                         return
             else:

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -1991,6 +1991,74 @@ class RelayTerminalTitleTests(unittest.TestCase):
             self.assertEqual([a["title"] for a in agents], ["fix the poll", ""])
 
 
+class RelayPollBlockedDedupTests(unittest.IsolatedAsyncioTestCase):
+    BLOCKED_AGENT = {
+        "pane_id": "w1:p1",
+        "agent": "opencode",
+        "status": "blocked",
+        "cwd": "/w",
+        "project": "proj",
+        "host": "local",
+        "remote": None,
+    }
+
+    async def test_animated_blocked_pane_notifies_once_then_marks_resends_as_updates(self):
+        """A pane parked in `blocked` with an animated TUI (spinner/timer) churns
+        its content -- and therefore its prompt_id -- on every 2s poll. Clients
+        still get every re-broadcast (the prompt_id moves with the content), but
+        each carries update=True after the first so downstream notifiers suppress
+        it, and the web push fires only once."""
+        with loaded_relay() as relay:
+            frames = iter([
+                "Rate limit exceeded\n  Build spinner |",
+                "Rate limit exceeded\n  Build spinner /",
+                "Rate limit exceeded\n  Build spinner -",
+            ])
+            broadcasts = []
+
+            async def capture(message):
+                broadcasts.append(message)
+
+            with mock.patch.object(relay, "get_all_panes", return_value=([dict(self.BLOCKED_AGENT)], [])), \
+                 mock.patch.object(relay, "read_pane", side_effect=lambda *a, **k: next(frames)), \
+                 mock.patch.object(relay, "send_web_push", new=mock.AsyncMock()) as web_push, \
+                 mock.patch.object(relay, "broadcast", side_effect=capture):
+                await relay._poll_once()
+                await relay._poll_once()
+                await relay._poll_once()
+
+        blocked = [m for m in broadcasts if m.get("type") == "blocked"]
+        self.assertEqual(len(blocked), 3)
+        self.assertEqual([m["update"] for m in blocked], [False, True, True])
+        self.assertEqual(web_push.await_count, 1)
+
+    async def test_new_block_after_pane_clears_is_not_an_update(self):
+        """When a pane leaves `blocked` and later blocks again, the relay has
+        forgotten the earlier prompt, so the next notification is a fresh block."""
+        with loaded_relay() as relay:
+            statuses = iter(["blocked", "working", "blocked"])
+
+            def snapshot():
+                return ([{**self.BLOCKED_AGENT, "status": next(statuses)}], [])
+
+            broadcasts = []
+
+            async def capture(message):
+                broadcasts.append(message)
+
+            with mock.patch.object(relay, "get_all_panes", side_effect=snapshot), \
+                 mock.patch.object(relay, "read_pane", return_value="Approve this?"), \
+                 mock.patch.object(relay, "send_web_push", new=mock.AsyncMock()), \
+                 mock.patch.object(relay, "broadcast", side_effect=capture):
+                await relay._poll_once()
+                await relay._poll_once()
+                await relay._poll_once()
+
+        blocked = [m for m in broadcasts if m.get("type") == "blocked"]
+        self.assertEqual(len(blocked), 2)
+        self.assertEqual([m["update"] for m in blocked], [False, False])
+
+
 class RelaySubprocessConcurrencyTests(unittest.TestCase):
     def test_calls_to_the_same_remote_are_serialized(self):
         with loaded_relay() as relay:


### PR DESCRIPTION
## The problem

An agent that is `blocked` **and keeps repainting its terminal** makes the relay
re-send a full blocked notification on every poll. Left overnight, one such
agent produces thousands of Telegram messages and gets the bot flood‑limited.

Reproduced here with an `opencode` agent that hit an OpenRouter daily
rate‑limit and parked on a screen with an animated `Build · <model>` spinner:
~8500 Telegram messages in a night from three such panes, then
`telegram.error.RetryAfter` for hours.

### Why it happens

`_poll_once` classifies each `blocked` broadcast as either a fresh prompt
(notify) or an in‑place update (don't) with:

```python
message["update"] = previous is not None and previous[0] == message["prompt_id"]
```

`prompt_id` comes from `question_prompt_id(pane_id, content)`. When the pane
is **not** sitting on a parsed question, that is:

```python
normalized = " ".join(content.split())
return hashlib.sha256(f"{pane_id}\n{normalized}".encode("utf-8")).hexdigest()[:20]
```

— a hash of the **entire captured screen**. A spinner frame, an elapsed‑time
counter, a streaming banner… any of them changes `content`, so `prompt_id`
and the dedup `fingerprint` churn on every 2 s poll even though the pane has
exactly one prompt on it.

Each churn then:

1. satisfies `previous != fingerprint`, so the branch runs again;
2. has a **new** `prompt_id`, so `previous[0] == message["prompt_id"]` is
   `False` → `update = False`;
3. `broadcast(message)` goes out as a brand‑new block, `send_web_push(...)`
   fires again, and the Telegram bridge (which only skips messages flagged
   `update`) posts a fresh notification **with a fresh approval keyboard**.

`POLL_INTERVAL` is 2 s, so that is ~30 notifications per minute per stuck pane.

## The fix

Once a pane has been announced for its current blocked streak, treat every
re‑broadcast as an update:

```python
message["update"] = previous is not None
```

`last_blocked_prompts[pid]` is cleared the moment the pane leaves `blocked`
(the `else` branch), so `previous is not None` means precisely *"already
announced this block"*. The re‑broadcast itself is **kept** — clients need the
current `prompt_id` to echo back when they approve — but `send_web_push` is now
gated on the same first‑time‑only condition, since the collapse‑topic push has
nothing new to say on a re‑broadcast either.

### Trade‑off

A second, genuinely different prompt on a pane that **never leaves `blocked`
between the two** (no non‑blocked poll in the ~2 s gap) now arrives flagged
`update` and is not re‑notified. In practice the agent passes through
`working` while it consumes the first answer, the poll catches it, and the
next prompt notifies normally. If you'd rather not accept even that narrow
gap, an alternative is to strip volatile runs (digits, ANSI) before hashing in
`question_prompt_id` — happy to go that route instead.

## Tests

New `RelayPollBlockedDedupTests` in `tests/test_herdr_relay.py`:

- **animated pane** — three polls with churning content produce three
  broadcasts but `update` flags `[False, True, True]` and exactly one web push;
- **clears and re‑blocks** — a pane that goes `blocked → working → blocked`
  produces two separate fresh notifications.

`sh tests/run.sh` passes (the one unrelated failure here is `demo worker
parses` — no `node` on my box).

## Notes

- Branched from `main` (`68aaf1c`).
- Not touched, but adjacent: the response‑validation path
  (`question_prompt_id(pane_id, content) != msg.get("prompt_id")`) has the same
  fragility — an approval for an animated pane can be rejected as "prompt
  changed" because the screen moved between the broadcast and the reply. Out of
  scope here; flagging it in case it's on your radar.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
