### PR TITLE
Answer Claude Code approval menus from Telegram

### DIFF
--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1645,6 +1645,19 @@ def custom_editor_active(text):
 def question_prompt_id(pane_id, content):
     question = detect_question(content)
     if not question:
+        numbered = detect_numbered_options(content)
+        if numbered:
+            # A Claude approval/question menu sits inside a live status region -- an elapsed
+            # timer ("· 5s"), a token counter ("↑ 21 tokens"), a "Unfurling…" spinner, a usage-
+            # percent line -- that repaints every second while the menu itself does not change.
+            # Hashing the whole screen (the else branch) made the id churn once or twice per
+            # poll, so the prompt_id a client echoed back with its tap was already stale and the
+            # tap was refused as "prompt changed". Hash only the option labels: stable while
+            # the same menu is up, and still different for a menu with different options (the
+            # stale-prompt guard the id exists for). The omp branch below hashes its labels for
+            # the same reason.
+            signature = json.dumps({"pane_id": pane_id, "numbered": numbered}, sort_keys=True)
+            return hashlib.sha256(signature.encode("utf-8")).hexdigest()[:20]
         normalized = " ".join(content.split())
         return hashlib.sha256(f"{pane_id}\n{normalized}".encode("utf-8")).hexdigest()[:20]
     labels = [
@@ -2466,8 +2479,13 @@ async def handle_client(ws):
                 remote = pane_remote_map.get(pane_id)
                 content = await asyncio.to_thread(read_pane, pane_id, remote=remote)
                 menu = detect_approval_options(content) or detect_numbered_options(content)
-                if menu and any(key.isdigit() for key in keys):
-                    if question_prompt_id(pane_id, content) != msg.get("prompt_id", ""):
+                digits = any(key.isdigit() for key in keys)
+                if digits and (menu or msg.get("prompt_id") is not None):
+                    # A digit aimed at a menu must echo the prompt_id of the menu on screen.
+                    # If the client echoes one but no menu is visible any more, the menu was
+                    # already answered (typically by the first of two taps) and the digit
+                    # would land in the agent's input line instead -- refuse it the same way.
+                    if not menu or question_prompt_id(pane_id, content) != msg.get("prompt_id", ""):
                         await ws.send(json.dumps(command_error("prompt changed; refresh and try again")))
                         continue
                 log.info("Keys from %s (%s): pane=%s keys=%s", ip, device, pane_id, keys)

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1545,6 +1545,84 @@ def detect_approval_options(text):
     return []
 
 
+# Claude Code draws every approval and question as a numbered menu:
+#
+#    Do you want to proceed?
+#    ❯ 1. Yes
+#      2. Yes, and always allow access to /tmp from this project
+#      3. Yes, and switch to auto mode · auto mode handles these prompts
+#         for you
+#      4. No
+#    Esc to cancel · Tab to amend
+#
+# None of that says "yes, single permission", so detect_approval_options() above finds nothing
+# and every client shows a blocked Claude with no way to answer it. The menu is driven by real
+# number keys -- exactly what `send_keys` delivers -- so the labels are harvested here and
+# clients bind key N to option N.
+NUMBERED_OPTION_RE = re.compile(r"^(\s*(?:[❯>›»▶]\s*)?)(\d{1,2})[.)]\s+(\S.*?)\s*$")
+
+
+def detect_numbered_options(text):
+    """Labels of the last `1.`..`N.` menu on screen, in order, or [] when there is none.
+
+    A run starts at `1.`, must count up by one per line, and ends at the first line that is
+    neither the next number nor a deeper-indented continuation of the previous label (Claude
+    wraps long options onto indented lines; the dialog's own footer is indented less than the
+    numbers, so it terminates the run instead of being glued onto the last option). Two options
+    are the minimum, so a stray "1." in ordinary output is not mistaken for a menu. The LAST
+    complete run wins because a blocked pane draws its menu under whatever the agent printed
+    earlier, and that earlier output may itself contain a numbered list.
+    """
+    best = []
+    current = []
+    number_col = None
+    for line in text.splitlines():
+        match = NUMBERED_OPTION_RE.match(line)
+        if match:
+            number = int(match.group(2))
+            if number == 1:
+                current = [match.group(3)]
+                number_col = len(match.group(1))
+            elif current and number == len(current) + 1:
+                current.append(match.group(3))
+            else:
+                current = []
+                number_col = None
+            if len(current) >= 2:
+                best = list(current)
+            continue
+        stripped = line.strip()
+        if not stripped:
+            continue
+        indent = len(line) - len(line.lstrip())
+        if current and number_col is not None and indent > number_col:
+            current[-1] = f"{current[-1]} {stripped}"
+            if len(current) >= 2:
+                best = list(current)
+            continue
+        current = []
+        number_col = None
+    return best
+
+
+def numbered_option_key(text, options):
+    """The key that picks `text` from a numbered menu, or None when nothing matches.
+
+    Accepts the bare number ("2") or an option's label, case-insensitively, either in full or
+    up to its first comma -- so "yes" picks "Yes" and "no" picks "No" even when the fuller
+    labels are "Yes, and always allow ..." / "No, and tell Claude ...". The first match wins.
+    """
+    if not options:
+        return None
+    if text.isdigit() and 1 <= int(text) <= len(options):
+        return text
+    wanted = text.casefold()
+    for index, label in enumerate(options, start=1):
+        if wanted in {label.casefold(), label.split(",")[0].strip().casefold()}:
+            return str(index)
+    return None
+
+
 def detect_options(text):
     approval_options = detect_approval_options(text)
     if approval_options:
@@ -1594,6 +1672,10 @@ def prompt_matches(pane_id, prompt_id, remote=None):
 def blocked_message(pane_id, agent, project, host, content):
     question = detect_question(content) if agent == "omp" else None
     options = detect_options(content) if agent == "omp" else detect_approval_options(content)
+    # omp has its own question grammar; everything else falls back to a Claude-style 1..N menu.
+    numbered = agent != "omp" and not options and detect_numbered_options(content)
+    if numbered:
+        options = numbered
     return {
         "type": "blocked",
         "pane_id": pane_id,
@@ -1609,7 +1691,7 @@ def blocked_message(pane_id, agent, project, host, content):
             if option["multi"] and option["label"] != QUESTION_OTHER
             and "Done selecting" not in option["label"] and option["checked"]
         ] if question else [],
-        "interaction": "omp_question" if question else "prompt",
+        "interaction": "omp_question" if question else ("numbered" if numbered else "prompt"),
         "multi": bool(question and question["multi"]),
         "update": False,
     }
@@ -2202,11 +2284,21 @@ async def handle_client(ws):
                     if await asyncio.to_thread(pane_is_omp, pane_id, remote=remote)
                     else None
                 )
+                menu_key = None if question else numbered_option_key(
+                    text, detect_numbered_options(content)
+                )
                 log.info("Response from %s (%s): pane=%s text=%r", ip, device, pane_id, text)
                 audit("respond", ip, device, pane_id, f"text={text!r}")
                 if question:
                     delivered = await asyncio.to_thread(
                         respond_to_question, pane_id, text, question, remote=remote
+                    )
+                elif menu_key and not custom_editor_active(content):
+                    # A numbered menu takes a real key press. Pasting "1" (or "no") through the
+                    # send-text branch below would not select anything -- the trailing Enter
+                    # lands on whichever option is highlighted, which is "Yes".
+                    delivered = await asyncio.to_thread(
+                        _mutate_herdr, "pane", "send-keys", pane_id, menu_key, remote=remote
                     )
                 elif custom_editor_active(content) or text.lower() in SAFE_RESPONSES:
                     delivered = await asyncio.to_thread(
@@ -2373,7 +2465,8 @@ async def handle_client(ws):
                     continue
                 remote = pane_remote_map.get(pane_id)
                 content = await asyncio.to_thread(read_pane, pane_id, remote=remote)
-                if detect_approval_options(content) and any(key.isdigit() for key in keys):
+                menu = detect_approval_options(content) or detect_numbered_options(content)
+                if menu and any(key.isdigit() for key in keys):
                     if question_prompt_id(pane_id, content) != msg.get("prompt_id", ""):
                         await ws.send(json.dumps(command_error("prompt changed; refresh and try again")))
                         continue

--- a/relay/herdr_telegram.py
+++ b/relay/herdr_telegram.py
@@ -44,6 +44,7 @@ if not TOKEN:
 pending: OrderedDict[tuple[int, int], str] = OrderedDict()  # (chat_id, message_id) -> pane_id
 approval_tokens: dict[str, str] = {}  # pane_id -> current blocked-notification generation
 blocked_prompt_ids: dict[str, str] = {}  # pane_id -> current relay prompt identity
+approval_in_flight: set[str] = set()  # panes whose tapped choice is still being delivered
 agents: list[dict] = []       # current agent list from relay
 prev_statuses: dict[str, str] = {}  # pane_id -> last known status
 relay_connected = False
@@ -596,6 +597,44 @@ async def cmd_digest(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
 # --- Callback handler (buttons) ---
 
+async def deliver_choice(query, pane_id: str, label: str, deliver) -> bool:
+    """Acknowledge a tapped choice at once, deliver it exactly once, then confirm or roll back.
+
+    Telegram shows nothing for a tap until the bot edits or replies, and the relay plus two
+    Telegram round trips take a second or two -- long enough to tap again. A second tap used
+    to reach the relay while the first was in flight; by then the dialog had closed, so the
+    duplicate "1" was typed into the agent's input line instead. So: the buttons come off the
+    message BEFORE delivery (that is the feedback), a second tap during delivery is refused,
+    and a failed delivery puts the buttons back so the user can retry. Returns True on
+    success.
+    """
+    if pane_id in approval_in_flight:
+        await query.message.reply_text(
+            f"Still sending your previous choice -- wait for \"Sent\" before tapping again."
+        )
+        return False
+    approval_in_flight.add(pane_id)
+    previous_markup = query.message.reply_markup
+    try:
+        await query.edit_message_reply_markup(reply_markup=None)
+    except Exception:
+        pass
+    try:
+        await deliver()
+        approval_tokens.pop(pane_id, None)
+    except Exception as e:
+        try:
+            await query.edit_message_reply_markup(reply_markup=previous_markup)
+        except Exception:
+            pass
+        await query.message.reply_text(f"Failed: {scrub(e)}")
+        return False
+    finally:
+        approval_in_flight.discard(pane_id)
+    await query.message.reply_text(f"Sent: {label}")
+    return True
+
+
 async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     """Handle inline keyboard button presses."""
     query = update.callback_query
@@ -715,14 +754,9 @@ async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         if not label:
             await query.message.reply_text("That approval action is no longer supported. Use the latest notification.")
             return
-        try:
-            await send_to_relay(pane_id, label, prompt_id=prompt_id)
-        except Exception as e:
-            await query.message.reply_text(f"Failed: {scrub(e)}")
-            return
-        approval_tokens.pop(pane_id, None)
-        await query.edit_message_reply_markup(reply_markup=None)
-        await query.message.reply_text(f"Sent: {label}")
+        await deliver_choice(
+            query, pane_id, label, lambda: send_to_relay(pane_id, label, prompt_id=prompt_id)
+        )
         return
 
     # Confirm a blocked agent's prompt by pressing the option number.
@@ -744,14 +778,9 @@ async def handle_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
                         label = btn.text
                 except (ValueError, TypeError):
                     pass
-    try:
-        await send_keys_to_relay(pane_id, [key], prompt_id=prompt_id)
-    except Exception as e:
-        await query.message.reply_text(f"Failed: {scrub(e)}")
-        return
-    approval_tokens.pop(pane_id, None)
-    await query.edit_message_reply_markup(reply_markup=None)
-    await query.message.reply_text(f"Sent: {label}")
+    await deliver_choice(
+        query, pane_id, label, lambda: send_keys_to_relay(pane_id, [key], prompt_id=prompt_id)
+    )
 
 
 # --- Free text reply ---
@@ -911,6 +940,10 @@ async def notify_blocked(
 
 async def notify_blocked_safely(app: Application, msg: dict):
     if msg.get("update"):
+        # Same blocked streak, re-hashed content: the prompt_id the relay will demand has
+        # moved, so keep ours current or every tap after the redraw fails as "prompt changed".
+        if msg.get("pane_id") in blocked_prompt_ids and msg.get("prompt_id"):
+            blocked_prompt_ids[msg["pane_id"]] = msg["prompt_id"]
         return
     try:
         await notify_blocked(

--- a/relay/herdr_telegram.py
+++ b/relay/herdr_telegram.py
@@ -799,6 +799,22 @@ SUBAGENT_BUTTONS = [
 ]
 
 
+NUMBERED_LABEL_MAX = 40
+
+
+def numbered_button_label(number: int, option: str) -> str:
+    """Button text for option N of a Claude-style numbered menu.
+
+    The number is kept because it is literally the key the button presses. Claude appends
+    hints after " · " ("switch to auto mode · auto mode handles these prompts for you"); the
+    hint does not fit a phone-width button, the choice does.
+    """
+    text = f"{number}. {option.split(' · ')[0].strip()}"
+    if len(text) > NUMBERED_LABEL_MAX:
+        text = text[:NUMBERED_LABEL_MAX - 1] + "…"
+    return text
+
+
 def make_keyboard(
     pane_id: str,
     options: list[str] | None,
@@ -809,6 +825,9 @@ def make_keyboard(
         return interaction_keyboard(pane_id)
     if interaction == "omp_question":
         buttons = [(opt, opt) for opt in options]
+    elif interaction == "numbered":
+        # Claude Code's 1..N menu: one button per option, pressing that option's number.
+        buttons = [(numbered_button_label(i, opt), opt) for i, opt in enumerate(options, start=1)]
     elif "trust" in " ".join(options).lower():
         buttons = TOOL_BUTTONS
     elif "approve all" in " ".join(options).lower():

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -2976,5 +2976,85 @@ class RelaySshMultiplexingTests(unittest.TestCase):
             self.assertEqual(args[:4], ["-o", "ConnectTimeout=5", "-o", "BatchMode=yes"])
 
 
+
+CLAUDE_MENU = """\
+● Creating empty test file
+  ⎿  $ touch /tmp/herdr-perm-test.txt
+────────────────────────────────────────────────────────────────────
+ Bash command
+   touch /tmp/herdr-perm-test.txt
+   Create empty test file
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and always allow access to /tmp from this project
+   3. Yes, and switch to auto mode · auto mode handles these prompts
+      for you
+   4. No
+ Esc to cancel · Tab to amend
+"""
+
+
+class ClaudeNumberedMenuTests(unittest.TestCase):
+    """Claude Code approval/question menus carry no Codex wording; they are 1..N key menus."""
+
+    def test_detects_menu_and_joins_wrapped_option(self):
+        with loaded_relay() as relay:
+            self.assertEqual(relay.detect_numbered_options(CLAUDE_MENU), [
+                "Yes",
+                "Yes, and always allow access to /tmp from this project",
+                "Yes, and switch to auto mode · auto mode handles these prompts for you",
+                "No",
+            ])
+
+    def test_footer_is_not_glued_onto_last_option(self):
+        with loaded_relay() as relay:
+            self.assertEqual(relay.detect_numbered_options(CLAUDE_MENU)[-1], "No")
+
+    def test_single_item_broken_sequence_and_plain_text_are_not_menus(self):
+        with loaded_relay() as relay:
+            self.assertEqual(relay.detect_numbered_options("1. only one\n Esc to cancel"), [])
+            self.assertEqual(relay.detect_numbered_options("1. a\n3. c"), [])
+            self.assertEqual(relay.detect_numbered_options("plain output\nno menu here"), [])
+
+    def test_earlier_numbered_list_in_output_does_not_shadow_the_menu(self):
+        screen = "Steps:\n1. clone\n2. build\n3. run\n\n" + CLAUDE_MENU
+        with loaded_relay() as relay:
+            options = relay.detect_numbered_options(screen)
+            self.assertEqual(len(options), 4)
+            self.assertEqual(options[0], "Yes")
+
+    def test_option_key_accepts_number_or_label(self):
+        with loaded_relay() as relay:
+            options = relay.detect_numbered_options(CLAUDE_MENU)
+            self.assertEqual(relay.numbered_option_key("1", options), "1")
+            self.assertEqual(relay.numbered_option_key("4", options), "4")
+            self.assertEqual(relay.numbered_option_key("yes", options), "1")
+            self.assertEqual(relay.numbered_option_key("No", options), "4")
+            self.assertIsNone(relay.numbered_option_key("5", options))
+            self.assertIsNone(relay.numbered_option_key("0", options))
+            self.assertIsNone(relay.numbered_option_key("maybe", options))
+            self.assertIsNone(relay.numbered_option_key("1", []))
+
+    def test_blocked_message_marks_claude_menu_as_numbered(self):
+        with loaded_relay() as relay:
+            message = relay.blocked_message("pane-1", "claude", "project", "local", CLAUDE_MENU)
+            self.assertEqual(message["interaction"], "numbered")
+            self.assertEqual(len(message["options"]), 4)
+            self.assertEqual(message["options"][3], "No")
+            self.assertEqual(message["multi_options"], [])
+
+    def test_codex_wording_still_wins_over_numbered_fallback(self):
+        screen = "1. yes, single permission\n2. trust, always allow\n3. no (tab to edit)"
+        with loaded_relay() as relay:
+            message = relay.blocked_message("pane-1", "codex", "project", "local", screen)
+            self.assertEqual(message["interaction"], "prompt")
+            self.assertEqual(message["options"], relay.TOOL_OPTIONS)
+
+    def test_omp_never_falls_back_to_numbered(self):
+        with loaded_relay() as relay:
+            message = relay.blocked_message("pane-1", "omp", "project", "local", CLAUDE_MENU)
+            self.assertNotEqual(message["interaction"], "numbered")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -3056,5 +3056,104 @@ class ClaudeNumberedMenuTests(unittest.TestCase):
             self.assertNotEqual(message["interaction"], "numbered")
 
 
+
+class AnswerKeyAfterMenuGoneTests(unittest.TestCase):
+    """A digit that echoes a prompt_id is an answer to that menu -- never plain typing."""
+
+    ANSWERED_SCREEN = "● Done.\n✻ Crunched for 4s\n❯ "
+
+    def _send_keys(self, relay, keys, prompt_id=None, screen=CLAUDE_MENU):
+        pane_id = "pane-1"
+        relay.known_panes.add(pane_id)
+        message = {"type": "send_keys", "pane_id": pane_id, "keys": keys}
+        if prompt_id is not None:
+            message["prompt_id"] = prompt_id
+        ws = _FakeWebSocket([json.dumps(message)])
+        with mock.patch.object(relay, "send_current_snapshot", new=mock.AsyncMock()), \
+             mock.patch.object(relay, "read_pane", return_value=screen), \
+             mock.patch.object(relay, "run_herdr_result") as run:
+            run.return_value.returncode = 0
+            asyncio.run(relay.handle_client(ws))
+        return run, json.loads(ws.sent[-1])
+
+    def test_answer_key_is_refused_once_the_menu_is_gone(self):
+        with loaded_relay() as relay:
+            stale = relay.question_prompt_id("pane-1", CLAUDE_MENU)
+            run, reply = self._send_keys(relay, ["1"], prompt_id=stale, screen=self.ANSWERED_SCREEN)
+            run.assert_not_called()
+            self.assertIn("prompt changed", reply["message"])
+
+    def test_answer_key_is_delivered_while_the_menu_matches(self):
+        with loaded_relay() as relay:
+            current = relay.question_prompt_id("pane-1", CLAUDE_MENU)
+            run, reply = self._send_keys(relay, ["4"], prompt_id=current)
+            self.assertEqual(run.call_args[0][:4], ("pane", "send-keys", "pane-1", "4"))
+            self.assertTrue(reply.get("ok"))
+
+    def test_menu_on_screen_still_demands_a_prompt_echo(self):
+        with loaded_relay() as relay:
+            run, reply = self._send_keys(relay, ["1"])
+            run.assert_not_called()
+            self.assertIn("prompt changed", reply["message"])
+
+    def test_plain_digit_without_prompt_echo_types_into_an_idle_agent(self):
+        with loaded_relay() as relay:
+            run, reply = self._send_keys(relay, ["1"], screen=self.ANSWERED_SCREEN)
+            self.assertEqual(run.call_args[0][:4], ("pane", "send-keys", "pane-1", "1"))
+            self.assertTrue(reply.get("ok"))
+
+
+class NumberedMenuPromptIdStabilityTests(unittest.TestCase):
+    """The prompt_id of a Claude menu must survive the live status region churning around it."""
+
+    MENU = "\n".join([
+        " Bash command",
+        "   touch /tmp/herdr-diff.txt",
+        "   Create empty file in /tmp",
+        " Do you want to proceed?",
+        " \u276f 1. Yes",
+        "   2. Yes, and always allow access to /tmp from this project",
+        "   3. Yes, and switch to auto mode",
+        "   4. No",
+        " Esc to cancel \u00b7 Tab to amend",
+    ])
+
+    def _with_status(self, tail):
+        # the volatile region herdr also captures a few lines above/below the menu
+        return "\u2733 Working\u2026 (%s)\n" % tail + self.MENU
+
+    def test_id_is_identical_as_the_timer_ticks(self):
+        with loaded_relay() as relay:
+            a = relay.question_prompt_id("pane-1", self._with_status("3s \u00b7 \u2191 21 tokens"))
+            b = relay.question_prompt_id("pane-1", self._with_status("6s \u00b7 \u2191 48 tokens"))
+            c = relay.question_prompt_id("pane-1", self._with_status("11s \u00b7 \u2191 90 tokens"))
+            self.assertEqual(a, b)
+            self.assertEqual(b, c)
+
+    def test_id_differs_for_a_menu_with_different_options(self):
+        other = self.MENU.replace(
+            "2. Yes, and always allow access to /tmp from this project",
+            "2. Yes, and always allow access to /etc from this project",
+        )
+        with loaded_relay() as relay:
+            self.assertNotEqual(
+                relay.question_prompt_id("pane-1", self.MENU),
+                relay.question_prompt_id("pane-1", other),
+            )
+
+    def test_id_is_pane_scoped(self):
+        with loaded_relay() as relay:
+            self.assertNotEqual(
+                relay.question_prompt_id("pane-1", self.MENU),
+                relay.question_prompt_id("pane-2", self.MENU),
+            )
+
+    def test_non_menu_screen_still_hashes_full_content(self):
+        with loaded_relay() as relay:
+            a = relay.question_prompt_id("pane-1", "just some output\nworking 3s")
+            b = relay.question_prompt_id("pane-1", "just some output\nworking 6s")
+            self.assertNotEqual(a, b)  # no menu -> old full-content behaviour, still churns
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -745,5 +745,40 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("1-10000", message.replies[0][0])
 
 
+
+class NumberedMenuKeyboardTests(unittest.TestCase):
+    """A Claude-style numbered menu becomes one button per option, each pressing its number."""
+
+    OPTIONS = [
+        "Yes",
+        "Yes, and always allow access to /tmp from this project",
+        "Yes, and switch to auto mode · auto mode handles these prompts for you",
+        "No",
+    ]
+
+    def test_buttons_press_their_option_number(self):
+        markup = tg.make_keyboard("pane-1", self.OPTIONS, interaction="numbered")
+        rows = markup.inline_keyboard
+        self.assertEqual(len(rows), 5)  # four options + "Open output & reply"
+        keys = [json.loads(row[0].callback_data)["k"] for row in rows[:4]]
+        self.assertEqual(keys, ["1", "2", "3", "4"])
+        self.assertEqual(rows[4][0].text, "Open output & reply")
+
+    def test_labels_keep_number_drop_hint_and_fit_a_phone(self):
+        markup = tg.make_keyboard("pane-1", self.OPTIONS, interaction="numbered")
+        labels = [row[0].text for row in markup.inline_keyboard[:4]]
+        self.assertEqual(labels[0], "1. Yes")
+        self.assertEqual(labels[3], "4. No")
+        self.assertTrue(labels[2].startswith("3. Yes, and switch to auto mode"))
+        self.assertNotIn("·", labels[2])
+        self.assertTrue(all(len(label) <= tg.NUMBERED_LABEL_MAX for label in labels))
+        self.assertTrue(labels[1].endswith("…"))
+
+    def test_plain_prompt_without_numbered_interaction_is_unchanged(self):
+        markup = tg.make_keyboard("pane-1", ["Yes", "No"])
+        labels = [row[0].text for row in markup.inline_keyboard[:2]]
+        self.assertEqual(labels, ["Yes", "No"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -399,7 +399,9 @@ class TelegramDashboardTests(unittest.IsolatedAsyncioTestCase):
             await tg.handle_callback(make_update(callback=callback), SimpleNamespace())
 
         self.assertIn("failed", callback.message.replies[0][0].lower())
-        self.assertEqual(callback.edit_calls, 0)
+        # Buttons come off on the tap and go back on failure: two edits, original markup restored.
+        self.assertEqual(callback.edit_calls, 2)
+        self.assertIs(callback.edited_markup, markup)
         self.assertIn("w0:p1", tg.approval_tokens)
 
     async def test_approval_sends_key_and_removes_controls_on_success(self):
@@ -778,6 +780,97 @@ class NumberedMenuKeyboardTests(unittest.TestCase):
         markup = tg.make_keyboard("pane-1", ["Yes", "No"])
         labels = [row[0].text for row in markup.inline_keyboard[:2]]
         self.assertEqual(labels, ["Yes", "No"])
+
+
+
+class ApprovalDoubleTapTests(unittest.IsolatedAsyncioTestCase):
+    """A tap is acknowledged at once, delivered once, and never duplicated by a second tap."""
+
+    def setUp(self):
+        self.old_chat_id = tg.CHAT_ID
+        tg.CHAT_ID = "42"
+        tg.relay_connected = True
+        tg.agents = make_agents(1, status="blocked")
+        tg.pending.clear()
+        tg.approval_tokens.clear()
+        tg.blocked_prompt_ids.clear()
+        tg.approval_in_flight.clear()
+
+    def tearDown(self):
+        tg.CHAT_ID = self.old_chat_id
+        tg.approval_in_flight.clear()
+
+    def _tap(self, markup):
+        callback = FakeCallback(markup.inline_keyboard[0][0].callback_data)
+        callback.message.reply_markup = markup
+        return callback
+
+    async def test_buttons_come_off_before_delivery(self):
+        callback = self._tap(make_active_approval_keyboard("w0:p1", ["yes", "no"]))
+        seen = {}
+
+        async def deliver(*args, **kwargs):
+            seen["edits"] = callback.edit_calls
+            seen["markup"] = callback.edited_markup
+
+        with patch.object(tg, "send_keys_to_relay", AsyncMock(side_effect=deliver)):
+            await tg.handle_callback(make_update(callback=callback), SimpleNamespace())
+
+        self.assertEqual(seen["edits"], 1)
+        self.assertIsNone(seen["markup"])
+        self.assertEqual(callback.edit_calls, 1)
+        self.assertIn("Sent: yes", callback.message.replies[0][0])
+        self.assertNotIn("w0:p1", tg.approval_tokens)
+        self.assertNotIn("w0:p1", tg.approval_in_flight)
+
+    async def test_second_tap_during_delivery_is_refused_not_resent(self):
+        markup = make_active_approval_keyboard("w0:p1", ["yes", "no"])
+        first_tap, second_tap = self._tap(markup), self._tap(markup)
+        gate = asyncio.Event()
+
+        async def deliver(*args, **kwargs):
+            await gate.wait()
+
+        send_keys = AsyncMock(side_effect=deliver)
+        with patch.object(tg, "send_keys_to_relay", send_keys):
+            first = asyncio.create_task(
+                tg.handle_callback(make_update(callback=first_tap), SimpleNamespace())
+            )
+            await asyncio.sleep(0)  # first tap reaches the relay call and parks on the gate
+            await tg.handle_callback(make_update(callback=second_tap), SimpleNamespace())
+            gate.set()
+            await first
+
+        self.assertEqual(send_keys.await_count, 1)
+        self.assertIn("wait", second_tap.message.replies[0][0].lower())
+        self.assertEqual(second_tap.edit_calls, 0)
+        self.assertIn("Sent: yes", first_tap.message.replies[0][0])
+        self.assertNotIn("w0:p1", tg.approval_in_flight)
+
+    async def test_tap_after_success_hits_the_older_prompt_guard(self):
+        markup = make_active_approval_keyboard("w0:p1", ["yes", "no"])
+        first_tap, second_tap = self._tap(markup), self._tap(markup)
+        with patch.object(tg, "send_keys_to_relay", AsyncMock()) as send_keys:
+            await tg.handle_callback(make_update(callback=first_tap), SimpleNamespace())
+            await tg.handle_callback(make_update(callback=second_tap), SimpleNamespace())
+
+        self.assertEqual(send_keys.await_count, 1)
+        self.assertIn("older prompt", second_tap.message.replies[0][0].lower())
+
+    async def test_blocked_update_refreshes_prompt_id_without_renotifying(self):
+        tg.blocked_prompt_ids["w0:p1"] = "old"
+        app = SimpleNamespace(bot=FakeBot())
+
+        await tg.notify_blocked_safely(
+            app, {"type": "blocked", "pane_id": "w0:p1", "prompt_id": "new", "update": True}
+        )
+        await tg.notify_blocked_safely(
+            app, {"type": "blocked", "pane_id": "w0:p2", "prompt_id": "x", "update": True}
+        )
+
+        self.assertEqual(tg.blocked_prompt_ids["w0:p1"], "new")
+        self.assertNotIn("w0:p2", tg.blocked_prompt_ids)  # never announced: nothing to refresh
+        self.assertEqual(app.bot.sent, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Claude Code renders every permission/approval prompt as a numbered menu:

```
Do you want to proceed?
❯ 1. Yes
  2. Yes, and always allow access to /tmp from this project
  3. Yes, and switch to auto mode
  4. No
```

None of that contains the `yes, single permission` wording `detect_approval_options`
looks for, so a blocked Claude agent reaches Telegram with **no option buttons**, and a
free-text reply is rejected with `free-text response requires a detected question`. There
is currently no way to answer a Claude permission prompt from the phone (only `Open output
& reply`, which cannot drive the dialog).

## Fix

**Detect the menu (relay).** `detect_numbered_options()` reads the last `1..N` menu on
screen: it joins Claude's wrapped option lines, stops before the dialog footer, and prefers
the last complete run so an earlier numbered list in the output does not shadow the live
menu. `blocked_message` now reports `interaction="numbered"` with the option labels; omp and
Codex detection are untouched and still win when their wording is present.

**Buttons that press real keys (telegram).** `interaction="numbered"` renders one inline
button per option (`1. Yes` … `4. No`), each sending that option's number through
`send_keys`. A bare-number or `yes`/`no` free-text reply is also accepted. Pasting a digit
plus Enter would not work — Claude selects the highlighted default on Enter — so the number
is delivered as a real key press.

**Keep the prompt_id stable (relay).** `question_prompt_id` hashed the whole screen for
non-omp agents, but a Claude menu sits inside a live status region (elapsed timer, token
counter, `Unfurling…`, usage-percent line) that repaints every second. A visually static
menu produced two different ids within eight seconds, so the id a client echoed back with its
tap was already stale and the tap was refused as `prompt changed`. The numbered-menu id now
hashes only the option labels — stable while the menu is up, still distinct when the options
differ — mirroring the existing omp branch.

**Debounce the tap (telegram + relay).** Telegram shows nothing until the bot edits/replies,
and the round trip takes a second or two, so users tap again. The second tap used to reach
the relay after the first had closed the menu, dropping a stray digit into the agent's input
line. The bot now removes the buttons on the tap as immediate feedback, refuses a second tap
while the first is in flight, and restores the buttons on failure; the relay refuses a digit
that echoes a prompt_id once no menu is on screen.

## Testing

- New unit tests for menu detection (wrapped options, footer boundary, shadowing list,
  key mapping), prompt_id stability across status-line churn, the numbered keyboard, the
  double-tap guard, and the answer-key-after-menu-gone guard.
- Full suite: `521 passed`.
- Verified live against herdr 0.9.0 + Claude Code v2.1.267: a real Bash permission prompt
  reaches Telegram as `interaction="numbered"` with four buttons, and a single tap selects
  the option.

## Compatibility

Codex and omp prompts take exactly the same paths as before; the numbered menu is a fallback
that only engages for a non-omp agent when no existing wording matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
