### PR TITLE
fix(web): quick-action approvals were rejected, and every option read "Yes"

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -395,6 +395,10 @@ body { font-family: var(--font-mono); background: var(--bg); color: var(--text);
 .term-content { flex: 1; min-width: 0; overflow: auto; padding: 10px 12px; background: var(--term-bg); color-scheme: dark; font-family: var(--font-term); font-size: clamp(0.68rem, 2.7vw, 0.8rem); line-height: 1.35; white-space: pre; color: var(--term-text); -webkit-overflow-scrolling: touch; overscroll-behavior: contain; }
 .quick-actions { padding: 6px 10px; border-top: 1px solid var(--border); display: flex; gap: 5px; flex-wrap: wrap; flex-shrink: 0; }
 .quick-actions button { padding: 8px 12px; border-radius: 8px; border: none; font-size: 0.8rem; font-weight: 600; cursor: pointer; flex: 1; min-width: 70px; display: flex; align-items: center; justify-content: center; gap: 6px; }
+/* A full option label ("Yes, and don't ask again for ...") cannot share a row with three more of
+   its kind: at flex:1 each gets a quarter of a phone's width and wraps into an unreadable stack.
+   Long ones take the whole row and read as a list, which is what a numbered menu actually is. */
+.quick-actions button.opt-long { flex: 1 1 100%; white-space: normal; text-align: center; line-height: 1.3; }
 .btn-yes { background: var(--green); color: var(--on-accent); } .btn-trust { background: var(--blue); color: var(--on-accent); } .btn-no { background: var(--red); color: var(--on-accent); }
 .term-input { border-top: 1px solid var(--border); padding: 5px 10px; display: flex; gap: 5px; background: var(--surface); flex-shrink: 0; }
 .term-input input { flex: 1; padding: 7px 9px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 14px; font-family: var(--font-term); min-width: 0; }

--- a/web/js/cards.js
+++ b/web/js/cards.js
@@ -1,3 +1,11 @@
+// The approval options whose labels were designed to be cut at the first comma. They mirror
+// TOOL_OPTIONS and SUBAGENT_OPTIONS in herdr_relay.py -- keep the two lists in step. Every other
+// option (notably Claude's numbered permission menu) keeps its full label; see the render below.
+const SHORT_LABEL_OPTIONS = new Set([
+  'yes, single permission', 'trust, always allow', 'no (tab to edit)',
+  'approve all pending', 'configure individually', 'exit (cancel subagents)',
+]);
+
 // ---- What a pane row is CALLED ---------------------------------------------
 //
 // Two questions, not one, so two functions and an explicit scope rather than one function guessing
@@ -456,7 +464,12 @@ function openTerminal(paneId) {
       const button = document.createElement('button');
       const lower = option.toLowerCase();
       button.className = lower.includes('yes')||lower.includes('approve')?'btn-yes':lower.includes('trust')?'btn-trust':'btn-no';
-      button.textContent = option.split(',')[0];
+      // Codex's fixed option set reads well cut at the first comma ("yes, single permission" ->
+      // "yes"). Claude's numbered menu is all "Yes, and ..." variants, so the same cut collapsed
+      // every option to Yes/Yes/Yes/No and the menu became unusable. Only the options the cut was
+      // designed for get it; anything else keeps its full label and wraps onto its own row.
+      button.textContent = SHORT_LABEL_OPTIONS.has(lower) ? option.split(',')[0] : option;
+      if (button.textContent.length > 18) button.classList.add('opt-long');
       if (a.interaction==='omp_question'&&a.multi) {
         button.dataset.selected=String((a.selected_options||[]).includes(option));
         button.classList.toggle('selected',button.dataset.selected==='true');
@@ -467,7 +480,7 @@ function openTerminal(paneId) {
           ws.send(JSON.stringify({type:'question_toggle',pane_id:activePane,prompt_id:a.prompt_id,option}));
         });
       } else {
-        button.addEventListener('click',()=>respond(option));
+        button.addEventListener('click',()=>respond(option, a.prompt_id));
       }
       qa.appendChild(button);
     }
@@ -486,7 +499,7 @@ function openTerminal(paneId) {
         const button = document.createElement('button');
         button.className = cls;
         button.textContent = label;
-        button.addEventListener('click',()=>respond(response));
+        button.addEventListener('click',()=>respond(response, a.prompt_id));
         ak.appendChild(button);
       }
     }

--- a/web/js/diff.js
+++ b/web/js/diff.js
@@ -32,8 +32,11 @@ function handleMessage(msg) {
   }
   if (msg.type === 'error') {
     // A rejected session_switch must not leave the UI stuck on
-    // "switching…" forever. Minimum handling only: no toast UI, since
-    // nothing else in this file renders errors.
+    // "switching…" forever. Still no toast UI, but silence was its own bug: a refused respond
+    // cleared the buttons and looked exactly like an accepted one, so a rejection has to be
+    // perceptible at least as a cue. The buttons themselves come back on the next blocked
+    // broadcast, since the pane is still blocked.
+    if (window.cue) cue('error');
     switchingSession = false;
     render();
     return;

--- a/web/js/nav.js
+++ b/web/js/nav.js
@@ -147,7 +147,18 @@ function pressCtrl(label) {
 
 function toggleArrows(){}
 function hideArrows(){}
-function respond(t){if(!ws||!activePane)return;if(window.cue)cue('success');ws.send(JSON.stringify({type:'respond',pane_id:activePane,text:t}));document.getElementById('quickActions').innerHTML='';setTimeout(refreshPane,500);}
+// The relay refuses any respond whose prompt_id does not match what is on the pane right now
+// (herdr_relay.py, "prompt changed; refresh and try again"). This path sent none at all, so every
+// quick-action button was rejected server-side while the UI cleared itself and looked like nothing
+// had happened -- the pane stayed blocked and the buttons reappeared on the next broadcast. The
+// caller passes the prompt_id of the agent card it drew the button from; mirror.js already did.
+function respond(t, promptId){
+  if(!ws||!activePane)return;
+  if(window.cue)cue('success');
+  ws.send(JSON.stringify({type:'respond',pane_id:activePane,prompt_id:promptId||'',text:t}));
+  document.getElementById('quickActions').innerHTML='';
+  setTimeout(refreshPane,500);
+}
 let imeComposing = false, imeEndedAt = 0;
 {
   const ti = document.getElementById('termInput');


### PR DESCRIPTION
Two independent bugs stacked on the same row of buttons. Together they made approving from the phone impossible.

### 1. Every click was refused

The relay rejects a `respond` whose `prompt_id` does not match the pane's current one:

```python
if question_prompt_id(pane_id, content) != msg.get("prompt_id", ""):
    return command_error("prompt changed; refresh and try again")
```

…and `nav.js` sent no `prompt_id` at all:

```js
ws.send(JSON.stringify({type:'respond',pane_id:activePane,text:t}));
```

The empty string never matches, so **the guard refused every quick-action click**. The error is not rendered anywhere and `respond()` clears the button row immediately, so a refusal looked exactly like an acceptance — the buttons vanish, nothing happens, and they reappear on the next `blocked` broadcast because the pane is of course still blocked.

`mirror.js` already passes `prompt_id` on the same message, so this reads as an omission rather than a design.

Measured on one relay, whole-log totals before the fix:

| | count |
|---|---|
| `Response from` | 1 |
| `Keys from` | 29 |

Everyone had quietly fallen back to sending raw keys. Six successful responses in the ten minutes after the fix.

### 2. Every option rendered as "Yes"

`cards.js` cut every label at the first comma. That reads well for the fixed Codex set (`yes, single permission` → `yes`), but Claude's numbered permission menu is:

```
1. Yes
2. Yes, and don't ask again for <tool> in <dir>
3. Yes, allow all edits during this session
4. No, and tell Claude what to do differently
```

which collapses to **Yes / Yes / Yes / No** — four buttons, three identical.

Now only the options the cut was designed for get it; the rest keep their full label, and anything too long to read in a quarter of a phone's width takes a row of its own.

### Also

A refused response now fires `cue('error')`. Silence is what made the first bug hard to notice at all — there is still no toast UI, so this is the minimum rather than the ideal.

### Testing

Driven from an iPhone against a live relay: numbered menus now show distinguishable labels, and tapping one actually answers the prompt (confirmed both in the pane and by `Response from` appearing in `relay.log`).