### PR TITLE
fix(web): re-send the push subscription on every connect

### DIFF
--- a/web/js/push.js
+++ b/web/js/push.js
@@ -16,6 +16,28 @@ async function initPush() {
   }
 }
 
+// The relay only ever hears about a subscription when somebody taps the toggle, so its copy is a
+// snapshot of that one moment -- while the browser hands out a new endpoint of its own accord (a
+// reinstall, a long idle, a subscription it decided to retire). Nothing reports that: the toggle
+// reads Enabled because it asks the BROWSER, and the relay goes on pushing to the old endpoint,
+// which APNs answers 201 for whether or not anything is behind it. Re-sending the live
+// subscription on every connect closes that: the relay dedupes by value, so an unchanged one
+// costs a few hundred bytes and a rotated one is registered before the next block -- and the
+// relay's "Push subscription added" line then says, in the log, that a rotation is what happened.
+async function resyncPushSubscription() {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+  try {
+    const reg = await navigator.serviceWorker.getRegistration();
+    const sub = reg && await reg.pushManager.getSubscription();
+    if (!sub) return;
+    pushSubscription = sub;
+    updatePushUI();
+    if (ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({type: 'push_subscribe', subscription: sub.toJSON()}));
+    }
+  } catch (e) {}
+}
+
 function updatePushUI() {
   const btn = document.getElementById('pushToggle');
   const status = document.getElementById('pushStatus');

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -286,7 +286,9 @@ function connect() {
   if (token) wsUrl += (url.includes('?') ? '&' : '?') + 'token=' + encodeURIComponent(token);
   const sock = new WebSocket(wsUrl);
   ws = sock;
-  sock.onopen = () => { if (ws !== sock) return; setStatus('connected'); if(window.cue) cue('ready'); };
+  sock.onopen = () => { if (ws !== sock) return; setStatus('connected'); if(window.cue) cue('ready');
+    // Push: the relay's copy of this device's subscription can be stale (see push.js).
+    if (typeof resyncPushSubscription === 'function') resyncPushSubscription(); };
   sock.onclose = () => { if (ws !== sock) return; setStatus('disconnected'); scheduleReconnect(); };
   sock.onerror = () => { if (ws !== sock) return; setStatus('disconnected'); };
   sock.onmessage = (e) => { if (ws !== sock) return; handleMessage(JSON.parse(e.data)); };


### PR DESCRIPTION
## The bug

The relay only ever hears about a push subscription when somebody taps the toggle, so its copy is a snapshot of that one moment. The browser meanwhile hands out a new endpoint of its own accord — a reinstall, a long idle, a subscription the push service decided to retire — and nothing reports that.

**The failure is invisible from both ends at once:**

- `initPush()` calls `getSubscription()`, which asks the **browser**, so Settings goes on reading `● Enabled` with a perfectly live subscription in hand.
- The relay goes on pushing to the old endpoint, and APNs answers **201 for a retired token exactly as it does for a live one**. 404 and 410 are the only replies that would retire it in `_deliver_push`, and neither is sent.

So `Push delivered to N subscription(s)` appears in the log, the toggle is green, and the handset never buzzes — with nothing anywhere saying that the two ends are talking about different subscriptions. On iOS this reads as "web push is broken", and there is no server-side evidence to contradict it.

## The fix

`resyncPushSubscription()` sends the live subscription on every socket open.

The relay already dedupes by value (`if sub and sub not in push_subscriptions`), so an unchanged one costs a few hundred bytes and no write. A rotated one is registered before the next block — and the relay's existing `Push subscription added` line then says, **in the log**, that a rotation is what happened, which is the one thing that could not be observed before.

A `pushsubscriptionchange` listener is the other half of this and can fire while the app is not running, but it cannot be the load-bearing half: Safari's support for the event is patchy, and iOS is where a silently rotated subscription costs the most. The per-connect resend works whether or not it fires.

## Testing

- `tests/run.sh`: 23 passed, 0 failed (including the 220 browser tests in step 9d).
- Verified on an iPhone installed as a PWA against a relay over Tailscale: three reconnects with an unchanged subscription log nothing, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZhXedK1qc1BQLuUiZkswf