### PR TITLE
Show the agent's name instead of the pane id

### DIFF
--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -800,6 +800,34 @@ def get_workspace_labels(remote=None):
         return {}
 
 
+def get_agent_names(remote=None):
+    """Map pane_id to the agent's own name in herdr ("mfc-exec", "dre-rev-1").
+
+    This is a second CLI call on a hot path, which the module otherwise avoids -- but the name
+    lives nowhere else. `pane list` carries the harness kind (`agent: "claude"`) and the pane's
+    own label, never the agent's name, so an agent started as `mfc-exec` reaches every client as
+    an empty label and is rendered as `w5:pH`.
+
+    It also makes `rename_agent` mean something. That handler shells out to `herdr agent rename`,
+    which sets exactly this field -- so before this map existed, renaming from the app wrote a
+    name that no client could ever read back.
+
+    Shaped like get_workspace_labels() and called on the same condition (only when there are
+    panes), so an idle host adds no round trips.
+    """
+    raw = run_herdr("agent", "list", remote=remote)
+    try:
+        data = json.loads(raw)
+        agents = data.get("result", {}).get("agents", [])
+        return {
+            a["pane_id"]: a["name"]
+            for a in agents
+            if a.get("pane_id") and a.get("name")
+        }
+    except (json.JSONDecodeError, KeyError):
+        return {}
+
+
 def activity_title(title, agent):
     """The terminal title, but only when it carries something the cwd does not.
 
@@ -893,6 +921,7 @@ def list_panes_from_host(remote=None):
         data = json.loads(raw)
         panes = data.get("result", {}).get("panes", [])
         workspace_labels = get_workspace_labels(remote=remote) if panes else {}
+        agent_names = get_agent_names(remote=remote) if panes else {}
     except (json.JSONDecodeError, KeyError):
         return [], []
 
@@ -916,7 +945,10 @@ def list_panes_from_host(remote=None):
         agents.append({
             "pane_id": p["pane_id"],
             "agent": p.get("agent", ""),
-            "label": p.get("label", ""),
+            # The agent's name first, the pane's label second. herdr keeps the two apart and
+            # `pane list` only carries the latter, which nothing sets by default -- so this field
+            # was empty for every agent on the host and clients fell back to the pane id.
+            "label": agent_names.get(p["pane_id"]) or p.get("label", ""),
             # Names the space, and stands in for panes that have no label.
             "workspace_label": workspace_labels.get(p.get("workspace_id", ""), ""),
             "status": p.get("agent_status", "unknown"),

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -440,12 +440,17 @@ class RelayActivityPersistenceTests(unittest.TestCase):
             "result": {"workspaces": [{"workspace_id": "w1", "label": label}]}
         })
 
+    @staticmethod
+    def _agent_list(name=None):
+        agents = [] if name is None else [{"pane_id": "w1:p1", "name": name}]
+        return json.dumps({"result": {"agents": agents}})
+
     def test_workspace_name_is_exposed_to_clients(self):
         with loaded_relay() as relay:
             with mock.patch.object(
                 relay,
                 "run_herdr",
-                side_effect=[self._pane_list(), self._workspace_list()],
+                side_effect=[self._pane_list(), self._workspace_list(), self._agent_list()],
             ):
                 agents = relay.get_agents_from_host()
 
@@ -457,7 +462,8 @@ class RelayActivityPersistenceTests(unittest.TestCase):
             with mock.patch.object(
                 relay,
                 "run_herdr",
-                side_effect=[self._pane_list(label="pane name"), self._workspace_list()],
+                side_effect=[self._pane_list(label="pane name"), self._workspace_list(),
+                             self._agent_list()],
             ):
                 agents = relay.get_agents_from_host()
 
@@ -470,11 +476,58 @@ class RelayActivityPersistenceTests(unittest.TestCase):
             with mock.patch.object(
                 relay,
                 "run_herdr",
-                side_effect=[self._pane_list(), self._workspace_list()],
+                side_effect=[self._pane_list(), self._workspace_list(), self._agent_list()],
             ):
                 agents = relay.get_agents_from_host()
 
             self.assertEqual(agents[0]["label"], "")
+
+    def test_the_agent_name_becomes_the_label(self):
+        """The name herdr knows the agent by is what every client renders.
+
+        `pane list` carries the pane's label and never the agent's name, and nothing sets a pane
+        label by default -- so without this lookup an agent started as `mfc-exec` reaches the
+        clients with an empty label and is drawn as its pane id.
+        """
+        with loaded_relay() as relay:
+            with mock.patch.object(
+                relay,
+                "run_herdr",
+                side_effect=[self._pane_list(), self._workspace_list(),
+                             self._agent_list("mfc-exec")],
+            ):
+                agents = relay.get_agents_from_host()
+
+            self.assertEqual(agents[0]["label"], "mfc-exec")
+
+    def test_the_agent_name_wins_over_a_pane_label(self):
+        """Both can be set; the name is the one the operator addresses the agent by, and the one
+        `herdr agent rename` writes."""
+        with loaded_relay() as relay:
+            with mock.patch.object(
+                relay,
+                "run_herdr",
+                side_effect=[self._pane_list(label="pane name"), self._workspace_list(),
+                             self._agent_list("mfc-exec")],
+            ):
+                agents = relay.get_agents_from_host()
+
+            self.assertEqual(agents[0]["label"], "mfc-exec")
+
+    def test_unusable_agent_list_falls_back_to_the_pane_label(self):
+        """A broken `agent list` must not cost the clients the label they had before."""
+        for raw in ("", "not json", json.dumps({"result": {}})):
+            with self.subTest(raw=raw):
+                with loaded_relay() as relay:
+                    with mock.patch.object(
+                        relay,
+                        "run_herdr",
+                        side_effect=[self._pane_list(label="pane name"),
+                                     self._workspace_list(), raw],
+                    ):
+                        agents = relay.get_agents_from_host()
+
+                    self.assertEqual(agents[0]["label"], "pane name")
 
     def test_unusable_workspace_list_leaves_workspace_label_empty(self):
         for raw in ("", "not json", json.dumps({"result": {}})):
@@ -483,7 +536,7 @@ class RelayActivityPersistenceTests(unittest.TestCase):
                     with mock.patch.object(
                         relay,
                         "run_herdr",
-                        side_effect=[self._pane_list(), raw],
+                        side_effect=[self._pane_list(), raw, self._agent_list()],
                     ):
                         agents = relay.get_agents_from_host()
 

--- a/tests/test_web_spaces.py
+++ b/tests/test_web_spaces.py
@@ -462,13 +462,21 @@ class WebPaneNamingTests(unittest.TestCase, _Page):
         }""")
         self.assertEqual(self.card("wA:pH")["meta"], "claude · worktrees/hotfix")
 
-    def test_a_hand_set_name_beats_the_cwd_and_the_title(self):
+    def test_a_name_leads_the_title_and_leaves_line_two_to_the_activity(self):
+        """The name still beats the cwd and the title -- it just does so from line one.
+
+        It used to lead line two, which put it on the same row as the harness and left the title
+        (`billing · 1`) saying nothing a sibling did not also say. Moving it up is what lets three
+        agents in one tab be told apart, and gives line two back to what the agent is doing.
+        """
         self.page.evaluate("""() => {
           Object.assign(agents.find(a => a.pane_id === 'wA:pH'),
                         {label: 'ingest rework', title: 'running tests'});
           render();
         }""")
-        self.assertEqual(self.card("wA:pH")["meta"], "claude · ingest rework")
+        card = self.card("wA:pH")
+        self.assertEqual(card["title"][-1], "ingest rework")
+        self.assertEqual(card["meta"], "claude · running tests")
 
     def test_what_a_pane_is_called_never_depends_on_scope(self):
         """`data-agent-name` prefills the rename dialog, so it carries the real thing in both views

--- a/web/js/cards.js
+++ b/web/js/cards.js
@@ -49,9 +49,14 @@ function paneParts(p) {
   // exists to untangle (several agents in ONE project) the cwd is identical on every row, so it
   // discriminates nothing.
   const tabCount = tabCountBySpace.get(agentWorkspaceKey(p)) || 0;
+  // The agent's own name beats the tab's. Both answer "which of this space's rows is this one",
+  // but the name says it: a herd of `dre-exec` / `dre-rev-1` / `dre-rev-2` all sit in one tab, so
+  // the tab label separated none of them and rendered as the bare tab number -- `DRE · 1` three
+  // times. The tab label stays as the fallback for a pane with no agent name.
+  const label = (p.label || '').trim();
   return {
     project,
-    tab: meaningfulTabLabel(tabLabelByKey.get(agentTabKey(p)), tabCount),
+    tab: label || meaningfulTabLabel(tabLabelByKey.get(agentTabKey(p)), tabCount),
     secondary: herdSecondary(p, project),
   };
 }
@@ -66,7 +71,10 @@ function paneTitleInTab(p) {
  *  label, their tab and their cwd are all empty or identical and the row would read
  *  `tuyaos-ai-qemu` three times. */
 function herdSecondary(p, project) {
-  return (p.label || p.title || '') || informativeCwd(p, project) || p.pane_id;
+  // The label is deliberately NOT first any more: paneParts() now puts it in the title, and
+  // repeating it here cost the row its only live field -- `DRE · dre-exec` over `claude ·
+  // dre-exec`, where line two used to carry what the agent was actually doing.
+  return (p.title || '') || informativeCwd(p, project) || p.pane_id;
 }
 
 /** Line one, as spans. See paneParts for why it is not a string. */


### PR DESCRIPTION
## The problem

herdr keeps an agent's **name** apart from its pane's **label**, and the relay only ever calls `pane list`, which carries the latter. Nothing sets a pane label by default, so on this host every one of 45 agents reached the clients with `label: ""`.

Two symptoms in the web app, which looked unrelated but are the same cause:

| view | shown | expected |
| --- | --- | --- |
| a space's panes | `w5:pH` | `mfc-exec` |
| the herd | `DRE · 1` | `DRE · dre-exec` |

The herd view falls back to the **tab** label, which separates nothing when a space's agents share a tab — `dre-exec`, `dre-rev-1` and `dre-rev-2` all render as `DRE · 1`. A scout only looks right by accident: its tab happens to be named `scout`.

There is a third symptom that is arguably the worst, because it makes an existing feature silently inert: **`rename_agent` writes a value no client can read back.** That handler shells out to `herdr agent rename`, which sets exactly this name — and then the relay reads from `pane list`, where it never appears.

Confirmed against herdr 0.9.0: a pane with an agent reports

```
['agent', 'agent_session', 'agent_status', 'cwd', 'focused', 'foreground_cwd',
 'pane_id', 'revision', 'scroll', 'tab_id', 'terminal_id', 'terminal_title',
 'terminal_title_stripped', 'workspace_id']
```

— `agent` is the harness kind (`"claude"`), and there is no `label` key at all. The name lives only in `agent list`.

## The change

**`relay/herdr_relay.py`** — `get_agent_names()`, deliberately shaped like the `get_workspace_labels()` right above it: same return shape, same call site, same guard on there being panes at all, so an idle host adds no round trips. The agent's name takes precedence over the pane's label, which stays as the fallback.

**`web/js/cards.js`** — `paneParts()` prefers the agent name over the tab label. Both answer "which row of this space is this one", but only the name separates siblings in one tab. `herdSecondary()` stops leading with the label now that the title carries it — otherwise line two repeats the name and the row loses its only live field.

The fix is in the relay, so the other clients (Telegram, TUI, the menu bar app) get it without changes.

## One deliberate behaviour change, flagged

`test_a_hand_set_name_beats_the_cwd_and_the_title` asserted the name leads line **two**. It now leads line **one**, and line two keeps the activity title. The intent of your test survives — the name still beats the cwd and the title — but its position moved, so I renamed the test and wrote the reasoning into its docstring rather than quietly editing the assertion. If you would rather keep the name on line two, say so and I will restrict the change to the relay; the space view is fixed by the relay alone, and only the `DRE · 1` case needs the client edit.

## Tests

`sh tests/run.sh` — **23 passed, 0 failed**, same as `main` before the change.

Three new relay tests: the name becomes the label; it wins over a pane label when both exist; a broken `agent list` falls back to the pane label rather than costing the clients what they had. The existing stubs drive `run_herdr` through `side_effect`, so each needed the third call added or it raises `StopIteration`.

## Verified live

Against a 45-agent host (herdr 0.9.0, Arch/Hyprland, Python 3.14), on a second relay on port 8399 so the running service was untouched. Both views now read `mfc-exec` / `DRE · dre-exec`, and line two still shows what each agent is doing.

