### PR TITLE
fix(relay): six bugs in the push and reply paths on iOS

### DIFF
--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1695,8 +1695,26 @@ def detect_options(text):
 
 
 def custom_editor_active(text):
-    return "Enter your response:" in text or (
-        "Custom answer:" in text and "submit" in text.lower()
+    """True when a free-text field on the pane has focus, so typed text must be sent AS TEXT.
+
+    Claude's "Type something." is not a second screen. Choosing it leaves the whole numbered
+    menu on display and turns that one row into an inline input -- so the option list still
+    parses, the relay still read it as a menu, and everything a reader typed was matched against
+    the labels and sent as a KEY PRESS. A digit landed in the field as a character ("3", then
+    "33" on the second try), a sentence that happened to equal a label pressed that label's
+    number, and anything else was refused outright as "free-text response requires a detected
+    question". The menu never closed, because nothing had been selected.
+
+    The one thing that changes between the two states is the dialog's own footer: it gains
+    "ctrl+g to edit in <editor>" exactly while the field has focus. The editor name is the
+    reader's $EDITOR, so only the invariant half is matched. Verified against captures of all
+    four states -- cursor on an ordinary option (absent), cursor on the field (present), and the
+    field holding one and two typed characters (present).
+    """
+    return (
+        "Enter your response:" in text
+        or ("Custom answer:" in text and "submit" in text.lower())
+        or "ctrl+g to edit in" in text.lower()
     )
 
 def question_prompt_id(pane_id, content):

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1957,10 +1957,20 @@ async def _poll_once():
                     if gen != POLL_GENERATION:
                         return
             else:
-                if last_statuses.get(pid) == "blocked":
-                    await send_web_push("", "", clear=True)
-                    if gen != POLL_GENERATION:
-                        return
+                # No clear push. A subscription is taken out with userVisibleOnly: true, which
+                # is a contract: every push it carries must end in a notification the reader can
+                # see. A clear deliberately shows nothing -- it closes the stale prompt and
+                # returns -- so each one is a broken promise, and Safari answers a run of them by
+                # retiring the subscription outright. Which is invisible from here: the browser's
+                # own getSubscription() starts returning null (the toggle reads Disabled) while
+                # APNs goes on answering 201 for the retired token, so the relay logs deliveries
+                # to a handset that is no longer listening. Measured on this host: four silent
+                # clears, then every later push -- notifications included -- stopped waking the
+                # service worker, with 201 on every one.
+                #
+                # The stale notification is not left forever. It carries tag "herdr-blocked", so
+                # the next block replaces it in place, and tapping it closes it. That is a far
+                # smaller cost than losing the channel.
                 last_blocked_prompts.pop(pid, None)
             last_statuses[pid] = status
 async def event_push():

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1944,6 +1944,7 @@ async def _poll_once():
                     # `previous is not None` means "already announced this block".
                     message["update"] = previous is not None
                     last_blocked_prompts[pid] = fingerprint
+                    log.info("Blocked (poll) pane=%s update=%s", pid, message["update"])
                     await broadcast(message)
                     # Clients still need every re-broadcast (the prompt_id they must echo back
                     # to approve moves with the content), but the notification is one-shot.
@@ -2024,12 +2025,29 @@ async def event_push():
             # that inserts an await between this check and the writes below.
             if gen != POLL_GENERATION:
                 continue        # a switch landed; this event is stale
+            # A block announced here is a block the poll will never announce. This path claims
+            # last_blocked_prompts, and _poll_once reads that same dict to decide whether a
+            # blocked pane is new -- so once the event has landed, the poll sees `previous is
+            # not None`, calls it an update and skips the notification, while an unchanged
+            # fingerprint stops it before even that. Either way send_web_push never ran, and
+            # since the plugin's event beats the poll whenever it fires at all, the
+            # notification was lost exactly when the fast path worked. Push here, on the same
+            # one-shot rule the poll uses: announce a new block, stay quiet for a re-broadcast.
+            previous = last_blocked_prompts.get(pane_id)
+            message["update"] = previous is not None
             last_blocked_prompts[pane_id] = (
                 message["prompt_id"],
                 tuple(message["selected_options"]),
                 message["prompt"],
             )
+            log.info("Blocked (event) pane=%s update=%s", pane_id, message["update"])
             await broadcast(message)
+            if not message["update"]:
+                await send_web_push(
+                    title=f"\U0001f411 {agent_data.get('project', '')} blocked",
+                    body=(content or agent_data.get("prompt", ""))[:120],
+                    url=f"/?pane={pane_id}",
+                )
 
 
 WEB_DIR = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "web"))

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1793,6 +1793,13 @@ def blocked_message(pane_id, agent, project, host, content):
             and "Done selecting" not in option["label"] and option["checked"]
         ] if question else [],
         "interaction": "omp_question" if question else ("numbered" if numbered else "prompt"),
+        # A text field on the pane has focus. The menu is still drawn and still parses -- Claude's
+        # "Type something." turns one of its own rows into an input rather than opening a second
+        # screen -- so nothing else in this message distinguishes the two states, and a client
+        # that draws option buttons here draws buttons that cannot work: the field takes every
+        # digit as a character, and the arrow keys are the only way back to the list. Clients
+        # older than this field ignore it and behave exactly as they did.
+        "text_field": custom_editor_active(content),
         "multi": bool(question and question["multi"]),
         "update": False,
     }

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -2375,6 +2375,8 @@ async def handle_client(ws):
                     continue
                 content = await asyncio.to_thread(read_pane, pane_id, remote=remote)
                 if question_prompt_id(pane_id, content) != msg.get("prompt_id", ""):
+                    log.warning("Response refused (stale prompt_id) from %s: pane=%s text=%r",
+                                ip, pane_id, text)
                     await ws.send(json.dumps(command_error("prompt changed; refresh and try again")))
                     continue
                 question = (
@@ -2385,7 +2387,13 @@ async def handle_client(ws):
                 menu_key = None if question else numbered_option_key(
                     text, detect_numbered_options(content)
                 )
-                log.info("Response from %s (%s): pane=%s text=%r", ip, device, pane_id, text)
+                log.info("Response from %s (%s): pane=%s text=%r route=%s", ip, device,
+                         pane_id, text,
+                         "question" if question else
+                         ("menu:" + menu_key) if menu_key and not custom_editor_active(content)
+                         else "text" if (custom_editor_active(content)
+                                         or text.lower() in SAFE_RESPONSES)
+                         else "refused")
                 audit("respond", ip, device, pane_id, f"text={text!r}")
                 if question:
                     delivered = await asyncio.to_thread(
@@ -2405,11 +2413,21 @@ async def handle_client(ws):
                         _mutate_herdr, "pane", "send-keys", pane_id, "Enter", remote=remote
                     )
                 else:
+                    # The one branch that silently drops a reader's typed text. Saying so out
+                    # loud is the difference between "the relay refused this" and "my message
+                    # vanished": the client shows a toast the reader has usually scrolled past.
+                    log.warning(
+                        "Response refused (no question detected) from %s: pane=%s text=%r "
+                        "numbered=%d editor=%s",
+                        ip, pane_id, text, len(detect_numbered_options(content)),
+                        custom_editor_active(content),
+                    )
                     await ws.send(json.dumps({
                         **command_error("free-text response requires a detected question"),
                     }))
                     continue
                 if not delivered:
+                    log.warning("Response delivery failed from %s: pane=%s text=%r", ip, pane_id, text)
                     await ws.send(json.dumps(command_error("response delivery failed")))
                     continue
                 response = {"type": "command_result", "command": "respond", "ok": True}

--- a/relay/herdr_relay.py
+++ b/relay/herdr_relay.py
@@ -1619,6 +1619,11 @@ def detect_approval_options(text):
 NUMBERED_OPTION_RE = re.compile(r"^(\s*(?:[❯>›»▶]\s*)?)(\d{1,2})[.)]\s+(\S.*?)\s*$")
 
 
+# A horizontal rule: box-drawing or ASCII dashes only, at least three of them. Used by
+# detect_numbered_options to step over a divider drawn inside a menu.
+MENU_RULE_RE = re.compile(r"^[\u2500-\u257f\u2014\u2013\-=_]{3,}$")
+
+
 def detect_numbered_options(text):
     """Labels of the last `1.`..`N.` menu on screen, in order, or [] when there is none.
 
@@ -1650,6 +1655,14 @@ def detect_numbered_options(text):
             continue
         stripped = line.strip()
         if not stripped:
+            continue
+        if current and MENU_RULE_RE.match(stripped):
+            # Claude draws a rule between the answers it was given and the two it always adds
+            # ("Type something.", "Chat about this"). The rule sits at column 0, so it is neither
+            # the next number nor a deeper-indented continuation and it ended the run -- losing
+            # every option below it. On a question menu that is the LAST option, which no client
+            # could then reach. It carries no label, so skipping it cannot invent one, and a run
+            # still ends at the first line that is genuinely neither.
             continue
         indent = len(line) - len(line.lstrip())
         if current and number_col is not None and indent > number_col:

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -818,26 +818,32 @@ class RelaySessionSwitchTests(unittest.TestCase):
             # The switch must stop the poll before it re-seeds a second pane.
             self.assertEqual(relay.last_blocked_prompts, {})
 
-    def test_stale_poll_bails_after_clear_push_without_restoring_status(self):
-        # last_statuses[pid] == "blocked" pre-set so the poll takes the
-        # clear-push branch; the switch lands during send_web_push. Without
-        # the post-push generation check, the trailing `last_statuses[pid] =
-        # status` line would restore an entry the reset just cleared.
+    def test_leaving_blocked_sends_no_push(self):
+        # A subscription is taken out with userVisibleOnly: true, which is a contract: every
+        # push it carries has to end in a notification the reader can see. The clear push
+        # deliberately showed nothing -- it closed the stale prompt and returned -- so each one
+        # was a broken promise, and Safari answers a run of them by retiring the subscription.
+        # Nothing about that is visible from the relay: getSubscription() starts returning null
+        # on the handset while APNs goes on answering 201, so the log records deliveries to a
+        # device that is no longer listening. Leaving blocked must therefore be silent on the
+        # push channel; the stale notification is replaced in place by the next block, which
+        # shares its tag.
         with loaded_relay() as relay:
             relay.last_statuses["w1:p1"] = "blocked"
+            relay.last_blocked_prompts["w1:p1"] = ("p1", (), "Deploy?")
             agents = [{"pane_id": "w1:p1", "agent": "claude", "status": "idle",
                        "cwd": "/tmp/x", "project": "x", "host": "local", "remote": None}]
 
-            async def switch_mid_clear_push(*args, **kwargs):
-                relay.reset_pane_state()          # simulates a switch landing
-
+            push = mock.AsyncMock()
             with mock.patch.object(relay, "get_all_panes", return_value=(agents, [])), \
                  mock.patch.object(relay, "broadcast", new=mock.AsyncMock()), \
-                 mock.patch.object(relay, "send_web_push", side_effect=switch_mid_clear_push):
+                 mock.patch.object(relay, "send_web_push", new=push):
                 asyncio.run(relay._poll_once())
 
-            # The switch must stop the poll from restoring last_statuses.
-            self.assertEqual(relay.last_statuses, {})
+            push.assert_not_awaited()
+            # The prompt is still forgotten, so the next block counts as new and does notify.
+            self.assertNotIn("w1:p1", relay.last_blocked_prompts)
+            self.assertEqual(relay.last_statuses, {"w1:p1": "idle"})
 
     def test_stale_event_does_not_reseed_blocked_prompt_after_switch(self):
         # A queued agent_event that is already in hand (past reset's queue

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -3095,8 +3095,55 @@ CLAUDE_MENU = """\
 """
 
 
+# A question menu, as Claude draws one: each answer's description on its own indented line,
+# and a rule between the answers it was given and the two it always appends.
+CLAUDE_QUESTION_MENU = """\
+ Which way?
+
+ ❯ 1. First
+     the first one
+   2. Second
+     the second one
+   3. Type something.
+────────────────────────────────────────
+   4. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+"""
+
+# The same screen with "Type something." chosen. Nothing moves except the cursor and the footer:
+# the menu is still there, still parses, and the chosen row is now an inline input.
+CLAUDE_QUESTION_FIELD = CLAUDE_QUESTION_MENU.replace(
+    "Enter to select · ↑/↓ to navigate · Esc to cancel",
+    "Enter to select · ↑/↓ to navigate · ctrl+g to edit in Nvim · Esc to cancel",
+)
+
+
 class ClaudeNumberedMenuTests(unittest.TestCase):
     """Claude Code approval/question menus carry no Codex wording; they are 1..N key menus."""
+
+    def test_the_inline_text_field_is_detected_from_the_footer(self):
+        # "Type something." is not a second screen: the menu stays on display and that row
+        # becomes an input, so the option list parses identically either way. The footer is the
+        # only thing that differs.
+        with loaded_relay() as relay:
+            self.assertFalse(relay.custom_editor_active(CLAUDE_QUESTION_MENU))
+            self.assertTrue(relay.custom_editor_active(CLAUDE_QUESTION_FIELD))
+            self.assertEqual(
+                relay.detect_numbered_options(CLAUDE_QUESTION_FIELD),
+                relay.detect_numbered_options(CLAUDE_QUESTION_MENU),
+            )
+
+    def test_text_typed_into_a_focused_field_still_matches_an_option(self):
+        # Which is exactly why the key press has to be gated on the field NOT having focus: a
+        # digit matches its own option, and a sentence matches an option whose label it equals.
+        # Sent as keys, both land in the field as characters and the menu never closes -- "3"
+        # then "33" on the second attempt.
+        with loaded_relay() as relay:
+            options = relay.detect_numbered_options(CLAUDE_QUESTION_FIELD)
+            self.assertEqual(relay.numbered_option_key("3", options), "3")
+            self.assertEqual(relay.numbered_option_key("Second the second one", options), "2")
+            self.assertTrue(relay.custom_editor_active(CLAUDE_QUESTION_FIELD))
 
     def test_detects_menu_and_joins_wrapped_option(self):
         with loaded_relay() as relay:

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -878,6 +878,48 @@ class RelaySessionSwitchTests(unittest.TestCase):
 
             self.assertEqual(relay.last_blocked_prompts, {})
 
+    def test_event_path_notifies_a_new_block_once(self):
+        # The plugin's event beats the poll whenever it fires at all, and this path claims
+        # last_blocked_prompts -- which is the same dict _poll_once reads to decide whether a
+        # blocked pane is new. So a block announced here was a block the poll then called an
+        # update and skipped the notification for, or skipped entirely on an unchanged
+        # fingerprint: send_web_push never ran, and the notification was lost exactly when the
+        # fast path worked. It must notify here, on the poll's own one-shot rule.
+        with loaded_relay() as relay:
+            event = {
+                "type": "agent_event",
+                "pane_id": "w1:p1",
+                "agent": "claude",
+                "status": "blocked",
+                "cwd": "/tmp/x",
+                "project": "x",
+                "host": "local",
+            }
+            push = mock.AsyncMock()
+
+            async def run_events(count):
+                with mock.patch.object(relay, "get_all_panes", return_value=([], [])), \
+                     mock.patch.object(relay, "read_pane", return_value="Deploy to prod?"), \
+                     mock.patch.object(relay, "broadcast", new=mock.AsyncMock()), \
+                     mock.patch.object(relay, "send_web_push", new=push):
+                    task = asyncio.create_task(relay.event_push())
+                    try:
+                        for _ in range(count):
+                            await relay.event_queue.put(dict(event))
+                            # event_push never calls task_done(), so the queue cannot be
+                            # joined; give the task a turn to drain instead.
+                            await asyncio.sleep(0.05)
+                    finally:
+                        task.cancel()
+                        with self.assertRaises(asyncio.CancelledError):
+                            await task
+
+            asyncio.run(run_events(2))
+
+            # One notification for the block; the re-broadcast is an update and stays quiet.
+            self.assertEqual(push.await_count, 1)
+            self.assertIn("w1:p1", relay.last_blocked_prompts)
+
     def test_reset_pane_state_drains_queued_events(self):
         # An event queued before a switch (never dequeued by event_push)
         # must not survive the switch to be processed afterward.

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -3122,6 +3122,17 @@ CLAUDE_QUESTION_FIELD = CLAUDE_QUESTION_MENU.replace(
 class ClaudeNumberedMenuTests(unittest.TestCase):
     """Claude Code approval/question menus carry no Codex wording; they are 1..N key menus."""
 
+    def test_a_rule_between_options_does_not_end_the_menu(self):
+        # Claude puts one between the answers it was given and the two it always appends, at
+        # column 0 -- neither the next number nor a deeper-indented continuation, so it ended the
+        # run and took every option below it with it. On a question menu that is the last option,
+        # which no client could then reach.
+        with loaded_relay() as relay:
+            options = relay.detect_numbered_options(CLAUDE_QUESTION_MENU)
+            self.assertEqual(len(options), 4)
+            self.assertEqual(options[-1], "Chat about this")
+            self.assertEqual(relay.numbered_option_key("Chat about this", options), "4")
+
     def test_the_inline_text_field_is_detected_from_the_footer(self):
         # "Type something." is not a second screen: the menu stays on display and that row
         # becomes an input, so the option list parses identically either way. The footer is the
@@ -3144,6 +3155,13 @@ class ClaudeNumberedMenuTests(unittest.TestCase):
             self.assertEqual(relay.numbered_option_key("3", options), "3")
             self.assertEqual(relay.numbered_option_key("Second the second one", options), "2")
             self.assertTrue(relay.custom_editor_active(CLAUDE_QUESTION_FIELD))
+
+    def test_a_rule_does_not_glue_unrelated_numbering_together(self):
+        # The skip only steps over the divider; a run still ends at the first line that is
+        # genuinely neither the next number nor a continuation.
+        with loaded_relay() as relay:
+            screen = "1. a\n2. b\n\u2500\u2500\u2500\u2500\u2500\u2500\nnot a menu line\n4. d\n"
+            self.assertEqual(relay.detect_numbered_options(screen), ["a", "b"])
 
     def test_detects_menu_and_joins_wrapped_option(self):
         with loaded_relay() as relay:

--- a/tests/test_herdr_relay.py
+++ b/tests/test_herdr_relay.py
@@ -2035,6 +2035,7 @@ class RelayEventPushTests(unittest.IsolatedAsyncioTestCase):
                             "multi_options": [],
                             "selected_options": [],
                             "interaction": "prompt",
+                            "text_field": False,
                             "multi": False,
                             "update": False,
                         },
@@ -3155,6 +3156,17 @@ class ClaudeNumberedMenuTests(unittest.TestCase):
             self.assertEqual(relay.numbered_option_key("3", options), "3")
             self.assertEqual(relay.numbered_option_key("Second the second one", options), "2")
             self.assertTrue(relay.custom_editor_active(CLAUDE_QUESTION_FIELD))
+
+    def test_blocked_message_reports_a_focused_text_field(self):
+        # Nothing else in the message distinguishes the two states: the menu is still drawn and
+        # still parses, so a client has no way to know its option buttons have stopped working.
+        with loaded_relay() as relay:
+            menu = relay.blocked_message("w1:p1", "claude", "x", "local", CLAUDE_QUESTION_MENU)
+            field = relay.blocked_message("w1:p1", "claude", "x", "local", CLAUDE_QUESTION_FIELD)
+            self.assertFalse(menu["text_field"])
+            self.assertTrue(field["text_field"])
+            # ...and the options are identical either way, which is the point.
+            self.assertEqual(menu["options"], field["options"])
 
     def test_a_rule_does_not_glue_unrelated_numbering_together(self):
         # The skip only steps over the divider; a run still ends at the first line that is

--- a/web/app.css
+++ b/web/app.css
@@ -399,6 +399,9 @@ body { font-family: var(--font-mono); background: var(--bg); color: var(--text);
    its kind: at flex:1 each gets a quarter of a phone's width and wraps into an unreadable stack.
    Long ones take the whole row and read as a list, which is what a numbered menu actually is. */
 .quick-actions button.opt-long { flex: 1 1 100%; white-space: normal; text-align: center; line-height: 1.3; }
+/* Not a button: the pane is waiting for typed text, and the only thing to do is type. It sits
+   in the row the option buttons would have filled, so the card does not change height. */
+.qa-hint { flex: 1 1 100%; padding: 8px 12px; border-radius: 8px; font-size: 0.8rem; font-weight: 600; text-align: center; color: var(--muted); border: 1px dashed var(--border); }
 .btn-yes { background: var(--green); color: var(--on-accent); } .btn-trust { background: var(--blue); color: var(--on-accent); } .btn-no { background: var(--red); color: var(--on-accent); }
 .term-input { border-top: 1px solid var(--border); padding: 5px 10px; display: flex; gap: 5px; background: var(--surface); flex-shrink: 0; }
 .term-input input { flex: 1; padding: 7px 9px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 14px; font-family: var(--font-term); min-width: 0; }

--- a/web/js/cards.js
+++ b/web/js/cards.js
@@ -464,7 +464,19 @@ function openTerminal(paneId) {
   const ak = document.getElementById('actionKeys');
   qa.replaceChildren();
   ak.replaceChildren();
-  if (a&&a.status==='blocked') {
+  if (a&&a.status==='blocked'&&a.text_field) {
+    // A text field on the pane has focus, which the relay reports because nothing else in the
+    // message says so: Claude's "Type something." turns one of the menu's own rows into an input
+    // rather than opening a second screen, so the option list is still there and still parses.
+    // Buttons drawn from it cannot work -- the field takes a digit as a character, and the arrow
+    // keys are the only way back to the list -- so say what is wanted instead of offering taps
+    // that would type their own label into the box. No focus() here: this card is rebuilt from
+    // every snapshot, and pulling up the keyboard twice a second is worse than not pulling it up.
+    const hint = document.createElement('div');
+    hint.className = 'qa-hint';
+    hint.textContent = 'Waiting for text \u2014 type your answer below';
+    qa.appendChild(hint);
+  } else if (a&&a.status==='blocked') {
     const opts = a.interaction==='omp_question'&&a.multi
       ? (Array.isArray(a.multi_options)?a.multi_options:[])
       : (Array.isArray(a.options)?a.options:[]);

--- a/web/js/diff.js
+++ b/web/js/diff.js
@@ -64,6 +64,7 @@ function handleMessage(msg) {
         options: previous.options,
         multi_options: previous.multi_options,
         interaction: previous.interaction,
+        text_field: previous.text_field,
         multi: previous.multi,
         prompt_id: previous.prompt_id,
         selected_options: previous.selected_options,
@@ -95,6 +96,7 @@ function handleMessage(msg) {
       a.selected_options=msg.selected_options||[];
       a.multi_options=msg.multi_options||[];
       a.interaction=msg.interaction;
+      a.text_field=!!msg.text_field;
       a.multi=msg.multi;
     }
     else agents.push({...msg, status:'blocked'});


### PR DESCRIPTION
Six bugs found while debugging two reports from one iPhone installed as a PWA: "the toggle says Enabled and the phone never buzzes", and "I picked *Type something.* and then couldn't type". They are independent; each is its own commit.

---

# Web push

## 1. The event path claimed the block and never notified

Two paths announce a blocked pane. `_poll_once` finds it by polling; `event_push` receives it from the herdr plugin's `pane.agent_status_changed` event — which is the point of the plugin: it fires the moment the status changes, well ahead of the next poll tick.

**Only one of them notified.** `event_push` wrote `last_blocked_prompts[pane_id]` and broadcast, and stopped there. That dict is also what `_poll_once` reads to decide whether a blocked pane is new:

```python
previous = last_blocked_prompts.get(pid)
if previous != fingerprint:
    message["update"] = previous is not None   # True: the event got here first
    if not message["update"]:
        await send_web_push(...)               # so this never runs
```

So the event path did not push, **and it also stopped the poll from pushing**: an unchanged fingerprint failed the outer test outright, and a churning one (a blocked TUI repaints its spinner every tick) came through as an update. The notification was lost precisely when the fast path worked — a push arrived only on the rare tick where the poll beat the event, which is what made it look flaky.

Nothing else broke, which is what made it hard to see. The blocked card still reached every connected client over the WebSocket, and the clear still fired (that is keyed off `last_statuses`, which `event_push` does not touch). So the phone showed the prompt when the app was open and stayed silent when it was not — the one case the notification exists for.

## 2. The clear push is silent, and Safari retires the subscription for it

A subscription is taken out with `userVisibleOnly: true`. That is a contract: **every push it carries has to end in a notification the reader can see.** The clear push breaks it by design — the service worker closes the stale prompt and returns, showing nothing — and Safari answers a run of broken promises by retiring the subscription.

None of which is visible from the relay. `getSubscription()` starts returning null on the handset, so the app's own toggle reads Disabled, while APNs goes on answering **201** for the retired token: 404 and 410 are the only replies that would drop it from `push_subs.json`, and neither is sent. The log therefore records successful deliveries to a device that stopped listening hours ago.

Measured: notifications and their acks worked all morning, then four clear pushes went out over the day and **every later push — ordinary notifications included — stopped waking the service worker.** HTTP 201 on every one, nothing on screen. Re-subscribing from the app restored it immediately, which is what places the failure in the subscription rather than anywhere else in the chain.

Leaving blocked is now silent on the push channel. The cost is small and bounded: a stale notification carries tag `herdr-blocked`, so **the next block replaces it in place**, and tapping it closes it. Connected clients still learn the pane is unblocked from the `agents` snapshot. The clear branch stays in `sw.js` for relays that still send one.

---

# Replying to a menu

## 3. A focused "Type something." field ate every reply

Claude's "Type something." is not a second screen. Choosing it leaves the whole numbered menu on display and turns that one row into an inline input — so the option list still parses, unchanged, and the relay went on reading the pane as a menu with nothing typed into it.

Every reply then went to the wrong place, in three different ways:

- **a digit matched its own option and was sent as that key**, which the focused field received as a character. "3" appeared in the box; a second attempt made it "33". The menu never closed, because nothing had been selected;
- **a sentence that happened to equal an option's label pressed that option's number** (seen live: a whole line of prose routed to `menu:2`);
- **anything else was refused outright** — "free-text response requires a detected question" — so the reader's text simply vanished.

Which means the one option whose entire purpose is free text was the one option after which free text could not be sent.

The states differ in exactly one place: the footer gains `ctrl+g to edit in <editor>` while the field has focus. The editor name is the reader's `$EDITOR`, so only the invariant half is matched. Both branches that mattered were already gated on `custom_editor_active`, so teaching the detector this one string routes all three cases correctly at once.

## 4. A rule inside a menu hid its last option

Claude draws a horizontal rule between the answers it was given and the two it always appends — "Type something." and "Chat about this". The rule sits at column 0, so it is neither the next number nor a deeper-indented continuation, and it ended the run: every option below it was dropped.

On a question menu that is the last option, and it was **unreachable from every client**. Not visibly broken, just absent — the card drew one fewer button than the pane had, and a reader who typed the missing label got "free-text response requires a detected question".

Measured on five captures of real question menus: four options found where the pane showed five, in every one.

## 5. Clients had no way to know the buttons had stopped working

Fixing 3 makes typing work, but it does not make the option buttons work, and nothing in the blocked message says so. Whatever the relay does with a tap while the field has focus is wrong: it used to send the option's number (which lands in the box as a character), and now it types the button's own label and submits it — and "Chat about this" is a mode switch, not an answer.

So the message carries `text_field`, and the web app draws one line — *Waiting for text — type your answer below* — in the row the buttons would have filled. No `focus()` with it: the card is rebuilt from every snapshot, and pulling the keyboard up twice a second is worse than not pulling it up. **Clients older than this field ignore it and behave exactly as they did.**

---

# Diagnostics

## 6. A `respond` chose between four destinations and logged none of them

An omp question, a menu key press, send-text, or refused outright — decided from the pane's own screen by two detectors the reader cannot see. When the answer is wrong the symptom is silence.

The log line now says where it went (`route=menu:4`, `route=text`, `route=refused`), and the refusal branch says why, with what the detectors saw:

```
Response refused (no question detected) from …: text='123' numbered=6 editor=False
```

That pair is the whole diagnosis for bugs 3 and 4. The two other silent exits (a stale `prompt_id`, a delivery returning false) now log too.

---

## Testing

`tests/run.sh`: **23 passed, 0 failed** (including the 220 browser tests).

New: `test_event_path_notifies_a_new_block_once`, `test_leaving_blocked_sends_no_push` (replaces a test of the removed clear-push branch), `test_a_rule_between_options_does_not_end_the_menu`, `test_the_inline_text_field_is_detected_from_the_footer`, `test_text_typed_into_a_focused_field_still_matches_an_option`, `test_a_rule_does_not_glue_unrelated_numbering_together`, `test_blocked_message_reports_a_focused_text_field`.

Verified end to end on an iPhone installed as a PWA with the app swiped away:

```
Blocked (event) pane=w2:p2 update=False
Push delivered to 1 subscription(s)
Push ack from service worker: stage=received
Push ack from service worker: stage=shown detail=open=2
...
Response from … text='Type something.' route=menu:4
Response from … text='test'            route=text
```

Both answers arrived through the text route, where the same input had been refused minutes earlier.

(The `Push ack` lines are a local diagnostic — a `/api/push-ack` endpoint the service worker calls — not part of this PR. Happy to send it separately; it is the only thing that separates "the service worker never woke" from "it woke and iOS declined to present" without a Mac and a cable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZhXedK1qc1BQLuUiZkswf